### PR TITLE
inventory: Remove unused build-packet-freebsd11-x64-1

### DIFF
--- a/ansible/inventory.yml
+++ b/ansible/inventory.yml
@@ -53,7 +53,6 @@ hosts:
       - packet:
           centos74-armv8-1: {ip: 147.75.196.30}
           ubuntu1604-armv8-2: {ip: 147.75.77.146}
-          freebsd11-x64-1: {ip: 147.75.101.29}
 
       - joyent:
           centos69-x64-1: {ip: 165.225.149.157}


### PR DESCRIPTION
We should likely consider whether to keep the machine around (assuming it's even assigned to us) but at the moment ansible is not able to communicate with it and we are not currently building anything on FreeBSD. We can regenerate the machines if required int he future.