### PR TITLE
Updates for RHEL6

### DIFF
--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/vars/RedHat.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/vars/RedHat.yml
@@ -9,6 +9,7 @@ Build_Tool_Packages:
   - bind-utils
   - cpio
   - cups-devel
+  - elfutils-libelf-devel
   - expat-devel
   - fontconfig-devel
   - freetype-devel
@@ -18,8 +19,11 @@ Build_Tool_Packages:
   - glibc
   - glibc-common
   - glibc-devel
+  - glibc-devel.i686
   - gmp-devel
+  - libdwarf-devel
   - libffi-devel
+  - libmpc-devel
   - libXext-devel
   - libXrender-devel
   - libXt-devel
@@ -40,9 +44,7 @@ Build_Tool_Packages:
 Additional_Build_Tools_RHEL7:
   - bison
   - curl-devel
-  - elfutils-libelf-devel
   - flex
-  - libdwarf-devel
   - libstdc++-static
 
 Additional_Build_Tools_RHEL7_PPC64LE:
@@ -61,6 +63,7 @@ Test_Tool_Packages:
   - acl
   - ant
   - ant-contrib
+  - ant-apache-regexp
   - perl
   - xorg-x11-xauth
   - xorg-x11-server-Xvfb

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/gcc_48/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/gcc_48/tasks/main.yml
@@ -8,41 +8,6 @@
   register: gcc_installed
   tags: gcc-4.8
 
-# MPC - gcc prerequisites
-- name: Download mpc sources
-  get_url:
-    url: http://www.multiprecision.org/downloads/mpc-0.8.1.tar.gz
-    dest: '/tmp/mpc-0.8.1.tar.gz'
-    force: no
-    mode: 0755
-  when:
-    - gcc_installed.rc != 0
-    - ansible_distribution == "RedHat"
-    - ansible_distribution_major_version == "6"
-    - ansible_architecture == "x86_64"
-  tags: gcc-4.8
-
-- name: Extract mpc
-  unarchive:
-    src: /tmp/mpc-0.8.1.tar.gz
-    dest: /tmp/
-    copy: False
-  when:
-    - gcc_installed.rc != 0
-    - ansible_distribution == "RedHat"
-    - ansible_distribution_major_version == "6"
-    - ansible_architecture == "x86_64"
-  tags: gcc-4.8
-
-- name: Running configure, compile and install for mpc
-  shell: cd /tmp/mpc-0.8.1 && ./configure && make -j {{ ansible_processor_vcpus }} && make install
-  when:
-    - gcc_installed.rc != 0
-    - ansible_distribution == "RedHat"
-    - ansible_distribution_major_version == "6"
-    - ansible_architecture == "x86_64"
-  tags: gcc-4.8
-
 # gcc
 - name: Download gcc-4.8.5 source
   get_url:
@@ -100,6 +65,49 @@
     owner: root
     group: root
     state: link
+  when:
+    - gcc_installed.rc != 0
+    - ansible_distribution == "RedHat"
+    - ansible_distribution_major_version == "6"
+    - ansible_architecture == "x86_64"
+  tags: gcc-4.8
+
+- name: Create symlink for c++-4.8
+  file:
+    src: /opt/gcc-4.8.5/bin/c++
+    dest: /usr/bin/c++-4.8
+    owner: root
+    group: root
+    state: link
+  when:
+    - gcc_installed.rc != 0
+    - ansible_distribution == "RedHat"
+    - ansible_distribution_major_version == "6"
+    - ansible_architecture == "x86_64"
+  tags: gcc-4.8
+
+- name: Create symlink for libstdc++.so.6.0.19
+  file:
+    src: /opt/gcc-4.8.5/lib64/libstdc++.so.6.0.19 
+    dest: /usr/lib64/libstdc++.so.6.0.19
+    owner: root
+    group: root
+    state: link
+  when:
+    - gcc_installed.rc != 0
+    - ansible_distribution == "RedHat"
+    - ansible_distribution_major_version == "6"
+    - ansible_architecture == "x86_64"
+  tags: gcc-4.8
+
+- name: Create symlink for libstdc++.so.6
+  file:
+    src: /usr/lib64/libstdc++.so.6.0.19
+    dest: /usr/lib64/libstdc++.so.6
+    owner: root
+    group: root
+    state: link
+    force: true
   when:
     - gcc_installed.rc != 0
     - ansible_distribution == "RedHat"


### PR DESCRIPTION
Fixes for gcc 4.8.5:
- install libmpc-devel package instead of building mpc from source
- install 32 bits glibc package
- add c++ symlink
- add libstdc++.so.6.0.19 symlink
Move dwarf and elf packages to build tools
Add ant-apache-regexp package to test tools

Signed-off-by: Violeta Sebe <vsebe@ca.ibm.com>