### PR TITLE
freebsd tweak

### DIFF
--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/GIT_Source/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/GIT_Source/tasks/main.yml
@@ -15,7 +15,7 @@
   tags: git_source
 
 - name: Test if git is installed at the correct version
-  shell: git --version >/dev/null | sed -e 's/git version //g' | awk -F'[.]' '{print $1 "." $2}'
+  shell: git --version | sed -e 's/git version //g' | awk -F'[.]' '{print $1 "." $2}'
   when: git_installed.rc == 0
   register: git_version
   tags: git_source


### PR DESCRIPTION
The check fails on freebsd
```
root@build-packet-freebsd11-x64-1:~ # git --version >/dev/null | sed -e 's/git version //g' | awk -F'[.]' '{print $1 "." $2}'
Ambiguous output redirect.
```
changing it to the below fixes things
```
root@build-packet-freebsd11-x64-1:~ # git --version | sed -e 's/git version //g' | awk -F'[.]' '{print $1 "." $2}'
2.15
```