### PR TITLE
Add xterm/gedit/gnome-terminal to playbook to support JCK interactives

### DIFF
--- a/ansible/playbooks/ubuntu-jck.yml
+++ b/ansible/playbooks/ubuntu-jck.yml
@@ -19,12 +19,15 @@
       - ant
       - acl
       - gcc
+      - gedit
+      - gnome-terminal
       - git
       - make
       - unzip
       - openjdk-8-jre
       - vnc4server
       - xvfb
+      - xterm
     - name: Create Jenkins user
       action: user name="{{ Jenkins_Username }}" state=present
       ignore_errors: yes


### PR DESCRIPTION
From @lumpfish

_One of the JCK tests requires that I drag and drop some text out of the JCK GUI and paste into a native application.  The JCK machine doesn't appear to have gedit installed.  Anyone have another suggestion?_