### PR TITLE
Added xorg-x11-server-Xvfb

### DIFF
--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/vars/OracleLinux.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/vars/OracleLinux.yml
@@ -51,5 +51,6 @@ Test_Tool_Packages:
   - perl
   - xorg-x11-xauth
   - xorg-x11-server-Xorg
+  - xorg-x11-server-Xvfb
 
 crontab_Patching: "/usr/bin/yum -y update"


### PR DESCRIPTION
Adding add-xvfb-to-oraclelinux because that's what's used on RHEL, which this o/s is based on.