### PR TITLE
Remove bblondin from infrastructure team

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,6 @@
 
 #### [@infrastructure](https://github.com/orgs/AdoptOpenJDK/teams/infrastructure)
 - [@ali-ince](https://github.com/ali-ince) - Ali Ince (LJC)
-- [@bblondin](https://github.com/bblondin) - Brad Blondin (IBM)
 - [@geraintwjones](https://github.com/geraintwjones) - Geraint Jones (IBM)
 - [@gdams](https://github.com/gdams) - George Adams (IBM)
 - [@jdekonin](https://github.com/jdekonin) - Joe deKoning


### PR DESCRIPTION
Signed-off-by: Stewart Addison <sxa@uk.ibm.com>

Going to need to remove all his keys etc. but this is a partial fix for https://github.com/AdoptOpenJDK/openjdk-infrastructure/issues/524