### PR TITLE
Add libcurl4-openssl-dev to packages

### DIFF
--- a/ansible/playbooks/AdoptOpenJDK_Linux_Playbook/roles/Common/vars/Ubuntu.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Linux_Playbook/roles/Common/vars/Ubuntu.yml
@@ -17,6 +17,7 @@ Build_Tool_Packages:
   - gettext
   - libasound2-dev
   - libcups2-dev
+  - libcurl4-openssl-dev
   - libdwarf-dev
   - libelf-dev
   - libexpat1-dev


### PR DESCRIPTION
- Required to build git properly from source
- Tested on ub14,16 x86, ppcle, s390

Fixes Issue #125

Signed-off-by: Adam Brousseau <adam.brousseau@ca.ibm.com>