### PR TITLE
removed gcc g++ 4.8 from Build_Tool_Packages

### DIFF
--- a/ansible/playbooks/AdoptOpenJDK_Linux_Playbook/roles/Common/vars/Ubuntu.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Linux_Playbook/roles/Common/vars/Ubuntu.yml
@@ -14,8 +14,6 @@ Build_Tool_Packages:
   - flex
   - g++
   - gcc
-  - g++-4.8
-  - gcc-4.8
   - gettext
   - libasound2-dev
   - libcups2-dev


### PR DESCRIPTION
During #114 I failed to remove 
  - g++-4.8
  - gcc-4.8
from Build_Tool_Packages which was moved into gcc_compiler
  