### PR TITLE
Remove CCACHE from APT

### DIFF
--- a/ansible/playbooks/ubuntu.yml
+++ b/ansible/playbooks/ubuntu.yml
@@ -50,7 +50,6 @@
       with_items:
         - autoconf
         - bison
-        - ccache
         - cpanminus
         - cpio
         - flex


### PR DESCRIPTION
We HAVE to use ccache 3.1.9 so fetching from APT won't work for us hence the manual steps below