### PR TITLE
missing underscore in Cleanup cmake

### DIFF
--- a/ansible/playbooks/ubuntu.yml
+++ b/ansible/playbooks/ubuntu.yml
@@ -222,7 +222,7 @@
       file:
         path: "{{ item }}"
         state: absent
-      with items:
+      with_items:
         - /tmp/cmake-3.7.2.tar.gz
         - /tmp/cmake-3.7.2
       tags: cmake 


### PR DESCRIPTION
Was: with items:
changed to with_items: