### PR TITLE
Add xvfb and acl to playbooks

### DIFF
--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/vars/RedHat.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/vars/RedHat.yml
@@ -55,8 +55,10 @@ Java_RHEL6_PPC64:
   - java-1.8.0-ibm-devel
 
 Test_Tool_Packages:
+  - acl
   - ant
   - perl
   - xorg-x11-xauth
+  - xorg-x11-server-Xvfb
 
 crontab_Patching: "/usr/bin/yum -y update"

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/vars/Ubuntu.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/vars/Ubuntu.yml
@@ -55,12 +55,14 @@ Additional_Build_Tools_aarch64:
   - libpng-dev
 
 Test_Tool_Packages:
+  - acl
   - ant
   - ant-contrib
   - mercurial
   - perl
   - xauth
   - xorg
+  - xvfb
 
 Test_Tool_Packages_x86_64:
   - pulseaudio


### PR DESCRIPTION
- package installs permit inclusion of an ubuntu machine to jck testing

Signed-off-by: Joe deKoning <joe_dekoning@ca.ibm.com>