### PR TITLE
Replace sles12-s390x-1 build box with rhel74-s390x-2

### DIFF
--- a/ansible/inventory.yml
+++ b/ansible/inventory.yml
@@ -36,8 +36,8 @@ hosts:
           macos1010-x64-2: {ip: 208.83.1.242, user: Administrator}
 
       - marist:
-          sles12-s390x-1: {ip: 148.100.110.56}
           rhel74-s390x-1: {ip: 148.100.110.129}
+          rhel74-s390x-2: {ip: 148.100.110.131}
           ubuntu1604-s390x-2: {ip: 148.100.33.178}
           ubuntu1604-s390x-3: {ip: 148.100.33.179}
           zos21-s390x-1: {ip: 148.100.36.136, user: OPEN1}


### PR DESCRIPTION
Machine has been reinstalled as per https://github.com/AdoptOpenJDK/openjdk-infrastructure/issues/396