### PR TITLE
Start Xvfb with 24-bit screen depth

### DIFF
--- a/ansible/playbooks/ubuntu-jck.yml
+++ b/ansible/playbooks/ubuntu-jck.yml
@@ -34,7 +34,7 @@
         state: present
         key: "{{ lookup('file', '{{ Jenkins_User_SSHKey }}') }}"
     - name: Start virtual X display on :1
-      shell: Xvfb :1 &
+      shell: Xvfb :1 -screen 0 1280x1024x24 &
       args:
         creates: /tmp/.X1-lock
       become: yes


### PR DESCRIPTION
Still tempted to just remove this section and leave the starting of it to the person running it (The scripts in the repository will do that if it's not already running) but the Xvfb seems to need to be more than the default 8 bit depth in order for the JCK UI tests to pass on non-x86 platforms.