### PR TITLE
Add libcurl-devel package for CentOS

### DIFF
--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/vars/CentOS.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/vars/CentOS.yml
@@ -26,6 +26,7 @@ Build_Tool_Packages:
   - gmp-devel
   - java-1.7.0-openjdk-devel
   - java-1.8.0-openjdk-devel
+  - libcurl-devel
   - libdwarf-devel
   - libXext-devel
   - libXrender-devel


### PR DESCRIPTION
The library is used by git-http-fetch, git-fetch.

Signed-off-by: Violeta Sebe <vsebe@ca.ibm.com>