### PR TITLE
Add fontconfig-devel to aix

### DIFF
--- a/ansible/playbooks/aix.yml
+++ b/ansible/playbooks/aix.yml
@@ -115,6 +115,7 @@
         - cups-libs
         - flex
         - freetype2-devel
+        - fontconfig-devel
         - gawk
         - git
         - grep


### PR DESCRIPTION
This was missing on both AIX machines and is needed to build openjdk10