### PR TITLE
Downgrade grep to 2.27

### DIFF
--- a/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/roles/Firefox/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/roles/Firefox/tasks/main.yml
@@ -5,7 +5,7 @@
 
 - name: Test if Firefox is already installed
   win_stat:
-    path: 'C:\Program Files (x86)\Mozilla Firefox\firefox.exe'
+    path: 'C:\Program Files\Mozilla Firefox\firefox.exe'
   register: firefox_installed
   tags: Firefox
 

--- a/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/roles/cygwin/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/roles/cygwin/tasks/main.yml
@@ -55,6 +55,17 @@
     - xterm
   tags: cygwin
 
+- name: Download grep-2.27-2
+  win_get_url:
+    url: "{{ Cygwin_SITE_URL + '/x86_64/release/grep/grep-2.27-2.tar.xz' }}"
+    dest: "{{ Cygwin_ROOT_INST_DIR + '\\tmp\\grep.tar.xz' }}"
+    force: no
+  tags: cygwin
+
+- name: Extract grep-2.27-2
+  win_command: "{{ Cygwin_ROOT_INST_DIR + '\\bin\\bash.exe -l -c \"tar -C / -xvf /tmp/grep.tar.xz\"' }}"
+  tags: cygwin
+
 - name: Remove c:\cygwin64\bin from the path if it exists
   win_path:
     elements:

--- a/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/roles/cygwin/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/roles/cygwin/tasks/main.yml
@@ -55,6 +55,14 @@
     - xterm
   tags: cygwin
 
+###############################################################################
+# Cygwin by default installs latest versions of packages, which is 3.0-2 for
+# grep. This version of grep is unable to match EOL (with $) when the file use
+# windows style CRLF sequence at end of lines and it is required for openjdk8
+# builds to complete. The following two steps downloads the latest known
+# version of grep to satisfy this requirement and overwrites the installed
+# grep version.
+###############################################################################
 - name: Download grep-2.27-2
   win_get_url:
     url: "{{ Cygwin_SITE_URL + '/x86_64/release/grep/grep-2.27-2.tar.xz' }}"


### PR DESCRIPTION
This add a couple of steps to Cygwin role to download grep 2.27 and install it (overwrite since cygwin doesn't allow us to downgrade a package unattended).

Fixes #384.