### PR TITLE
Install git to /usr/local to avoid package manager collision

### DIFF
--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/GIT_Source/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/GIT_Source/tasks/main.yml
@@ -46,7 +46,7 @@
     - (ansible_distribution == "RedHat" and ansible_distribution_major_version == "6")
 
 - name: Compile and install git from source
-  shell: cd /tmp/git-2.15.0 && ./configure --prefix=/usr --without-tcltk && make clean && make -j {{ ansible_processor_vcpus }} && sudo make install
+  shell: cd /tmp/git-2.15.0 && ./configure --prefix=/usr/local --without-tcltk && make clean && make -j {{ ansible_processor_vcpus }} && sudo make install
   become: yes
   when:
     - (git_installed.rc != 0 ) or (git_installed.rc == 0 and git_version.stdout | version_compare('2.15', operator='lt') )
@@ -55,7 +55,7 @@
   tags: git_source
 
 - name: Compile and install git from source on s390x
-  shell: cd /tmp/git-2.15.0 && ./configure --prefix=/usr --without-tcltk && make -j {{ ansible_processor_cores }} && sudo make install
+  shell: cd /tmp/git-2.15.0 && ./configure --prefix=/usr/local --without-tcltk && make -j {{ ansible_processor_cores }} && sudo make install
   become: yes
   when:
     - (git_installed.rc != 0 ) or (git_installed.rc == 0 and git_version.stdout | version_compare('2.15', operator='lt') )


### PR DESCRIPTION
- Installing to /usr/bin/git seems to be
  causing issues when yum updates and
  overwrites this version back to default.
- Install to /usr/local/bin/git instead.
- This is on the PATH before /usr/bin
- Tested on rhel7 ppc64le.

Signed-off-by: Adam Brousseau <adam.brousseau88@gmail.com>