### PR TITLE
Make java7/8 sdk identifier generic on Cent/Redhat

### DIFF
--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/tasks/CentOS.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/tasks/CentOS.yml
@@ -167,3 +167,30 @@
   when:
     - ansible_architecture == "x86_64"
   tags: expat
+
+########
+# Java #
+########
+- name: Check if java8 directory exists
+  shell: ls -d /usr/lib/jvm/java-1.8.0-openjdk.* >/dev/null 2>&1
+  ignore_errors: yes
+  register: java8
+  tags: java
+
+- name: Create /usr/lib/jvm/java-1.8.0-openjdk symlink
+  shell: ln -s /usr/lib/jvm/java-1.8.0-openjdk.* /usr/lib/jvm/java-1.8.0-openjdk
+  when:
+    - java8.rc == 0
+  tags: java
+
+- name: Check if java7 directory exists
+  shell: ls -d /usr/lib/jvm/java-1.7.0-openjdk.* >/dev/null 2>&1
+  ignore_errors: yes
+  register: java7
+  tags: java
+
+- name: Create /usr/lib/jvm/java-1.7.0-openjdk symlink
+  shell: ln -s /usr/lib/jvm/java-1.7.0-openjdk.* /usr/lib/jvm/java-1.7.0-openjdk
+  when:
+    - java7.rc == 0
+  tags: java

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/tasks/RedHat.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/tasks/RedHat.yml
@@ -84,11 +84,37 @@
   package: "name={{ item }} state=latest"
   with_items: "{{ Java_NOT_RHEL6_PPC64 }}"
   when: (ansible_distribution_major_version != "6" and ansible_architecture != "ppc64")
+  tags: java
 
 - name: Install Java when RedHat 6 on ppc64
   package: "name={{ item }} state=latest"
   with_items: "{{ Java_RHEL6_PPC64 }}"
   when: (ansible_distribution_major_version == "6" and ansible_architecture == "ppc64")
+  tags: java
+
+- name: Check if java8 directory exists
+  shell: ls -d /usr/lib/jvm/java-1.8.0-openjdk.* >/dev/null 2>&1
+  ignore_errors: yes
+  register: java8
+  tags: java
+
+- name: Create /usr/lib/jvm/java-1.8.0-openjdk symlink
+  shell: ln -s /usr/lib/jvm/java-1.8.0-openjdk.* /usr/lib/jvm/java-1.8.0-openjdk
+  when:
+    - java8.rc == 0
+  tags: java
+
+- name: Check if java7 directory exists
+  shell: ls -d /usr/lib/jvm/java-1.7.0-openjdk.* >/dev/null 2>&1
+  ignore_errors: yes
+  register: java7
+  tags: java
+
+- name: Create /usr/lib/jvm/java-1.7.0-openjdk symlink
+  shell: ln -s /usr/lib/jvm/java-1.7.0-openjdk.* /usr/lib/jvm/java-1.7.0-openjdk
+  when:
+    - java7.rc == 0
+  tags: java
 
 ####################
 # Set default Java #


### PR DESCRIPTION
* intel - installs java7 to /usr/lib/jvm/java-1.7.0-openjdk.x86_64
* amd - installs java7 to /usr/lib/jvm/java-1.7.0-openjdk.amd64

Signed-off-by: Joe deKoning <joe_dekoning@ca.ibm.com>