### PR TITLE
Initial attempt at formatting hostnames/inventory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 .vagrant
 .idea/*
 ansible/playbooks/*.retry
+*.pyc
+ansible/host_vars/*

--- a/ansible/ansible.cfg
+++ b/ansible/ansible.cfg
@@ -1,0 +1,27 @@
+[defaults]
+filter_plugins      = plugins/filter
+gathering           = explicit
+host_key_checking   = False
+inventory           = plugins/inventory/adoptopenjdk_yaml.py
+library             = plugins/library
+remote_user         = root
+retry_files_enabled = False
+roles_path          = roles
+squash_actions      = apk
+
+
+# Pass an empty path to ssh so it doesn't read config. We don't need it
+# since we have all information available.
+[ssh_connection]
+ssh_args            = -F /dev/null -o ControlMaster=auto -o ControlPersist=60s
+scp_if_ssh          = True
+
+[privilege_escalation]
+become_user         = root
+become_method       = sudo
+
+[hosts:smartos]
+ansible_python_interpreter = /opt/local/bin/python
+
+[hosts:freebsd]
+ansible_python_interpreter = /usr/local/bin/python

--- a/ansible/inventory.yml
+++ b/ansible/inventory.yml
@@ -1,0 +1,85 @@
+---
+
+#
+# AdoptOpenJDK hosts! check the readme on how to add more
+# (if its not obvious enough).
+#
+
+hosts:
+
+  - build:
+
+    - cloudcone:
+        ubuntu1604-x64-1: {ip: 173.82.219.221}
+
+    - 1and1:
+        win2008r2-x64-1: {ip: 109.228.48.187}
+
+    - macstadium:
+        macos1010-x64-1: {ip: 207.254.50.138, user: Administrator}
+        macos1010-x64-2: {ip: 208.83.1.242, user: Administrator}
+
+    - marist:
+        sles12-s390x-1: {ip: 148.100.110.56, user: linux1}
+        ubuntu1604-s390x-1: {ip: 148.100.33.147, user: linux1}
+        ubuntu1604-s390x-2: {ip: 148.100.33.178, user: linux1}
+        ubuntu1604-s390x-3: {ip: 148.100.33.179, user: linux1}
+        zos21-s390x-1: {ip: 148.100.36.136, user: OPEN1}
+        zos21-s390x-2: {ip: 148.100.36.137, user: OPEN1}
+
+    - osuosl:
+        centos72-ppc64le-1: {ip: 140.211.168.138, user: centos}
+        fedora24-ppc64le-1: {ip: 140.211.168.134, user: fedora}
+        ubuntu1710-ppc64le-1: {ip: 140.211.168.135, user: ubuntu}
+        aix71-ppc64-1: {ip: 140.211.9.10}
+        aix71-ppc64-2: {ip: 140.211.9.12}
+
+    - packet:
+        ubuntu1604-armv8-1: {ip: 147.75.196.30}
+
+    - joyent:
+        ubuntu1604-x64-2: {ip: 37.153.109.201}
+
+    - scaleway:
+        ubuntu1604-x64-2: {ip: 51.15.46.107}
+        ubuntu1604-armv7-1: {ip: 212.47.233.28}
+        ubuntu1604-armv7-2: {ip: 212.47.246.7}
+
+    - softlayer:
+        win2012r2-x64-1: {ip: 37.58.193.195}
+        win2012r2-x64-2: {ip: 37.58.103.196}
+
+  - test:
+
+    - osuosl:
+        ubuntu1604-ppc64le-1: {ip: 140.211.168.227, user: ubuntu}
+        ubuntu1604-ppc64le-2: {ip: 140.211.168.190, user: ubuntu}
+
+    - packet:
+        ubuntu1604-armv8-1: {ip: 147.75.74.50}
+        ubuntu1604-x64-1: {ip: 147.75.204.239}
+        win2012r2-x64-1: {ip: 147.75.101.30}
+
+    - macincloud:
+        macos1010-x64-1: {ip: 74.80.250.151, user: admin}
+        macos1010-x64-2: {ip: 74.80.250.173, user: admin}
+
+    - scaleway:
+        ubuntu1604-x64-1: {ip: 51.15.76.107}
+
+  - jck:
+
+    - macstadium:
+        macos1010-x64-1: {ip: 207.254.71.30, user: Administrator}
+        macos1010-x64-2: {ip: 207.254.71.31, user: Administrator}
+
+    - osuosl:
+        ubuntu1604-ppc64le-1: {ip: 140.211.168.225, user: ubuntu}
+        ubuntu1604-ppc64le-2: {ip: 140.211.168.217, user: ubuntu}
+
+    - packet:
+        ubuntu1604-armv8-1: {ip: 147.75.193.234}
+
+    - softlayer:
+        ubuntu1604-x64-1: {ip: 159.122.210.205}
+        ubuntu1604-x64-2: {ip: 159.122.210.194}

--- a/ansible/inventory.yml
+++ b/ansible/inventory.yml
@@ -36,6 +36,7 @@ hosts:
 
     - packet:
         ubuntu1604-armv8-1: {ip: 147.75.196.30}
+        freebsd11-x64-1: {ip: 147.75.101.29}
 
     - joyent:
         ubuntu1604-x64-2: {ip: 37.153.109.201}

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/group_vars/all/adoptopenjdk_variables.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/group_vars/all/adoptopenjdk_variables.yml
@@ -3,6 +3,9 @@
 # adoptopenjdk_variables #
 ##########################
 
+# Domain for setting hostname
+Domain: adoptopenjdk.net
+
 # Jenkins User Variables:
 Jenkins_Username: jenkins
 Jenkins_User_SSHKey: /Vendor_Files/keys/id_rsa.pub

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/main.yml
@@ -4,6 +4,10 @@
 - hosts:
     - build
     - test
+    - "!*zos*"
+    - "!*win*"
+    - "!*macos*"
+    - "!*aix*"
   gather_facts: yes
   tasks:
 

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/main.yml
@@ -1,9 +1,10 @@
 ###################################
 # AdoptOpenJDK - Ansible Playbook #
 ###################################
-- hosts: all
-  remote_user: root
-  become: yes
+- hosts:
+    - build
+    - test
+  gather_facts: yes
   tasks:
 
   #########

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/tasks/main.yml
@@ -29,6 +29,14 @@
     - ansible_distribution == "Debian"
     - ansible_architecture == "armv7l"
 
+################
+# Set Hostname #
+################
+- name: Set hostname to inventory_hostname
+  hostname:
+    name: "{{ inventory_hostname }}.{{ Domain }}"
+  tags: hostname
+
 #####################
 # Update /etc/hosts #
 #####################
@@ -36,7 +44,7 @@
   lineinfile:
     dest: /etc/hosts
     regexp: "^(.*){{ ansible_hostname }}(.*)$"
-    line: "{{ ansible_default_ipv4.address }} {{ ansible_fqdn }} {{ ansible_hostname }}"
+    line: "{{ ansible_default_ipv4.address }} {{ inventory_hostname }}.{{ Domain }} {{ inventory_hostname }}"
     state: present
     backup: yes
   tags: hosts_file

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Debug/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Debug/tasks/main.yml
@@ -7,6 +7,7 @@
     msg:
       - "inventory_hostname: {{ inventory_hostname | default('***Undefined***') }} "
       - "ansible_hostname: {{ ansible_hostname | default('***Undefined***') }}"
+      - "ansible_ssh_private_key_file: {{ ansible_ssh_private_key_file }}"
       - "ansible_fqdn: {{ ansible_fqdn | default('***Undefined***') }}"
       - "ansible_default_ipv4.address: {{ ansible_default_ipv4.address | default('***Undefined***') }}"
       - "ansible_os_family: {{ ansible_os_family | default('***Undefined***') }} "

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Debug/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Debug/tasks/main.yml
@@ -7,7 +7,6 @@
     msg:
       - "inventory_hostname: {{ inventory_hostname | default('***Undefined***') }} "
       - "ansible_hostname: {{ ansible_hostname | default('***Undefined***') }}"
-      - "ansible_ssh_private_key_file: {{ ansible_ssh_private_key_file }}"
       - "ansible_fqdn: {{ ansible_fqdn | default('***Undefined***') }}"
       - "ansible_default_ipv4.address: {{ ansible_default_ipv4.address | default('***Undefined***') }}"
       - "ansible_os_family: {{ ansible_os_family | default('***Undefined***') }} "

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Nagios_Master_Config/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Nagios_Master_Config/tasks/main.yml
@@ -14,10 +14,10 @@
 # The AWX (Ansible Tower) host but have the root ssh key to access the Nagios Master
 # Nagios_Monitoring: Enabled - must be set in the group_vars
 # Nagios_Master_IP: x.x.x.x - must be set in the group_vars
-# Script must exist on Nagios Master 
+# Script must exist on Nagios Master
 #
-- name: SSH into the Nagios Master and excute the Nagios_Ansible_Config_tool.sh script 
-  local_action: command ssh -o StrictHostKeyChecking=no root@{{ Nagios_Master_IP }} "/usr/local/nagios/Nagios_Ansible_Config_tool/Nagios_Ansible_Config_tool.sh  {{ ansible_distribution }} {{ ansible_architecture }} {{ ansible_fqdn }} {{ ansible_default_ipv4.address }} "
+- name: SSH into the Nagios Master and excute the Nagios_Ansible_Config_tool.sh script
+  local_action: command ssh -o StrictHostKeyChecking=no root@{{ Nagios_Master_IP }} "/usr/local/nagios/Nagios_Ansible_Config_tool/Nagios_Ansible_Config_tool.sh  {{ ansible_distribution }} {{ ansible_architecture }} {{ inventory_hostname }} {{ ansible_default_ipv4.address }} "
   when:
     - Nagios_Monitoring == "Enabled"
     - Nagios_Master_IP is defined

--- a/ansible/plugins/filter/filters.py
+++ b/ansible/plugins/filter/filters.py
@@ -1,0 +1,63 @@
+# -*- coding: utf-8 -*-
+
+# Copyright Node.js contributors. All rights reserved.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to
+# deal in the Software without restriction, including without limitation the
+# rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+# sell copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+# FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+# IN THE SOFTWARE.
+#
+
+from ansible.errors import AnsibleFilterError
+import re
+
+
+def match_key(value, dictionary, raise_error=True, feedback_name='os'):
+    for key, val in dictionary.iteritems():
+        # yes, yes; we can lambda this but my old self in
+        # two years will cry having to understand
+        if type(val) is list:
+            for list_key in val:
+                if value.startswith(list_key):
+                    return key
+        elif value.startswith(val):
+            return key
+    if raise_error:
+        raise AnsibleFilterError(
+            "Couldn\'t find %s in supported %s types" % (value, feedback_name)
+        )
+    return False
+
+
+def starts_with(value, query):
+    return value.startswith(query)
+
+
+def stripversion(value):
+    # returns stuff up to first digit
+    match = re.search(r'^\D+', value)
+    return match.group() if match else False
+
+
+class FilterModule(object):
+    ''' Query filter '''
+
+    def filters(self):
+        return {
+            'match_key': match_key,
+            'startswith': starts_with,
+            'stripversion': stripversion
+        }

--- a/ansible/plugins/inventory/adoptopenjdk_yaml.py
+++ b/ansible/plugins/inventory/adoptopenjdk_yaml.py
@@ -35,7 +35,7 @@ import json
 import yaml
 import os
 import sys
-
+from os import path
 
 valid = {
   # taken from nodejs/node.git: ./configure
@@ -69,7 +69,9 @@ def main():
     export = {'_meta': {'hostvars': {}}}
 
     # get inventory
-    with open("inventory.yml", 'r') as stream:
+    basepath = path.dirname(__file__)
+    inventory_path = path.abspath(path.join(basepath, "..", "..", "inventory.yml"))
+    with open(inventory_path, 'r') as stream:
         try:
             hosts = yaml.load(stream)
 

--- a/ansible/plugins/inventory/adoptopenjdk_yaml.py
+++ b/ansible/plugins/inventory/adoptopenjdk_yaml.py
@@ -1,0 +1,197 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+# Copyright Node.js contributors. All rights reserved.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to
+# deal in the Software without restriction, including without limitation the
+# rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+# sell copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+# FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+# IN THE SOFTWARE.
+#
+
+import argparse
+try:
+    import configparser
+except ImportError:
+    import ConfigParser as configparser
+try:
+    from itertools import ifilter
+except ImportError:
+    from itertools import filter as ifilter
+import json
+import yaml
+import os
+import sys
+
+
+valid = {
+  # taken from nodejs/node.git: ./configure
+  'arch': ('armv7', 'armv8', 'ppc64le', 'ppc64', 'x64', 's390x'),
+
+  # valid roles - add as necessary
+  'type': ('build', 'test', 'jck'),
+
+  # providers - validated for consistency
+  'provider': ('cloudcone', 'joyent', 'marist', 'osuosl', 'scaleway',
+        'macstadium', 'macincloud', 'softlayer', 'packet')
+}
+
+# customisation options per host:
+#
+# - ip [string] (required): ip address of host
+# - alias [string]: 'nickname', will be used in ssh config
+# - labels [sequence]: passed to jenkins
+#
+# parsing done on host naming:
+#
+# - *freebsd*: changes path to python interpreter
+# - *smartos*: changes path to python interpreter
+#
+# @TODO: properly support --list and --host $host
+
+
+def main():
+
+    hosts = {}
+    export = {'_meta': {'hostvars': {}}}
+
+    # get inventory
+    with open("inventory.yml", 'r') as stream:
+        try:
+            hosts = yaml.load(stream)
+
+        except yaml.YAMLError as exc:
+            print(exc)
+        finally:
+            stream.close()
+
+    # get special cases
+    config = configparser.ConfigParser()
+    config.read('ansible.cfg')
+
+    for host_types in hosts['hosts']:
+        for host_type, providers in host_types.iteritems():
+            export[host_type] = {}
+            export[host_type]['hosts'] = []
+
+            key = '~/.ssh/id_rsa'
+            export[host_type]['vars'] = {
+                'ansible_ssh_private_key_file': key
+            }
+
+            for provider in providers:
+                for provider_name, hosts in provider.iteritems():
+                    for host, metadata in hosts.iteritems():
+                        # some hosts have metadata appended to provider
+                        # which requires underscore
+                        delimiter = "_" if host.count('-') is 3 else "-"
+                        hostname = '{}-{}{}{}'.format(host_type, provider_name,
+                                                      delimiter, host)
+
+                        # no point in adding windows servers for now
+                        if 'win' in hostname:
+                            continue
+                        else:
+                            export[host_type]['hosts'].append(hostname)
+
+                        c = {}
+
+                        try:
+                            parsed_host = parse_host(hostname)
+                            for k, v in parsed_host.iteritems():
+                                c.update({k: v[0] if type(v) is dict else v})
+                        except Exception, e:
+                            raise Exception('Failed to parse host: %s' % e)
+
+                        c.update({'ansible_host': metadata['ip']})
+
+                        if 'port' in metadata:
+                            c.update({'ansible_port': str(metadata['port'])})
+
+                        if 'user' in metadata:
+                            c.update({'ansible_user': metadata['user']})
+                            c.update({'ansible_become': True})
+
+                        if 'labels' in metadata:
+                            c.update({'labels': metadata['labels']})
+
+                        if 'alias' in metadata:
+                            c.update({'alias': metadata['alias']})
+
+                        if 'win' in hostname:
+                            c.update({'is_win': True})
+
+                        # add specific options from config
+                        for option in ifilter(lambda s: s.startswith('hosts:'),
+                                              config.sections()):
+                            # remove `hosts:`
+                            if option[6:] in hostname:
+                                for o in config.items(option):
+                                    # configparser returns tuples of key, value
+                                    c.update({o[0]: o[1]})
+
+                        export['_meta']['hostvars'][hostname] = {}
+                        export['_meta']['hostvars'][hostname].update(c)
+
+    print(json.dumps(export, indent=2))
+
+
+def parse_host(host):
+    """Parses a host and validates it against our naming conventions"""
+
+    hostinfo = dict()
+    info = host.split('-')
+
+    expected = ['type', 'provider', 'os', 'arch', 'uid']
+
+    if len(info) is not 5:
+        raise Exception('Host format is invalid: %s,' % host)
+
+    for key, item in enumerate(expected):
+        hostinfo[item] = has_metadata(info[key])
+
+    for item in ['type', 'provider', 'arch']:
+        if hostinfo[item] not in valid[item]:
+            raise Exception('Invalid %s: %s' % (item, hostinfo[item]))
+
+    return hostinfo
+
+
+def has_metadata(info):
+    """Checks for metadata in variables. These are separated from the "key"
+       metadata by underscore. Not used anywhere at the moment for anything
+       other than descriptiveness"""
+
+    param = dict()
+    metadata = info.split('_', 1)
+
+    try:
+        key = metadata[0]
+        metadata = metadata[1]
+    except IndexError:
+        metadata = False
+        key = info
+
+    return key if metadata else info
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--list', action='store_true')
+    parser.add_argument('--host', action='store')
+    args = parser.parse_args()
+
+    main()

--- a/ansible/plugins/inventory/host_vars/README.md
+++ b/ansible/plugins/inventory/host_vars/README.md
@@ -1,0 +1,21 @@
+## The `host_vars` folder
+
+If you have to handle secrets for workers or pass other variables,
+create a file in here with the same name as the machine and store it
+in there. It will be automatically made available as part of the
+ansible playbook.
+
+### Variables
+
+You will always have to set the following variables to configure a host:
+
+- `secret`: the jenkins slave secrets
+
+#### Optional variables
+
+Variables that _might_ be available for you to change depending on
+what init system your host will be running:
+
+- `server_jobs`: the number of parallel jobs to run on a host
+- `server_ram`: how much memory the slave should assign to java-base
+                (defaults to "128m")

--- a/ansible/plugins/library/ssh_config.py
+++ b/ansible/plugins/library/ssh_config.py
@@ -1,0 +1,122 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+# Copyright Node.js contributors. All rights reserved.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to
+# deal in the Software without restriction, including without limitation the
+# rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+# sell copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+# FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+# IN THE SOFTWARE.
+#
+
+from ansible.module_utils.basic import *
+from jinja2 import Environment, Template, filters
+import os
+import re
+
+pre_match = '# begin: adoptopenjdk template'
+post_match = '# end: adoptopenjdk template'
+match = re.compile(r'^' + re.escape(pre_match) + '(.*)' + re.escape(post_match),
+                   flags=re.DOTALL | re.MULTILINE)
+
+replace_ssh_args = {
+    '-o ': '',
+    '\'': '',
+    '=': ' '
+}
+
+host_template = \
+    '''
+{%- for host, metadata in hosts|dictsort -%}
+{%- if metadata.ansible_host and not metadata.is_win -%}
+{%- set ssh_arg = metadata.ansible_ssh_common_args %}
+Host {{ host }} {{ metadata.alias }}
+  HostName {{ metadata.ansible_host }}
+  IdentityFile {{ metadata.ansible_ssh_private_key_file }}
+  User {{ metadata.ansible_user or 'root' }}
+{{
+  '  Port ' + metadata.ansible_port + '\n' if metadata.ansible_port
+}}{{
+  '  ' + ssh_arg|multi_replace(args) + '\n' if ssh_arg
+}}
+ {%- endif -%}
+{%- endfor -%}
+'''
+
+
+def multi_replace(content, to_replace):
+    for key, val in to_replace.iteritems():
+        content = content.replace(key, val)
+    return content
+
+
+def is_templatable(path, config):
+    return os.path.exists(path) and bool(re.search(match, config))
+
+
+def render_template(hosts):
+    render = Environment()
+    render.filters['multi_replace'] = multi_replace
+    return render.from_string(host_template).render(hosts=hosts,
+                                                    args=replace_ssh_args)
+
+
+def main():
+    module = AnsibleModule(
+        argument_spec={
+            'path': {
+                'required': True,
+                'type': 'str',
+            },
+            'hostinfo': {
+                'required': True,
+                'type': 'dict',
+            }
+        }
+    )
+
+    path = os.path.expanduser(module.params['path'])
+
+    try:
+        with open(path, 'r') as f:
+            contents = f.read()
+        f.close()
+    except IOError:
+        module.fail_json(msg='Couldn\'t find a ssh config at %s' %
+                         path)
+
+    if not is_templatable(path, contents):
+        module.fail_json(msg='Your ssh config lacks template stubs. ' +
+                             'Check README.md for instructions.')
+
+    rendered = '{}{}{}'.format(
+        pre_match,
+        render_template(module.params['hostinfo']),
+        post_match
+    )
+
+    try:
+        with open(path, 'w+') as f:
+            f.write(match.sub(rendered, contents))
+        f.close()
+    except IOError:
+        module.fail_json(msg='Couldn\'t write to ssh config. Check permissions')
+
+    module.exit_json(changed=True, meta='Updated %s successfully' % path)
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
So I have used some of the fantastic code written at https://github.com/nodejs/build to setup an inventory based system. The key thing to this is that the backend python does some pretty clever stuff. You can see the inventory [here](https://github.com/gdams/openjdk-infrastructure/blob/inventory/ansible/inventory.yml).

#### Example:
```yaml
hosts:
  - build:
    - cloudcone:
        ubuntu1604-x64-1: {ip: 173.82.219.221}
```
Becomes `build-cloudcone-ubuntu1604-x64-1`

And this in turn means that the ansible variables are a bit more useful:

```bash
ok: [build-cloudcone-ubuntu1604-x64-1] => {
    "msg": [
        "inventory_hostname: build-cloudcone-ubuntu1604-x64-1 ", 
        "ansible_hostname: build-cloudcone-x64-ubuntu-16-04-1", 
        "ansible_ssh_private_key_file: ~/.ssh/id_rsa", 
        "ansible_fqdn: build-cloudcone-x64-ubuntu-16-04-1.cloudcone.com", 
        "ansible_default_ipv4.address: 173.82.219.221", 
        "ansible_os_family: Debian ", 
        "ansible_distribution: Ubuntu ", 
        "ansible_distribution_major_version: 16 ", 
        "ansible_architecture: x86_64 ", 
        "ansible_processor_vcpus: 4 ", 
        "ansible_processor_cores: 1 ", 
        "Jenkins_Username: jenkins ", 
        "Superuser_Account: Enabled", 
        "Vendor_File: ***Undefined***", 
        "Nagios_Plugins: Enabled ", 
        "Nagios_Monitoring: Enabled", 
        "Nagios_Master_IP: 78.47.239.96"
    ]
}
```

This should then allow us to standardise the hostnames which was part of the problem but can also be used as the hostname for the nagios master updates etc.

#### To Run:
```bash
ansible-playbook playbooks/AdoptOpenJDK_Linux_Playbook/main.yml --limit "build-cloudcone*"
```
macOS requires you to run:
```bash
export PYTHONPATH=$(pip2 show pyyaml | grep Location | awk '{print $2}')
```
(thanks @gibfahn for working that one out)