### PR TITLE
Change hosts to allow for Vendor groups

### DIFF
--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/main.yml
@@ -1,13 +1,7 @@
 ###################################
 # AdoptOpenJDK - Ansible Playbook #
 ###################################
-- hosts:
-    - build
-    - test
-    - "!*zos*"
-    - "!*win*"
-    - "!*macos*"
-    - "!*aix*"
+- hosts: "{{ groups['Vendor_groups'] | default('build:test:!*zos*:!*win*:!*macos*:!*aix*') }}"
   gather_facts: yes
   tasks:
 

--- a/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/main.yml
@@ -16,9 +16,7 @@
 # .\ConfigureRemotingForAnsible.ps1 -ForceNewSSLCert
 # .\ConfigureRemotingForAnsible.ps1 -SkipNetworkProfileCheck
 
-- hosts:
-    - "build*win*"
-    - "test*win*"
+- hosts: "{{ groups['Vendor_groups'] | default('build*win*:test*win*') }}"
   gather_facts: yes
   tasks:
 


### PR DESCRIPTION
- The way the 'hosts' module is currently configured would force others to use the same naming convention as AdoptOpenJDK build/test-vendor-xxx-arch-num
- Changed hosts to allow for Vendor groups
- (*Ansible's hosts module doesn't allow for the use of loops/with_items)
 
```yml
from:
- hosts:
  - build		
  - test		
  - "!*zos*"		
  - "!*win*"		
  - "!*macos*"		
  - "!*aix*"

to:
- hosts: "{{ groups['Vendor_groups'] | default('build:test:!*zos*:!*win*:!*macos*:!*aix*') }}"
```
Thus if 'Vendor_groups' is not found it will default to the standard limits