### PR TITLE
Changed url of apache ant binaries

### DIFF
--- a/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/roles/ANT/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/roles/ANT/tasks/main.yml
@@ -17,7 +17,7 @@
 
 - name: Download Apache ANT
   win_get_url:
-    url: http://apache.forsale.plus/ant/binaries/apache-ant-1.10.3-bin.zip
+    url: https://archive.apache.org/dist/ant/binaries/apache-ant-1.10.5-bin.zip
     dest: c:\temp\ant.zip
     force: no
   when: (ant_installed.stat.exists == false) and (ant_download.stat.exists == false)
@@ -33,7 +33,7 @@
   tags: ANT
 
 - name: Set ANT_HOME
-  raw: setx ANT_HOME "C:\apache-ant\apache-ant-1.10.3"
+  raw: setx ANT_HOME "C:\apache-ant\apache-ant-1.10.5"
   when: (ant_installed.stat.exists == false)
   tags: ANT
 
@@ -47,7 +47,7 @@
 
 - name: Test if ant-contrib is already installed
   win_stat:
-    path: 'C:\apache-ant\apache-ant-1.10.3\lib\ant-contrib.jar'
+    path: 'C:\apache-ant\apache-ant-1.10.5\lib\ant-contrib.jar'
   register: ant_contrib_installed
   tags: ANT
 
@@ -70,7 +70,7 @@
 - name: Copy the ant-contrib.jar to ANT's lib folder
   win_copy:
     src: C:\temp\ant-contrib\ant-contrib\lib\ant-contrib.jar
-    dest: C:\apache-ant\apache-ant-1.10.3\lib\ant-contrib.jar
+    dest: C:\apache-ant\apache-ant-1.10.5\lib\ant-contrib.jar
     remote_src: True
   when: (ant_contrib_installed.stat.exists == false)
   tags: ANT


### PR DESCRIPTION
1.10.3 is missing, used the same url as in the Unix playbook.
This issue came up when installing on windows 2012.
#553
Signed-off-by: Colton Mills <millscolt3@gmail.com>