### PR TITLE
Ensure iptables changes are made permanently

### DIFF
--- a/ansible/playbooks/ubuntu-jckservices.yml
+++ b/ansible/playbooks/ubuntu-jckservices.yml
@@ -122,6 +122,8 @@
     - iptables:
         chain: INPUT
         jump: REJECT
+    - name: iptables_permanent
+      command: iptables-save
 # If your users are set to lock out after some retries you'll need this:
 #    - pamd:
 #        name: common-auth


### PR DESCRIPTION
Executes `iptables-save` after setting the firewall rules so they survive the machine being restarted