### PR TITLE
Add Ansible-lint to the build pipeline

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,16 +15,28 @@ install:
   # Install ansible
   - pip install ansible
   - pip install yamllint
+  - pip install ansible-lint
 
   # Check ansible version
   - ansible --version
 
 script:
   - cd ansible
+
     # Check that the inventory is valid
   - ansible-inventory --host=build-cloudcone-ubuntu1604-x64-1
+
     # Check YAML validity
   - yamllint -c yamllint.yml .
+
+    # Ansible code static analysis
+  - ansible-lint playbooks/AdoptOpenJDK_Unix_Playbook/main.yml
+  - ansible-lint playbooks/AdoptOpenJDK_Windows_Playbook/main.yml
+  - ansible-lint playbooks/AdoptOpenJDK_Services_Playbooks/ubuntu-api.yml
+  - ansible-lint playbooks/AdoptOpenJDK_Services_Playbooks/ubuntu-jckservices.yml
+  - ansible-lint playbooks/aix.yml
+  - ansible-lint playbooks/ubuntu-jck.yml
+
     # Check Playbook syntax.
   - ansible-playbook playbooks/AdoptOpenJDK_Unix_Playbook/main.yml --syntax-check
   - ansible-playbook playbooks/AdoptOpenJDK_Windows_Playbook/main.yml --syntax-check

--- a/ansible/playbooks/AdoptOpenJDK_Services_Playbooks/ubuntu-api.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Services_Playbooks/ubuntu-api.yml
@@ -31,7 +31,10 @@
           with_items:
             - iptables-persistent
             - nodejs
-          tags: dependencies
+          tags:
+            - dependencies
+            # TODO: Package installs should not use latest
+            - skip_ansible_lint
 
         - name: Create Jenkins user
           action: user name={{ Jenkins_Username }} state=present shell=/bin/bash
@@ -84,13 +87,18 @@
 
         - name: Git Clone openjdk-api.git
           become_user: "{{ Jenkins_Username }}"
+          become: True
           git:
             repo: 'https://github.com/AdoptOpenJDK/openjdk-api.git'
             dest: "/home/{{ Jenkins_Username }}/openjdk-api"
             update: yes
+          tags:
+            # TODO: Git checkouts must contain explicit version
+            - skip_ansible_lint
 
         - name: NPM install api package.json
           become_user: "{{ Jenkins_Username }}"
+          become: True
           npm:
             path: "/home/{{ Jenkins_Username }}/openjdk-api"
 
@@ -100,6 +108,7 @@
 
         - name: Start api app
           become_user: "{{ Jenkins_Username }}"
+          become: True
           raw: "export PRODUCTION=true && /usr/local/bin/forever start /home/{{ Jenkins_Username }}/openjdk-api/server.js"
 
         - name: Add cron job to check for updates

--- a/ansible/playbooks/AdoptOpenJDK_Services_Playbooks/ubuntu-jckservices.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Services_Playbooks/ubuntu-jckservices.yml
@@ -75,6 +75,8 @@
           args:
             creates: krb5.jckusers.txt
           tags:
+            #false positive for 'use shell only when shell is required'
+            #this whole piece should be rewritten to avoid 'bashsible' code style
             - skip_ansible_lint
 
         - name: Start krb5-kdc service
@@ -166,7 +168,8 @@
             chain: INPUT
             source: 169.55.170.68
             jump: ACCEPT
-        - iptables:
+        - name: Setup iptables
+          iptables:
             chain: INPUT
             jump: REJECT
         - name: iptables_permanent

--- a/ansible/playbooks/AdoptOpenJDK_Services_Playbooks/ubuntu-jckservices.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Services_Playbooks/ubuntu-jckservices.yml
@@ -26,6 +26,11 @@
             - pwgen
             - tomcat8
             - unzip
+          tags:
+            # TODO: replace 'latest' with specified versions
+            - skip_ansible_lint
+
+
         - name: Create Jenkins user
           action: user name="{{ Jenkins_Username }}" state=present
           ignore_errors: yes
@@ -54,11 +59,14 @@
             group: root
             mode: 0644
             backup: yes
+
         - name: Configure kerberos server
-          shell: kdb5_util create -r ADOPTOPENJDK_NET -W -s -P `pwgen -1`
+          command: kdb5_util create -r ADOPTOPENJDK_NET -W -s -P `pwgen -1`
           args:
             creates: /etc/krb5kdc/principal.kadm5
-        - shell: "{{ item }}"
+
+        - name: Run shell scripts
+          shell: "{{ item }}"
           with_items:
             - kadmin.local -q "addprinc -pw `pwgen -1` admin/admin@ADOPTOPENJDK_NET"
             - kadmin.local -q "addprinc -pw user1 user1/jckservices.adoptopenjdk.net@ADOPTOPENJDK_NET"
@@ -66,74 +74,95 @@
             - kadmin.local -q getprincs | egrep '^admin/admin@|^user1/|^user2/' > krb5.jckusers.txt; if test $(wc -l < krb5.jckusers.txt) -ne 3; then echo Wrong number of users - expected 3:; cat krb5.jckusers.txt; rm krb5.jckusers.txt; exit 1; fi
           args:
             creates: krb5.jckusers.txt
-        - service:
+          tags:
+            - skip_ansible_lint
+
+        - name: Start krb5-kdc service
+          service:
             name: krb5-kdc
             state: started
-        - service:
+        - name: Start krb5-admin-server service
+          service:
             name: krb5-admin-server
             state: started
-        - service:
+        - name: Start tomcat8 service
+          service:
             name: tomcat8
             state: started
-        - iptables:
+        - name: Setup iptables
+          iptables:
             chain: INPUT
             ctstate: ESTABLISHED,RELATED
             jump: ACCEPT
-        - iptables:
+        - name: Setup iptables
+          iptables:
             chain: INPUT
             protocol: icmp
             jump: ACCEPT
-        - iptables:
+        - name: Setup iptables
+          iptables:
             chain: INPUT
             protocol: tcp
             destination_port: 22
             jump: ACCEPT
-        - iptables:
+        - name: Setup iptables
+          iptables:
             chain: INPUT
             protocol: tcp
             destination_port: 80
             jump: ACCEPT
-        - iptables:
+        - name: Setup iptables
+          iptables:
             chain: INPUT
             source: 159.122.210.194
             jump: ACCEPT
-        - iptables:
+        - name: Setup iptables
+          iptables:
             chain: INPUT
             source: 159.122.210.205
             jump: ACCEPT
-        - iptables:
+        - name: Setup iptables
+          iptables:
             chain: INPUT
             source: 207.254.71.30
             jump: ACCEPT
-        - iptables:
+        - name: Setup iptables
+          iptables:
             chain: INPUT
             source: 207.254.71.31
             jump: ACCEPT
-        - iptables:
+        - name: Setup iptables
+          iptables:
             chain: INPUT
             source: 147.75.193.234
             jump: ACCEPT
-        - iptables:
+        - name: Setup iptables
+          iptables:
             chain: INPUT
             source: 140.211.168.225
             jump: ACCEPT
-        - iptables:
+        - name: Setup iptables
+          iptables:
             chain: INPUT
             source: 140.211.168.217
             jump: ACCEPT
-        - iptables:
+        - name: Setup iptables
+          iptables:
             chain: INPUT
             source: 148.100.33.183
             jump: ACCEPT
-        - iptables:
+        - name: Setup iptables
+          iptables:
             chain: INPUT
             source: 148.100.33.184
             jump: ACCEPT
-        - iptables:
+        - name: Setup iptables
+          iptables:
             chain: INPUT
             source: 165.225.150.83
             jump: ACCEPT
-        - iptables:
+        - name: Setup iptables
+          iptables:
             chain: INPUT
             source: 169.55.170.68
             jump: ACCEPT

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/CPAN/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/CPAN/tasks/main.yml
@@ -9,7 +9,10 @@
   ignore_errors: yes
   when:
     - (ansible_distribution == "RedHat" and ansible_distribution_major_version == "6") or (ansible_distribution == "CentOS" and ansible_distribution_major_version == "6") or (ansible_distribution == "SLES")
-  tags: test_tools
+  tags:
+    - test_tools
+    - skip_ansible_lint
+    #TODO: curl used in place of get_url or uri module
 
 - name: Install cpanminus RedHat 7 and Centos 7
   yum:
@@ -21,22 +24,25 @@
 
 # All
 - name: Install JSON
-  shell: |
-    cpanm --with-recommends JSON
+  command: cpanm --with-recommends JSON
   tags:
     - cpan
     - json
+    # TODO: write a condition when NOT to run this step
+    - skip_ansible_lint
 
 - name: Install Text::CSV
-  shell: |
-    cpanm --with-recommends Text::CSV
+  command: cpanm --with-recommends Text::CSV
   tags:
     - cpan
     - text_csv
+    # TODO: write a condition when NOT to run this step
+    - skip_ansible_lint
 
 - name: Install XML::Parser
-  shell: |
-    cpanm --with-recommends XML::Parser
+  command: cpanm --with-recommends XML::Parser
   tags:
     - cpan
     - xml_parser
+    # TODO: write a condition when NOT to run this step
+    - skip_ansible_lint

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Docker/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Docker/tasks/main.yml
@@ -6,7 +6,10 @@
   shell: docker >/dev/null 2>&1
   ignore_errors: yes
   register: docker_installed
-  tags: docker
+  tags:
+    - docker
+    # TODO: write a condition when NOT to run this step
+    - skip_ansible_lint
 
 # Ubuntu
 - name: Add Docker Repo for Ubuntu
@@ -30,7 +33,10 @@
     - docker_installed.rc != 0
     - ansible_distribution == "Ubuntu"
     - ansible_architecture == "x86_64"
-  tags: docker
+  tags:
+    - docker
+    # TODO: Package installs should not use latest
+    - skip_ansible_lint
 
 - name: Install additional Docker prerequisites for Ubuntu 14
   apt: pkg={{ item }} state=latest
@@ -42,7 +48,10 @@
     - ansible_distribution == "Ubuntu"
     - ansible_distribution_major_version == "14"
     - ansible_architecture == "x86_64"
-  tags: docker
+  tags:
+    - docker
+    # TODO: Package installs should not use latest
+    - skip_ansible_lint
 
 - name: Import Docker Repo key for Ubuntu
   apt_key:
@@ -106,7 +115,10 @@
     - ansible_distribution == "SLES"
     - ansible_distribution_major_version == "12"
     - ansible_architecture == "x86_64"
-  tags: docker
+  tags:
+    - docker
+    # TODO: Package installs should not use latest
+    - skip_ansible_lint
 
 # CentOS
 - name: Install EPEL repo for CentOS 7
@@ -161,7 +173,10 @@
     - docker_installed.rc != 0
     - (ansible_distribution == "RedHat" and ansible_distribution_major_version == "7" ) or (ansible_distribution == "Ubuntu") or (ansible_distribution == "CentOS" and ansible_distribution_major_version == "7" )
     - ansible_architecture == "x86_64"
-  tags: docker
+  tags:
+    - docker
+    # TODO: Package installs should not use latest
+    - skip_ansible_lint
 
 - name: Add Jenkins user to the docker group for ALL
   user: name={{ Jenkins_Username }}

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/GIT_Source/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/GIT_Source/tasks/main.yml
@@ -12,13 +12,19 @@
   shell: git --version >/dev/null
   ignore_errors: yes
   register: git_installed
-  tags: git_source
+  tags:
+    - git_source
+    # Emits 'git used in place of git module'
+    - skip_ansible_lint
 
 - name: Test if git is installed at the correct version
   shell: git --version | sed -e 's/git version //g' | awk -F'[.]' '{print $1 "." $2}'
   when: git_installed.rc == 0
   register: git_version
-  tags: git_source
+  tags:
+    - git_source
+    # Emits 'git used in place of git module'
+    - skip_ansible_lint
 
 - name: Download git source
   get_url:
@@ -44,6 +50,9 @@
   package: "name=curl-devel state=latest"
   when:
     - (ansible_distribution == "RedHat" and ansible_distribution_major_version == "6")
+  tags:
+    # TODO: Package installs should not use latest
+    - skip_ansible_lint
 
 - name: Compile and install git from source
   shell: cd /tmp/git-2.15.0 && ./configure --prefix=/usr/local --without-tcltk && make clean && make -j {{ ansible_processor_vcpus }} && sudo make install

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Jenkins_User/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Jenkins_User/tasks/main.yml
@@ -35,9 +35,15 @@
   tags: jenkins_user
 
 - name: Unset expiry on user account for Redhat for Jenkins user
-  shell: chage -M -1 -E -1 {{ Jenkins_Username }}
-  tags: jenkins_user
+  command: chage -M -1 -E -1 {{ Jenkins_Username }}
+  tags:
+    - jenkins_user
+    # TODO: write a condition when NOT to run this step
+    - skip_ansible_lint
 
 - name: Unset expiry on user account for Redhat for root
-  shell: chage -M -1 -E -1 root
-  tags: jenkins_user
+  command: chage -M -1 -E -1 root
+  tags:
+    - jenkins_user
+    # TODO: write a condition when NOT to run this step
+    - skip_ansible_lint

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/NTP_TIME/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/NTP_TIME/tasks/main.yml
@@ -3,14 +3,17 @@
 # NTP_TIME #
 ############
 - name: Set timedatectl set-ntp no
-  shell: timedatectl set-ntp no
+  command: timedatectl set-ntp no
   when:
     - (ansible_distribution == "RedHat" and ansible_distribution_major_version == "7") or (ansible_distribution == "Ubuntu") or (ansible_distribution == "SLES" and ansible_distribution_major_version == "12") or (ansible_distribution == "centos" and ansible_distribution_major_version == "7" )
   tags: ntp_time
 
 - name: Configure NTP server pools
   shell: "cat /etc/ntp.conf | grep '1.pool.ntp.org' && echo NTP || echo -e 'pool 1.pool.ntp.org\npool 2.pool.ntp.org\npool 3.pool.ntp.org' >> /etc/ntp.conf"
-  tags: ntp_time
+  tags:
+    - ntp_time
+    # TODO: write a condition when NOT to run this step
+    - skip_ansible_lint
 
 - name: Start NTP for Ubuntu and SLES 11
   service:

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/NVidia_Cuda_Toolkit/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/NVidia_Cuda_Toolkit/tasks/main.yml
@@ -20,7 +20,7 @@
   tags: nvidia_cuda_toolkit
 
 - name: Install NVidia CUDA toolkit
-  shell: sh /tmp/cuda9_linux-run --silent --toolkit --override
+  command: sh /tmp/cuda9_linux-run --silent --toolkit --override
   when:
     - cuda_installed.stat.isdir is not defined
     - (ansible_distribution == "Ubuntu" and ansible_distribution_major_version == "16") or (ansible_distribution == "RedHat" and (ansible_distribution_major_version == "6" or ansible_distribution_major_version == "7")) or (ansible_distribution == "CentOS" and (ansible_distribution_major_version == "6" or ansible_distribution_major_version == "7") )
@@ -101,7 +101,7 @@
   tags: nvidia_cuda_toolkit
 
 - name: Enable NVidia CUDA toolkit Repo for SLES12 on x86_64
-  shell: |
+  command: |
     rpm -i /tmp/sles12_cuda9_repo.rpm
     sed 's/gpgcheck=1/gpgcheck=0/' -i /etc/zypp/repos.d/cuda.repo
   when:
@@ -109,7 +109,10 @@
     - ansible_architecture == "x86_64"
     - ansible_distribution == "SLES"
     - ansible_distribution_major_version == "12"
-  tags: nvidia_cuda_toolkit
+  tags:
+    - nvidia_cuda_toolkit
+    #TODO: rpm used in place of yum or rpm_key module
+    - skip_ansible_lint
 
 - name: Install NVidia CUDA toolkit for SLES12 on x86_64
   zypper: pkg=cuda state=latest update_cache=yes
@@ -118,4 +121,7 @@
     - ansible_architecture == "x86_64"
     - ansible_distribution == "SLES"
     - ansible_distribution_major_version == "12"
-  tags: nvidia_cuda_toolkit
+  tags:
+    - nvidia_cuda_toolkit
+    # TODO: Package installs should not use latest
+    - skip_ansible_lint

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Swap_File/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Swap_File/tasks/main.yml
@@ -13,13 +13,19 @@
   command: ls /swapfile
   ignore_errors: yes
   register: swap_root
-  tags: swap_file
+  tags:
+    - swap_file
+    # TODO: use stat to check file existence
+    - skip_ansible_lint
 
 - name: Test swapfile path - /tmp/swapfile
   command: ls /tmp/swapfile
   ignore_errors: yes
   register: swap_tmp
-  tags: swap_file
+  tags:
+    - swap_file
+    # TODO: use stat to check file existence
+    - skip_ansible_lint
 
 - name: Set Swapfile path - /swapfile
   set_fact:

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/adoptopenjdk9/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/adoptopenjdk9/tasks/main.yml
@@ -6,7 +6,9 @@
   shell: ls -ld /usr/lib/jvm/jdk-9+* >/dev/null 2>&1
   ignore_errors: yes
   register: adoptopenjdk9_installed
-  tags: adoptopenjdk9
+  tags:
+    - adoptopenjdk9
+    - skip_ansible_lint
 
 - name: Install latest release if one not already installed
   unarchive:

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/cmake/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/cmake/tasks/main.yml
@@ -13,7 +13,9 @@
   shell: cmake >/dev/null 2>&1
   ignore_errors: yes
   register: cmake_installed
-  tags: cmake
+  tags:
+    - cmake
+    - skip_ansible_lint
 
 - name: Test if cmake is installed at the correct version
   shell: cmake --version 2>/dev/null | grep version | awk '{print $3}'
@@ -55,4 +57,7 @@
   apt: pkg=cmake state=latest update_cache=yes
   when:
     - ansible_architecture == "armv7l"
-  tags: cmake
+  tags:
+    - cmake
+    # TODO: Package installs should not use latest
+    - skip_ansible_lint

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/gcc_48/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/gcc_48/tasks/main.yml
@@ -6,7 +6,10 @@
   shell: /usr/bin/gcc-4.8 >/dev/null 2>&1
   ignore_errors: yes
   register: gcc_installed
-  tags: gcc-4.8
+  tags:
+    - gcc-4.8
+    # TODO: write a condition when NOT to run this step
+    - skip_ansible_lint
 
 # gcc
 - name: Download gcc-4.8.5 source

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/x11/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/x11/tasks/main.yml
@@ -19,4 +19,7 @@
   shell: startx -- :1 &
   ignore_errors: yes
   no_log: True
-  tags: x11
+  tags:
+    - x11
+    # TODO: write a condition when NOT to run this step
+    - skip_ansible_lint

--- a/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/roles/cygwin/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/roles/cygwin/tasks/main.yml
@@ -83,4 +83,7 @@
 
 - name: Add c:\cygwin64\bin to the start of the %PATH%
   raw: setx PATH "C:\cygwin64\bin;$env:Path"
-  tags: cygwin
+  tags:
+    - cygwin
+    # TODO: write a condition when NOT to run this step
+    - skip_ansible_lint

--- a/ansible/playbooks/aix.yml
+++ b/ansible/playbooks/aix.yml
@@ -29,7 +29,8 @@
           command: /tmp/AIX_filesystem_config.sh
           tags: filesystem
 
-        - file:
+        - name: Remove AIX filesystem configuration script
+          file:
             state: absent
             path: /tmp/AIX_filesystem_config.sh
           tags: filesystem
@@ -50,7 +51,7 @@
           tags: openssl
 
         - name: Install IBM Openssl - installp
-          shell: installp -aXYgd /tmp/openssl-1.0.2.1300 openssl.base
+          command: installp -aXYgd /tmp/openssl-1.0.2.1300 openssl.base
           register: result.openssl
           ignore_errors: yes
           tags: openssl
@@ -77,8 +78,10 @@
           shell: rpm -e --nodeps $(rpm -qa | grep -E "cloud-init|perl|openssl") 2>/dev/null
           ignore_errors: True
           when: yum.stat.islnk is not defined
-          tags: rpm_remove
-
+          tags:
+            - rpm_remove
+            # TODO: rpm used in place of yum or rpm_key module
+            - skip_ansible_lint
       ####################################
       # Install yum and update to latest #
       ####################################
@@ -93,18 +96,24 @@
           tags: yum
 
         - name: Install yum and dependencies
-          shell: /tmp/yum.sh
+          command: /tmp/yum.sh
           register: result.yum
           ignore_errors: yes
           when: yum.stat.islnk is not defined
-          tags: yum
+          tags:
+            - yum
+            #TODO: Package installs should not use latest
+            - skip_ansible_lint
 
         - name: Yum update
           yum:
             update_cache: yes
             name: '*'
             state: latest
-          tags: yum
+          tags:
+            - yum
+            #TODO: Package installs should not use latest
+            - skip_ansible_lint
 
         - name: Install yum package support
           yum: name={{ item }} state=present update_cache=yes
@@ -149,7 +158,8 @@
       ##############
       # IBM Java 8 #
       ##############
-        - stat:
+        - name: Get java8 path information
+          stat:
             path: /usr/java8_64
           register: java8
           tags: java8
@@ -168,7 +178,7 @@
           tags: java8
 
         - name: Move extracted Java8 to /usr/java8_64
-          shell: mv /tmp/jdk8u144-b01/ /usr/java8_64
+          command: mv /tmp/jdk8u144-b01/ /usr/java8_64
           when: java8.stat.isdir is not defined
           tags: java8
 
@@ -192,7 +202,8 @@
             msg: "{{ java8_version.stderr }}"
           tags: java8
 
-        - replace:
+        - name: Modify Java version in /etc/environment
+          replace:
             path: /etc/environment
             regexp: 'java5'
             replace: 'java8_64'
@@ -201,7 +212,8 @@
       ##############
       # IBM Java 7 #
       ##############
-        - stat:
+        - name: Check for Java7 availability
+          stat:
             path: /usr/java7
           register: java7
           tags: java7
@@ -220,7 +232,7 @@
           tags: java7
 
         - name: Move extracted Java7 to /usr/java7
-          shell: mv /tmp/j2sdk-image /usr/java7
+          command: mv /tmp/j2sdk-image /usr/java7
           when: java7.stat.isdir is not defined
           tags: java7
 
@@ -246,19 +258,21 @@
           tags: x11
 
         - name: Install IBM X11 Extensions - installp
-          shell: installp -aXYgd /tmp/X11.adt X11.adt.ext
+          command: installp -aXYgd /tmp/X11.adt X11.adt.ext
           register: result.x11
           ignore_errors: yes
           tags: x11
 
-        - file:
+        - name: Remove X11 installp
+          file:
             state: absent
             path: /tmp/X11.adt
 
       ############
       # IBM XL C #
       ############
-        - stat:
+        - name: Checking for XLC availability
+          stat:
             path: /usr/bin/xlc
           register: xlc
           tags: xlc
@@ -277,7 +291,7 @@
           tags: xlc
 
         - name: Install IBM XL C - installp
-          shell: installp -aXYgd /tmp/usr/sys/inst.images all
+          command: installp -aXYgd /tmp/usr/sys/inst.images all
           register: result.xlc
           ignore_errors: yes
           when: xlc.stat.islnk is not defined
@@ -330,7 +344,8 @@
       ###############
       #     ant     #
       ###############
-        - stat:
+        - name: Checking for Ant availability
+          stat:
             path: /usr/bin/ant
           register: ant
           tags: ant
@@ -356,7 +371,8 @@
       ###############
       # ant-contrib #
       ###############
-        - stat:
+        - name: Checking for ant-contrib availability
+          stat:
             path: /opt/apache-ant-1.9.9/lib/ant-contrib.jar
           register: antcontrib
           tags: ant-contrib
@@ -396,12 +412,14 @@
           tags: cpan
 
         - name: Install Text::CSV
-          shell: |
-            CC=xlc_r cpan -i Text::CSV
+          command: CC=xlc_r cpan -i Text::CSV
           environment:
             PERL_MB_OPT: "--install_base \"/home/{{ Jenkins_Username }}\""
             PERL_MM_OPT: "INSTALL_BASE=/home/{{ Jenkins_Username }}"
-          tags: cpan
+          tags:
+            - cpan
+            # Environment variables don't work as part of command
+            - skip_ansible_lint
 
       #########################
       # Configure system logs #
@@ -441,19 +459,22 @@
       ######################################
       # Add bash to available login shells #
       ######################################
-        - replace:
+        - name: Add bash to available login shells
+          replace:
             path: /etc/security/login.cfg
             regexp: 'shells = '
             replace: 'shells = /bin/bash,'
           tags: login_shell
 
-        - blockinfile:
+        - name: Add bash to available login shells
+          blockinfile:
             dest: /etc/shells
             block: |
               /bin/bash
           tags: login_shell
 
-        - blockinfile:
+        - name: Add bash to available login shells
+          blockinfile:
             dest: /etc/environment
             block: |
               AIXTHREAD_HRT=true
@@ -461,7 +482,8 @@
               PERL5LIB=/home/{{ Jenkins_Username }}/lib/perl5
           tags: login_shell
 
-        - replace:
+        - name: Add bash to available login shells
+          replace:
             path: /etc/environment
             regexp: 'PATH=/usr/bin'
             replace: 'PATH=/opt/freeware/bin:/opt/IBM/xlC/13.1.3/bin:/usr/bin'
@@ -470,7 +492,8 @@
       ################
       # Jenkins user #
       ################
-        - stat:
+        - name: Check for user directory existence
+          stat:
             path: /home/{{ Jenkins_Username }}
           register: jenkins
           tags: jenkins_user
@@ -481,7 +504,7 @@
           tags: jenkins_user
 
         - name: Create jenkins user
-          shell: mkuser home="/home/{{ Jenkins_Username }}" shell="/bin/bash" {{ Jenkins_Username }}
+          command: mkuser home="/home/{{ Jenkins_Username }}" shell="/bin/bash" {{ Jenkins_Username }}
           ignore_errors: yes
           when: jenkins.stat.isdir is not defined
           tags: jenkins_user
@@ -505,17 +528,18 @@
           tags: jenkins_user
 
         # Use the system defaults as defined in /etc/environment
-        - file:
+        - name: Remove .profile
+          file:
             state: absent
             path: /home/{{ Jenkins_Username }}/.profile
 
         - name: Set user capabilites
-          shell: chuser capabilities=CAP_NUMA_ATTACH,CAP_BYPASS_RAC_VMM,CAP_PROPAGATE {{ Jenkins_Username }}
+          command: chuser capabilities=CAP_NUMA_ATTACH,CAP_BYPASS_RAC_VMM,CAP_PROPAGATE {{ Jenkins_Username }}
           tags: jenkins_user
 
 
         - name: Set group capabilites
-          shell: chgroup adms=root staff
+          command: chgroup adms=root staff
           tags: jenkins_user
 
         - name: ensure adequate limits are set in /etc/security/limits
@@ -536,7 +560,8 @@
       ##############
       # freemarker #
       ##############
-        - stat:
+        - name: Check for freemarker.jar existence
+          stat:
             path: /home/{{ Jenkins_Username }}/freemarker.jar
           register: freemarker
           tags: freemarker
@@ -582,7 +607,7 @@
       # superuser account #
       #####################
         - name: Setup zeus user
-          shell: mkuser home="/home/zeus" shell="/usr/bin/ksh" zeus
+          command: mkuser home="/home/zeus" shell="/usr/bin/ksh" zeus
           ignore_errors: yes
           when: Superuser_Account == "Enabled"
           tags: superuser
@@ -687,7 +712,10 @@
           changed_when: "'Extending' in extendlv_result.stdout"
           notify:
             - restart machine
-          tags: swap
+          tags:
+            - swap
+            # Environment variables don't work as part of command
+            - skip_ansible_lint
 
   handlers:
     - name: restart machine

--- a/ansible/playbooks/nagios/nagios_aix.yml
+++ b/ansible/playbooks/nagios/nagios_aix.yml
@@ -15,7 +15,9 @@
 ##########
 - name: Creates Nagios folder
   file: path=/usr/local/nagios/ state=directory mode=0755
-- file: path=/usr/local/nagios/libexec/ state=directory mode=0755
+
+- name: Creates Nagios libexec folder
+  file: path=/usr/local/nagios/libexec/ state=directory mode=0755
 
 ##################
 # Install Nagios #
@@ -32,8 +34,11 @@
 # Nagios user #
 ###############
 - name: Setup Nagios user
-  shell: mkuser home="/home/nagios" shell="/usr/bin/ksh" nagios
+  command: mkuser home="/home/nagios" shell="/usr/bin/ksh" nagios
   ignore_errors: yes
+  tags:
+    # TODO: write a condition when NOT to run this step
+    - skip_ansible_lint
 
 - name: Create SSH Key folder for Nagios
   file:

--- a/ansible/playbooks/ubuntu-jck.yml
+++ b/ansible/playbooks/ubuntu-jck.yml
@@ -31,6 +31,9 @@
             - vnc4server
             - xvfb
             - xterm
+          tags:
+            # TODO: Package installs should not use latest
+            - skip_ansible_lint
         - name: Create Jenkins user
           action: user name="{{ Jenkins_Username }}" state=present
           ignore_errors: yes

--- a/ansible/yamllint.yml
+++ b/ansible/yamllint.yml
@@ -4,3 +4,5 @@ rules:
   line-length:
     max: 120
     level: warning
+  #mixed style truthy values are OK for Ansible code
+  truthy: disable

--- a/ansible/yamllint.yml
+++ b/ansible/yamllint.yml
@@ -2,5 +2,5 @@
 extends: default
 rules:
   line-length:
-    max: 80
+    max: 120
     level: warning

--- a/yamllint.yml
+++ b/yamllint.yml
@@ -1,6 +1,0 @@
----
-extends: default
-rules:
-  line-length:
-    max: 80
-    level: warning


### PR DESCRIPTION
This one adds Ansible-lint to the build pipeline.

Both YAMLLint and Ansible-lint are prerequisites for the `Molecule` automated testing system.

* Added ansible-linting to Travis build
* Fixed simple and unambigious issues, such as using `shell` instead of `command` and missing task names.
* For all the other cases added `skip_ansible_lint` tag and added TODO comments.
* Removed the duplicated yamllint.yml file and increased the line length threshold from 80 to 120.

Most unresolved Anslible-lint issues relate to the places in code that are just 'ansibilized' shell scripts, without guaranteed idempotency and usage of respecting Ansible modules.

Deeper refactoring is possible, but, as any refactoring, it requires the automated tests. 

The further steps could be adding `molecule` testing to some of the roles.

