### PR TITLE
ansible: autoconf role is failing when not on RHEL6

### DIFF
--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/autoconf/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/autoconf/tasks/main.yml
@@ -19,10 +19,10 @@
     force: no
     mode: 0755
   when:
-    - ((autoconf_version.rc == 0) and (autoconf_version.stdout | version_compare('2.69', operator='lt')))
     - (ansible_distribution == "RedHat" or ansible_distribution == "CentOS")
     - ansible_distribution_major_version == "6"
     - ansible_architecture == "x86_64"
+    - ((autoconf_version.rc == 0) and (autoconf_version.stdout | version_compare('2.69', operator='lt')))
   tags: autoconf-2.69
 
 - name: Extract Autoconf v2.69
@@ -31,19 +31,19 @@
     dest: /tmp
     copy: False
   when:
-    - ((autoconf_version.rc == 0) and (autoconf_version.stdout | version_compare('2.69', operator='lt')))
     - (ansible_distribution == "RedHat" or ansible_distribution == "CentOS")
     - ansible_distribution_major_version == "6"
     - ansible_architecture == "x86_64"
+    - ((autoconf_version.rc == 0) and (autoconf_version.stdout | version_compare('2.69', operator='lt')))
   tags: autoconf-2.69
 
 - name: Build and install Autoconf v2.69
   shell: cd /tmp/autoconf-2.69 && ./configure && make && make install
   when:
-    - ((autoconf_version.rc == 0) and (autoconf_version.stdout | version_compare('2.69', operator='lt')))
     - (ansible_distribution == "RedHat" or ansible_distribution == "CentOS")
     - ansible_distribution_major_version == "6"
     - ansible_architecture == "x86_64"
+    - ((autoconf_version.rc == 0) and (autoconf_version.stdout | version_compare('2.69', operator='lt')))
   tags: autoconf-2.69
 
 - name: Remove the older Autoconf package
@@ -51,10 +51,10 @@
     name: autoconf
     state: absent
   when:
-    - ((autoconf_version.rc == 0) and (autoconf_version.stdout | version_compare('2.69', operator='lt')))
     - (ansible_distribution == "RedHat" or ansible_distribution == "CentOS")
     - ansible_distribution_major_version == "6"
     - ansible_architecture == "x86_64"
+    - ((autoconf_version.rc == 0) and (autoconf_version.stdout | version_compare('2.69', operator='lt')))
   tags: autoconf-2.69
 
 - name: Remove downloaded packages for Autoconf v2.69
@@ -66,8 +66,8 @@
     - /tmp/autoconf-2.69
   ignore_errors: yes
   when:
-    - ((autoconf_version.rc == 0) and (autoconf_version.stdout | version_compare('2.69', operator='lt')))
     - (ansible_distribution == "RedHat" or ansible_distribution == "CentOS")
     - ansible_distribution_major_version == "6"
     - ansible_architecture == "x86_64"
+    - ((autoconf_version.rc == 0) and (autoconf_version.stdout | version_compare('2.69', operator='lt')))
   tags: autoconf-2.69


### PR DESCRIPTION
rc check is done even when the version check operation was skipped on the platform. This re-orders the check until after the distribution check is done. This is blocking x/z Linux playbook executions which are on RHEL7 machines
```
TASK [autoconf : Test if Autoconf v2.69 is installed] **************************
14:19:22
skipping: [build-osuosl-centos74-ppc64le-2]
TASK [autoconf : Download Autoconf v2.69] **************************************
14:19:22
fatal: [build-osuosl-centos74-ppc64le-2]: FAILED! => {"failed": true, "msg": "The conditional check '((autoconf_version.rc == 0) and (autoconf_version.stdout | version_compare('2.69', operator='lt')))' failed. The error was: error while evaluating conditional (((autoconf_version.rc == 0) and (autoconf_version.stdout | version_compare('2.69', operator='lt')))): 'dict object' has no attribute 'rc'\n\nThe error appears to have been in '/var/lib/awx/projects/_6__adoptopenjdk_git_infrastructure/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/autoconf/tasks/main.yml': line 15, column 3, but may\nbe elsewhere in the file depending on the exact syntax problem.\n\nThe offending line appears to be:\n\n\n- name: Download Autoconf v2.69\n  ^ here\n"}
```

Fixes https://github.com/AdoptOpenJDK/openjdk-infrastructure/issues/371