### PR TITLE
cuda clean sections - using 'file' not 'win_file'

### DIFF
--- a/ansible/playbooks/windows.yml
+++ b/ansible/playbooks/windows.yml
@@ -487,7 +487,7 @@
       tags: Cuda_Toolkit
 
     - name: Cleanup NVidia CUDA toolkit - Windows 10 and Server 2016
-      file:
+      win_file:
         path: C:\temp\cuda_9.0.176_win10_network-exe.exe
         state: absent
       when: (cuda_installed.stat.exists == false and ansible_distribution_major_version == "10")


### PR DESCRIPTION
Cleanup NVidia CUDA toolkit - Windows 10 and Server 2016
using 'file' not 'win_file'

** we need to be more diligent when checking code
and ensure the 'coder' tested it