### PR TITLE
Add user directory for perl module to search path

### DIFF
--- a/ansible/playbooks/aix.yml
+++ b/ansible/playbooks/aix.yml
@@ -398,6 +398,9 @@
         - name: Install Text::CSV
           shell: |
             CC=xlc_r cpan -i Text::CSV
+          environment:
+            PERL_MB_OPT: "--install_base \"/home/{{ Jenkins_Username }}\""
+            PERL_MM_OPT: "INSTALL_BASE=/home/{{ Jenkins_Username }}"
           tags: cpan
 
       #########################
@@ -455,6 +458,7 @@
             block: |
               AIXTHREAD_HRT=true
               PKG_CONFIG_PATH=/opt/freeware/lib64/pkgconfig:/opt/freeware/lib/pkgconfig
+              PERL5LIB=/home/{{ Jenkins_Username }}/lib/perl5
           tags: login_shell
 
         - replace:
@@ -472,7 +476,7 @@
           tags: jenkins_user
 
         - debug:
-            msg: "i{{ Jenkins_Username }} home directory found, skipping user creation tasks"
+            msg: "{{ Jenkins_Username }} home directory found, skipping user creation tasks"
           when: jenkins.stat.isdir is defined
           tags: jenkins_user
 


### PR DESCRIPTION
Signed-off-by: Joe deKoning <joe_dekoning@ca.ibm.com>

Installing the CSV package as root should install to the default folders of 
    /opt/freeware/lib/perl5/site_perl/5.24.0/ppc-aix-thread-multi
    /opt/freeware/lib/perl5/site_perl/5.24.0
    /opt/freeware/lib/perl5/5.24.0/ppc-aix-thread-multi
    /opt/freeware/lib/perl5/5.24.0

But I have seen setups where a logged on user isn't getting those directories in their search path.

`Can't locate Text/CSV.pm in @INC (you may need to install the Text::CSV module)...` 
Setting the installation location and then the export of PERL5LIB resolves this issue.