### PR TITLE
include aarch64 in nagios

### DIFF
--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Nagios_Plugins/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Nagios_Plugins/tasks/main.yml
@@ -12,7 +12,7 @@
   ignore_errors: yes
   when:
     - Nagios_Plugins == "Enabled"
-    - ansible_architecture == "x86_64"
+    - (ansible_architecture == "x86_64" or ansible_architecture == "aarch64")
   tags: nagios_plugins
 
 - name: Set authorized key for Nagios user
@@ -22,7 +22,7 @@
     key: "{{ lookup('file', '{{ Nagios_User_SSHKey }}') }}"
   when:
     - Nagios_Plugins == "Enabled"
-    - ansible_architecture == "x86_64"
+    - (ansible_architecture == "x86_64" or ansible_architecture == "aarch64")
   tags: nagios_plugins
 
   ###################
@@ -68,7 +68,7 @@
   when:
     - Nagios_Plugins == "Enabled"
   tags: nagios_plugins
-  
+
   ##############################
   # Install additional plugins #
   ##############################

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Nagios_Plugins/tasks/nagios_Ubuntu.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Nagios_Plugins/tasks/nagios_Ubuntu.yml
@@ -21,7 +21,7 @@
       - perl
       - qstat
     when:
-      - ansible_architecture == "x86_64"
+      - (ansible_architecture == "x86_64" or ansible_architecture == "aarch64")
     tags: nagios_plugins
 
   ##########
@@ -30,11 +30,11 @@
   - name: Creates Nagios folder
     file: path=/usr/local/nagios/ state=directory mode=0755 owner=nagios
     when:
-      - ansible_architecture == "x86_64"
+      - (ansible_architecture == "x86_64" or ansible_architecture == "aarch64")
     tags: nagios_plugins
 
   - name: Create symlink to plugins
     file: src=/usr/lib/nagios/plugins dest=/usr/local/nagios/libexec state=link
     when:
-      - ansible_architecture == "x86_64"
+      - (ansible_architecture == "x86_64" or ansible_architecture == "aarch64")
     tags: nagios_plugins


### PR DESCRIPTION
I have added `aarch64` to the nagios setup. I have checked that there is nothing that the ubuntu aarch64 machines cannot do in the playbook so we should be all good