### PR TITLE
Revert "Fix conditional for autoconf version check (#443)"

### DIFF
--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/autoconf/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/autoconf/tasks/main.yml
@@ -22,7 +22,7 @@
     - (ansible_distribution == "RedHat" or ansible_distribution == "CentOS")
     - ansible_distribution_major_version == "6"
     - ansible_architecture == "x86_64"
-    - ((autoconf_version.stdout == '') or ((autoconf_version.stdout != '') and (autoconf_version.stdout is version('2.69', operator='lt', strict=True))))
+    - ((autoconf_version.rc == 0) and (autoconf_version.stdout | version_compare('2.69', operator='lt')))
   tags: autoconf-2.69
 
 - name: Extract Autoconf v2.69
@@ -34,7 +34,7 @@
     - (ansible_distribution == "RedHat" or ansible_distribution == "CentOS")
     - ansible_distribution_major_version == "6"
     - ansible_architecture == "x86_64"
-    - ((autoconf_version.stdout == '') or ((autoconf_version.stdout != '') and (autoconf_version.stdout is version('2.69', operator='lt', strict=True))))
+    - ((autoconf_version.rc == 0) and (autoconf_version.stdout | version_compare('2.69', operator='lt')))
   tags: autoconf-2.69
 
 - name: Build and install Autoconf v2.69
@@ -43,7 +43,7 @@
     - (ansible_distribution == "RedHat" or ansible_distribution == "CentOS")
     - ansible_distribution_major_version == "6"
     - ansible_architecture == "x86_64"
-    - ((autoconf_version.stdout == '') or ((autoconf_version.stdout != '') and (autoconf_version.stdout is version('2.69', operator='lt', strict=True))))
+    - ((autoconf_version.rc == 0) and (autoconf_version.stdout | version_compare('2.69', operator='lt')))
   tags: autoconf-2.69
 
 - name: Remove the older Autoconf package
@@ -54,7 +54,7 @@
     - (ansible_distribution == "RedHat" or ansible_distribution == "CentOS")
     - ansible_distribution_major_version == "6"
     - ansible_architecture == "x86_64"
-    - ((autoconf_version.stdout != '') and (autoconf_version.stdout is version('2.69', operator='lt', strict=True)))
+    - ((autoconf_version.rc == 0) and (autoconf_version.stdout | version_compare('2.69', operator='lt')))
   tags: autoconf-2.69
 
 - name: Remove downloaded packages for Autoconf v2.69
@@ -69,5 +69,5 @@
     - (ansible_distribution == "RedHat" or ansible_distribution == "CentOS")
     - ansible_distribution_major_version == "6"
     - ansible_architecture == "x86_64"
-    - ((autoconf_version.stdout == '') or ((autoconf_version.stdout != '') and (autoconf_version.stdout is version('2.69', operator='lt', strict=True))))
+    - ((autoconf_version.rc == 0) and (autoconf_version.stdout | version_compare('2.69', operator='lt')))
   tags: autoconf-2.69


### PR DESCRIPTION
This reverts commit 97323e925ee35c00220474e1574183e2db780db5.
Pushing this through as it is not working on our AWX server (although it does work with my local ansible 2.6.3)

```
TASK [autoconf : Download Autoconf v2.69] **************************************
14:24:43
fatal: [build-joyent-centos69-x64-1]: FAILED! => {"failed": true, "msg": "The conditional check '((autoconf_version.stdout == '') or ((autoconf_version.stdout != '') and (autoconf_version.stdout is version('2.69', operator='lt', strict=True))))' failed. The error was: template error while templating string: no test named 'version'. String: {% if ((autoconf_version.stdout == '') or ((autoconf_version.stdout != '') and (autoconf_version.stdout is version('2.69', operator='lt', strict=True)))) %} True {% else %} False {% endif %}\n\nThe error appears to have been in '/var/lib/awx/projects/_6__adoptopenjdk_git_infrastructure/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/autoconf/tasks/main.yml': line 15, column 3, but may\nbe elsewhere in the file depending on the exact syntax problem.\n\nThe offending line appears to be:\n\n\n- name: Download Autoconf v2.69\n  ^ here\n"}
```