### PR TITLE
Add java8 as default java on ubuntu16 x86 machines

### DIFF
--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/tasks/Ubuntu.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/tasks/Ubuntu.yml
@@ -110,8 +110,8 @@
 - name: Set default java version for x86_64
   shell: update-alternatives --set java /usr/lib/jvm/java-8-openjdk-amd64/jre/bin/java
   when:
-   - ansible_distribution_major_version == "14"
-   - ansible_architecture == "x86_64"
+   - (ansible_distribution_major_version == "14" and ansible_architecture == "x86_64") or 
+     (ansible_distribution_major_version == "16" and ansible_architecture == "x86_64")
   tags: default_java
 
 - name: Set default java version for armv7l


### PR DESCRIPTION
* zulu java9 causes intermittant failures for jenkins clients when using Xvfb

Signed-off-by: Joe deKoning <joe_dekoning@ca.ibm.com>