### PR TITLE
WIP: Adding pkg-config into the ansible playbooks

### DIFF
--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/vars/RedHat.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/vars/RedHat.yml
@@ -31,6 +31,7 @@ Build_Tool_Packages:
   - openssl-devel
   - perl-CPAN
   - perl-devel
+  - pkgconfig
   - unzip
   - wget
   - xz

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/vars/SLES.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/vars/SLES.yml
@@ -19,6 +19,7 @@ Build_Tool_Packages:
   - libelf1
   - make
   - ntp
+  - pkg-config
   - unzip
   - wget
   - zip


### PR DESCRIPTION
This package is required on zLinux to enable OpenJDK to find
freetype without patching, as it changes the locations we search
for freetype to include the default location.

Tried contributing the patch so we search the *right* locations
for freetype, but OpenJDK has chosen not to accept this.


Signed-off-by: Adam Farley <adam.farley@uk.ibm.com>