### PR TITLE
Fixed bugs in ANT windows role

### DIFF
--- a/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/roles/ANT/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/roles/ANT/tasks/main.yml
@@ -5,7 +5,7 @@
 
 - name: Test if Ant is already installed
   win_stat:
-    path: 'C:\apache-ant\apache-ant-1.10.3'
+    path: 'C:\apache-ant\apache-ant-1.10.5'
   register: ant_installed
   tags: ANT
 
@@ -33,7 +33,7 @@
   tags: ANT
 
 - name: Set ANT_HOME
-  raw: setx ANT_HOME "C:\apache-ant\apache-ant-1.10.5"
+  raw: setx ANT_HOME "C:\apache-ant\apache-ant-1.10.5" /m
   when: (ant_installed.stat.exists == false)
   tags: ANT
 


### PR DESCRIPTION
The ant url was changed but forgot to update 1.10.3 to 1.10.5 when
testing if ant was already installed ([see PR](https://github.com/AdoptOpenJDK/openjdk-infrastructure/pull/556)). Also added /m when declaring
ANT_HOME so the variable will be set at the system level.

Signed-off-by: Colton Mills <millscolt3@gmail.com>