### PR TITLE
Ensure root, Jenkins User and Superuser accounts never expires

### DIFF
--- a/ansible/playbooks/AdoptOpenJDK_Linux_Playbook/roles/Common/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Linux_Playbook/roles/Common/tasks/main.yml
@@ -13,6 +13,17 @@
     - ansible_distribution == "Debian"
     - ansible_architecture == "armv7l"
 
+###########################
+# Set Root account policy #
+###########################
+- name: Root account policy - expire date
+  command: chage -E -1 root
+  tags: root_account
+
+- name: Root account policy - max days
+  command: chage -M -1 root
+  tags: root_account
+
 ########################
 # Include OS variables #
 ########################

--- a/ansible/playbooks/AdoptOpenJDK_Linux_Playbook/roles/Jenkins_User/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Linux_Playbook/roles/Jenkins_User/tasks/main.yml
@@ -25,6 +25,14 @@
     key: "{{ lookup('file', '{{ Jenkins_User_SSHKey }}') }}"
   tags: [jenkins_user, jenkins_authorized_key]
 
+- name: Jenkins user account policy - expire date
+  command: chage -E -1 "{{ Jenkins_Username }}"
+  tags: jenkins_user
+
+- name: Jenkins user account policy - max days
+  command: chage -M -1 "{{ Jenkins_Username }}"
+  tags: jenkins_user
+
 - name: Add Jenkins user to the audio group
   user: name={{ Jenkins_Username }}
     groups=audio

--- a/ansible/playbooks/AdoptOpenJDK_Linux_Playbook/roles/Superuser/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Linux_Playbook/roles/Superuser/tasks/main.yml
@@ -35,3 +35,13 @@
     line: 'zeus ALL=(ALL) NOPASSWD: ALL'
   when: Superuser_Account == "Enabled"
   tags: supperuser
+
+- name: Superuser account policy - expire date
+  command: chage -E -1 zeus
+  when: Superuser_Account == "Enabled"
+  tags: supperuser
+
+- name: Superuser account policy - max days
+  command: chage -M -1 zeus
+  when: Superuser_Account == "Enabled"
+  tags: supperuser


### PR DESCRIPTION
Depending on how the base OS was setup/provided to us, a system wide password policy maybe in effect that could expire these user accounts. (example: force change of password ever 90 days) 
These changes to the 'expire date' and 'max days' will prevent this from occuring.