### PR TITLE
add linaro aarch64 machines

### DIFF
--- a/ansible/inventory.yml
+++ b/ansible/inventory.yml
@@ -15,7 +15,7 @@ hosts:
     - 1and1:
         win2008r2-x64-1: {ip: 109.228.48.187}
       
-    - linaro
+    - linaro:
         centos74-armv8-1: {ip: 64.28.99.122}
         centos74-armv8-2: {ip: 64.28.99.122, port: 2222}
 

--- a/ansible/inventory.yml
+++ b/ansible/inventory.yml
@@ -14,6 +14,10 @@ hosts:
 
     - 1and1:
         win2008r2-x64-1: {ip: 109.228.48.187}
+      
+    - linaro
+        centos74-armv8-1: {ip: 64.28.99.122}
+        centos74-armv8-2: {ip: 64.28.99.122, port: 2222}
 
     - macstadium:
         macos1010-x64-1: {ip: 207.254.50.138, user: Administrator}


### PR DESCRIPTION
We use box number as a jump box to number 2 (we only have 1 external IP). This also gives us a chance to fixup any bugs with centos7 on aarch64 which I don't believe that we have ever run the playbook against