### PR TITLE
don't install glibc-devel.i686 on non-x86 architectures

### DIFF
--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/tasks/RedHat.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/tasks/RedHat.yml
@@ -51,6 +51,13 @@
     - (ansible_distribution_major_version != "7" and ansible_architecture != "s390x")
   tags: build_tools
 
+- name: Install additional build tools for RHEL on x86_64
+  package: "name={{ item }} state=latest"
+  with_items: "{{ Additional_Build_Tools_RHEL_x86_64 }}"
+  when:
+    - ansible_architecture == "x86_64"
+  tags: build_tools
+
 #################
 # xorg Packages #
 #################

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/vars/RedHat.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/vars/RedHat.yml
@@ -19,7 +19,6 @@ Build_Tool_Packages:
   - glibc
   - glibc-common
   - glibc-devel
-  - glibc-devel.i686
   - gmp-devel
   - libdwarf-devel
   - libffi-devel
@@ -50,6 +49,9 @@ Additional_Build_Tools_RHEL7:
 Additional_Build_Tools_RHEL7_PPC64LE:
   - libcurl-devel
   - ant-contrib
+
+Additional_Build_Tools_RHEL_x86_64:
+  - glibc-devel.i686
 
 Java_NOT_RHEL6_PPC64:
   - java-1.7.0-openjdk-devel


### PR DESCRIPTION
The glibc-devel.i686 package shouldn't be installed in the common Build_Tool_Packages section because it doesn't apply to non-x86 architectures, so have moved it into a new Additional_Build_Tools_RHEL_x86_64 section for x86_64 only.

Fixes [issue #446](https://github.com/AdoptOpenJDK/openjdk-infrastructure/issues/446)