### PR TITLE
Added xorg-x11-server-extra to SLES test tool package

### DIFF
--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/vars/SLES.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/vars/SLES.yml
@@ -41,7 +41,8 @@ Test_Tool_Packages:
   - ant
   - perl
   - pulseaudio
-  - xorg-x11-server
   - xorg-x11
+  - xorg-x11-server
+  - xorg-x11-server-extra
 
 crontab_Patching: "/usr/bin/zypper refresh && /usr/bin/zypper -n up"


### PR DESCRIPTION
This pull request satisfies the SLES requirement of issue #184.
Xvfb on SLES is provided by the `xorg-x11-server-extra` package.