### PR TITLE
Added printer-driver-cups-pdf and gv to the JCK playbook

### DIFF
--- a/ansible/playbooks/ubuntu-jck.yml
+++ b/ansible/playbooks/ubuntu-jck.yml
@@ -22,9 +22,11 @@
       - gedit
       - gnome-terminal
       - git
+      - gv
       - make
       - unzip
       - openjdk-8-jre
+      - printer-driver-cups-pdf
       - vnc4server
       - xvfb
       - xterm


### PR DESCRIPTION
Added `gv` and `printer-driver-cups-pdf` to the list of prerequisite packages.
Answers issue #307.