### PR TITLE
Added mercurial program to be installed on Ubuntu box via the respective ansible script

### DIFF
--- a/ansible/playbooks/AdoptOpenJDK_Linux_Playbook/roles/Common/tasks/Ubuntu.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Linux_Playbook/roles/Common/tasks/Ubuntu.yml
@@ -79,8 +79,8 @@
 # VCS tool: Mercurial    #
 ##########################
 - name: Install Mercurial
-  pip: name=mercurial version="3.7.3"
-       state=present
+  apt: name=mercurial state=present
+  tags: vcs_tool
 
 #################
 # xorg Packages #

--- a/ansible/playbooks/AdoptOpenJDK_Linux_Playbook/roles/Common/tasks/Ubuntu.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Linux_Playbook/roles/Common/tasks/Ubuntu.yml
@@ -75,13 +75,6 @@
     - ansible_architecture == "aarch64"
   tags: build_tools
 
-##########################
-# VCS tool: Mercurial    #
-##########################
-- name: Install Mercurial
-  apt: name=mercurial state=present
-  tags: vcs_tool
-
 #################
 # xorg Packages #
 #################

--- a/ansible/playbooks/AdoptOpenJDK_Linux_Playbook/roles/Common/tasks/Ubuntu.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Linux_Playbook/roles/Common/tasks/Ubuntu.yml
@@ -75,6 +75,13 @@
     - ansible_architecture == "aarch64"
   tags: build_tools
 
+##########################
+# VCS tool: Mercurial    #
+##########################
+- name: Install Mercurial
+  pip: name=mercurial version="3.7.3"
+       state=present
+
 #################
 # xorg Packages #
 #################

--- a/ansible/playbooks/AdoptOpenJDK_Linux_Playbook/roles/Common/vars/Ubuntu.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Linux_Playbook/roles/Common/vars/Ubuntu.yml
@@ -61,5 +61,6 @@ Test_Tool_Packages:
   - pulseaudio
   - xauth
   - xorg
+  - mercurial
 
 crontab_Patching: "/usr/bin/apt-get update && /usr/bin/apt-get -y upgrade"

--- a/ansible/playbooks/AdoptOpenJDK_Linux_Playbook/roles/Common/vars/Ubuntu.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Linux_Playbook/roles/Common/vars/Ubuntu.yml
@@ -57,10 +57,10 @@ Additional_Build_Tools_aarch64:
 Test_Tool_Packages:
   - ant
   - ant-contrib
+  - mercurial
   - perl
   - pulseaudio
   - xauth
   - xorg
-  - mercurial
 
 crontab_Patching: "/usr/bin/apt-get update && /usr/bin/apt-get -y upgrade"


### PR DESCRIPTION
Was unable to test it using the vagrant/ansible box. The location of the Ubuntu.yml ansible script changed to a new location. 

README.md was amended during the process.

Currently unable to run the command:
```
ansible-playbook -i hosts -s AdoptOpenJDK_Linux_Playbook/roles/Common/tasks/Ubuntu.yml 
``` 
from inside the vagrant box.

There should be a straight-forward way to run this playbook in your local environment.