### PR TITLE
Register Visual Studio DIA SDK shared libraries

### DIFF
--- a/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/roles/MSVS_2010/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/roles/MSVS_2010/tasks/main.yml
@@ -20,6 +20,10 @@
   when: (vs2010_installed.stat.exists == false)
   tags: MSVS_2010
 
+- name: Register Visual Studio 2010 DIA SDK shared libraries
+  raw: 'for /r "C:\Program Files (x86)\Microsoft Visual Studio 10.0\DIA SDK" %F in ( msdia*.dll ) do regsvr32 /s "%~F"'
+  tags: MSVS_2010
+
 - name: Reboot machine after Visual Studio 2010 installation
   win_reboot:
     reboot_timeout: 1800

--- a/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/roles/MSVS_2013/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/roles/MSVS_2013/tasks/main.yml
@@ -23,6 +23,10 @@
   when: (vs2013_installed.stat.exists == false)
   tags: MSVS_2013
 
+- name: Register Visual Studio Community 2013 DIA SDK shared libraries
+  raw: 'for /r "C:\Program Files (x86)\Microsoft Visual Studio 12.0\DIA SDK" %F in ( msdia*.dll ) do regsvr32 /s "%~F"'
+  tags: MSVS_2013
+
 - name: Reboot machine after Visual Studio installation
   win_reboot:
     reboot_timeout: 1800


### PR DESCRIPTION
OpenJ9 uses the ddrgen tool from OMR; that tool depends on msdia100.dll which must be registered. This change arranges that both the 32-bit and 64-bit variants are registered as part of installing Visual Studio 2010.