### PR TITLE
Add HiRes Time perl module to CentOS

### DIFF
--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/vars/CentOS.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/vars/CentOS.yml
@@ -43,6 +43,7 @@ Build_Tool_Packages:
   - perl-devel
   - perl-GD
   - perl-libwww-perl
+  - perl-Time-HiRes
   - unzip
   - wget
   - xz


### PR DESCRIPTION
* OpenJ9 sanity testing has a requirement on having this module installed

Signed-off-by: Joe deKoning <joe_dekoning@ca.ibm.com>