### PR TITLE
ansible: Add libstdc++-static on CentOS (already on RedHat)

### DIFF
--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/vars/CentOS.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/vars/CentOS.yml
@@ -27,6 +27,7 @@ Build_Tool_Packages:
   - java-1.7.0-openjdk-devel
   - java-1.8.0-openjdk-devel
   - libdwarf-devel
+  - libstdc++-static
   - libXext-devel
   - libXrender-devel
   - libXt-devel


### PR DESCRIPTION
Unblocks https://github.com/AdoptOpenJDK/openjdk-infrastructure/issues/408 and is a prereq for https://github.com/AdoptOpenJDK/openjdk-infrastructure/issues/256