### PR TITLE
ansible: Remove libstdc++-static from CentOS6

### DIFF
--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/tasks/CentOS.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/tasks/CentOS.yml
@@ -49,6 +49,15 @@
 ##########################
 # Additional build tools #
 ##########################
+##########################
+# Additional build tools #
+##########################
+- name: Install additional build tools for CentOS 7
+  package: "name={{ item }} state=latest"
+  with_items: "{{ Additional_Build_Tools_CentOS7 }}"
+  when: ansible_distribution_major_version == "7"
+  tags: build_tools
+
 - name: Add devtools-2 to yum repo list for gcc 4.8
   get_url:
     url: https://people.centos.org/tru/devtools-2/devtools-2.repo

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/vars/CentOS.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/vars/CentOS.yml
@@ -27,7 +27,6 @@ Build_Tool_Packages:
   - java-1.7.0-openjdk-devel
   - java-1.8.0-openjdk-devel
   - libdwarf-devel
-  - libstdc++-static
   - libXext-devel
   - libXrender-devel
   - libXt-devel
@@ -59,6 +58,9 @@ gcc73_devtoolset_compiler:
   - devtoolset-7-gcc
   - devtoolset-7-binutils
   - devtoolset-7-gcc-c++
+
+Additional_Build_Tools_CentOS7:
+  - libstdc++-static
 
 Additional_Build_Tools_x86_64:
   - zulu-9


### PR DESCRIPTION
Fixes https://github.com/AdoptOpenJDK/openjdk-infrastructure/issues/544
Partially reverts https://github.com/AdoptOpenJDK/openjdk-infrastructure/pull/497