### PR TITLE
missing underscore in Cleanup cmake

### DIFF
--- a/ansible/playbooks/rhel.yml
+++ b/ansible/playbooks/rhel.yml
@@ -218,7 +218,7 @@
       file:
         path: "{{ item }}"
         state: absent
-      with items:
+      with_items:
         - /tmp/cmake-3.7.2.tar.gz
         - /tmp/cmake-3.7.2
       tags: cmake


### PR DESCRIPTION
Was: with items:
changed to with_items: