### PR TITLE
Move libstdc++-static from only ppc64le to all arch

### DIFF
--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/vars/RedHat.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/vars/RedHat.yml
@@ -40,10 +40,10 @@ Additional_Build_Tools_RHEL7:
   - elfutils-libelf-devel
   - flex
   - libdwarf-devel
+  - libstdc++-static
 
 Additional_Build_Tools_RHEL7_PPC64LE:
   - libcurl-devel
-  - libstdc++-static
   - ant-contrib
 
 Java_NOT_RHEL6_PPC64:


### PR DESCRIPTION
- OpenJ9 needs this lib in order to compile on x86 RHEL7

Signed-off-by: Adam Brousseau <adam.brousseau88@gmail.com>