### PR TITLE
Add ability to run ansible on a specific machine

### DIFF
--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/main.yml
@@ -1,7 +1,7 @@
 ###################################
 # AdoptOpenJDK - Ansible Playbook #
 ###################################
-- hosts: "{{ groups['Vendor_groups'] | default('build:test:!*zos*:!*win*:!*macos*:!*aix*') }}"
+- hosts: "{{ groups['Vendor_groups'] | default('localhost:build:test:!*zos*:!*win*:!*macos*:!*aix*') }}"
   gather_facts: yes
   tasks:
 


### PR DESCRIPTION
* enable anyone to be able to run on a single machine without
* Ansible Tower installed or the use of a inventory file.

Signed-off-by: Joe deKoning <joe_dekoning@ca.ibm.com>