### PR TITLE
change cut to awk

### DIFF
--- a/ansible/playbooks/AdoptOpenJDK_Linux_Playbook/roles/GIT_Source/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Linux_Playbook/roles/GIT_Source/tasks/main.yml
@@ -15,7 +15,7 @@
   tags: git_source
 
 - name: Test if git is installed at the correct version
-  shell: git --version 2>/dev/null | sed -e 's/git version //g' | cut -c 1-4
+  shell: git --version 2>/dev/null | sed -e 's/git version //g' | awk -F'[.]' '{print $1 "." $2}'
   when: git_installed.rc == 0
   register: git_version
   tags: git_source


### PR DESCRIPTION
- Issues have been found when the version of git as only 1 char in the second field
example: git version 2.7.1 would be cut down to 2.7.