### PR TITLE
Update Ansible script to install Clang on Windows

### DIFF
--- a/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/main.yml
@@ -47,3 +47,5 @@
     - NTP_TIME
     - 7-Zip
     - MinGW-W64
+    - Clang_64bit
+    - Clang_32bit

--- a/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/roles/Clang_32bit/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/roles/Clang_32bit/tasks/main.yml
@@ -19,7 +19,7 @@
   tags: clang_32bit
 
 - name: Install Clang 32bit
-  win_command: 'c:\temp\LLVM-7.0.0-win32.exe'
+  win_command: 'c:\temp\LLVM-7.0.0-win32.exe /S'
   when: clang_32bit_installed.stat.exists == false
   tags: clang_32bit
 

--- a/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/roles/Clang_32bit/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/roles/Clang_32bit/tasks/main.yml
@@ -3,6 +3,8 @@
 # LLVM/Clang 32bit #
 ####################
 # Clang 32bit is an OpenJ9 prerequisite.
+# Silent installer for 32-bit will remove the 64-bit version so
+# we install from a zip file
 
 - name: Test if Clang 32bit is already installed (required by OpenJ9)
   win_stat:
@@ -12,20 +14,34 @@
 
 - name: Download Clang 32bit
   win_get_url:
-    url: https://releases.llvm.org/7.0.0/LLVM-7.0.0-win32.exe
+    url: https://ci.adoptopenjdk.net/userContent/llvm700/llvm-7.0.0-win32.zip
     dest: 'C:\temp\'
     force: no
   when: clang_32bit_installed.stat.exists == false
   tags: clang_32bit
 
-- name: Install Clang 32bit
-  win_command: 'c:\temp\LLVM-7.0.0-win32.exe /S'
+- name: Install (unzip) Clang 32bit
+  win_unzip:
+  src: C:\temp\llvm-7.0.0-win32.zip
+  dest: C:\
+  creates: 'C:\Program Files (x86)\LLVM\bin\clang.exe'
   when: clang_32bit_installed.stat.exists == false
   tags: clang_32bit
 
-- name: Cleanup Clang 32bit installer
+- name: Test if LLVM32 symlink is already created
+  win_stat:
+    path: 'C:\openjdk\LLVM32'
+  register: llvm32_symlink
+  tags: clang_32bit
+
+- name: Create symlink to C:\openjdk\LLVM32
+  raw: cmd /c mklink /D "C:\openjdk\LLVM32\" "C:\Program Files (x86)\LLVM"
+  when: (llvm32_symlink.stat.exists == false)
+  tags: clang_32bit
+
+- name: Cleanup Clang 32bit zip
   win_file:
-    path: 'c:\temp\LLVM-7.0.0-win32.exe'
+    path: 'c:\temp\LLVM-7.0.0-win32.zip'
     state: absent
   ignore_errors: yes
   tags: clang_32bit

--- a/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/roles/Clang_32bit/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/roles/Clang_32bit/tasks/main.yml
@@ -1,0 +1,31 @@
+---
+####################
+# LLVM/Clang 32bit #
+####################
+# Clang 32bit is an OpenJ9 prerequisite.
+
+- name: Test if Clang 32bit is already installed (required by OpenJ9)
+  win_stat:
+    path: 'C:\Program Files (x86)\LLVM\bin\clang.exe'
+  register: clang_32bit_installed
+  tags: clang_32bit
+
+- name: Download Clang 32bit
+  win_get_url:
+    url: https://releases.llvm.org/7.0.0/LLVM-7.0.0-win32.exe
+    dest: 'C:\temp\'
+    force: no
+  when: clang_32bit_installed.stat.exists == false
+  tags: clang_32bit
+
+- name: Install Clang 32bit
+  win_command: 'c:\temp\LLVM-7.0.0-win32.exe'
+  when: clang_32bit_installed.stat.exists == false
+  tags: clang_32bit
+
+- name: Cleanup Clang 32bit installer
+  win_file:
+    path: 'c:\temp\LLVM-7.0.0-win32.exe'
+    state: absent
+  ignore_errors: yes
+  tags: clang_32bit

--- a/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/roles/Clang_64bit/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/roles/Clang_64bit/tasks/main.yml
@@ -19,7 +19,7 @@
   tags: clang_64bit
 
 - name: Install Clang 64bit
-  win_command: 'c:\temp\LLVM-7.0.0-win64.exe'
+  win_command: 'c:\temp\LLVM-7.0.0-win64.exe /S'
   when: clang_64bit_installed.stat.exists == false
   tags: clang_64bit
 

--- a/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/roles/Clang_64bit/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/roles/Clang_64bit/tasks/main.yml
@@ -22,13 +22,13 @@
   win_command: 'c:\temp\LLVM-7.0.0-win64.exe /S'
   when: clang_64bit_installed.stat.exists == false
   tags: clang_64bit
-  
+
 - name: Test if LLVM64 symlink is already created
    win_stat:
      path: 'C:\openjdk\LLVM64'
    register: llvm64_symlink
    tags: clang_64bit
- 
+
 - name: Create symlink to C:\openjdk\LLVM64
    raw: cmd /c mklink /D "C:\openjdk\LLVM64\" "C:\Program Files\LLVM"
    when: (llvm64_symlink.stat.exists == false)

--- a/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/roles/Clang_64bit/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/roles/Clang_64bit/tasks/main.yml
@@ -1,0 +1,31 @@
+---
+####################
+# LLVM/Clang 64bit #
+####################
+# Clang 64bit is an OpenJ9 prerequisite.
+
+- name: Test if Clang 64bit is already installed (required by OpenJ9)
+  win_stat:
+    path: 'C:\Program Files\LLVM\bin\clang.exe'
+  register: clang_64bit_installed
+  tags: clang_64bit
+
+- name: Download Clang 64bit
+  win_get_url:
+    url: https://releases.llvm.org/7.0.0/LLVM-7.0.0-win64.exe
+    dest: 'C:\temp\'
+    force: no
+  when: clang_64bit_installed.stat.exists == false
+  tags: clang_64bit
+
+- name: Install Clang 64bit
+  win_command: 'c:\temp\LLVM-7.0.0-win64.exe'
+  when: clang_64bit_installed.stat.exists == false
+  tags: clang_64bit
+
+- name: Cleanup Clang 64bit installer
+  win_file:
+    path: 'c:\temp\LLVM-7.0.0-win64.exe'
+    state: absent
+  ignore_errors: yes
+  tags: clang_64bit

--- a/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/roles/Clang_64bit/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/roles/Clang_64bit/tasks/main.yml
@@ -22,6 +22,17 @@
   win_command: 'c:\temp\LLVM-7.0.0-win64.exe /S'
   when: clang_64bit_installed.stat.exists == false
   tags: clang_64bit
+  
+- name: Test if LLVM64 symlink is already created
+   win_stat:
+     path: 'C:\openjdk\LLVM64'
+   register: llvm64_symlink
+   tags: clang_64bit
+ 
+- name: Create symlink to C:\openjdk\LLVM64
+   raw: cmd /c mklink /D "C:\openjdk\LLVM64\" "C:\Program Files\LLVM"
+   when: (llvm64_symlink.stat.exists == false)
+   tags: clang_64bit
 
 - name: Cleanup Clang 64bit installer
   win_file:


### PR DESCRIPTION
The changes are to install LLVM/Clang so as to 
compile JDK 8 & JDK 11 on Windows.

Signed-off-by: CHENGJin <jincheng@ca.ibm.com>