### PR TITLE
Add coreutils to yum install package list

### DIFF
--- a/ansible/playbooks/aix.yml
+++ b/ansible/playbooks/aix.yml
@@ -111,6 +111,7 @@
           with_items:
             - autoconf
             - bison
+            - coreutils
             - cups-devel
             - cups-libs
             - flex
@@ -135,7 +136,6 @@
         - name: Install yum package support
           yum: name={{ item }} state=present update_cache=yes
           with_items:
-            - http://www.oss4aix.org/download/RPMS/mktemp/mktemp-1.7-1.aix5.1.ppc.rpm
             - http://www.bullfreeware.com/download/bin/2328/libiconv-1.14-22.aix6.1.ppc.rpm
             - http://www.bullfreeware.com/download/bin/2591/libunistring-0.9.6-2.aix6.1.ppc.rpm
             - http://www.bullfreeware.com/download/bin/3944/perl-5.24.0-3.aix6.1.ppc.rpm


### PR DESCRIPTION
* readlink is a new requirement for jdk11
* readlink is supplied by coreutils as is mktemp
* remove rpm installation of mktemp as it conflicts with coreutils
* Fixes #410

Signed-off-by: Joe deKoning <joe_dekoning@ca.ibm.com>