### PR TITLE
Sync RedHat/CentOS ansible definitions

### DIFF
--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/vars/RedHat.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/vars/RedHat.yml
@@ -8,19 +8,23 @@ Build_Tool_Packages:
   - alsa-lib-devel
   - autoconf
   - bind-utils
+  - bison
+  - bzip2
   - cpio
   - cups-devel
   - elfutils-libelf-devel
-  - expat-devel
+  - flex
   - fontconfig-devel
   - freetype-devel
   - gcc
   - gcc-c++
   - gettext
+  - git
   - glibc
   - glibc-common
   - glibc-devel
   - gmp-devel
+  - libcurl-devel
   - libdwarf-devel
   - libffi-devel
   - libmpc-devel
@@ -42,14 +46,11 @@ Build_Tool_Packages:
   - zip
 
 Additional_Build_Tools_RHEL7:
-  - bison
-  - curl-devel
-  - flex
   - libstdc++-static
 
 Additional_Build_Tools_RHEL7_PPC64LE:
-  - libcurl-devel
   - libstdc++.so.5
+
 Additional_Build_Tools_RHEL_x86_64:
   - glibc-devel.i686
 


### PR DESCRIPTION
This will make them a bit closer. Diff now as follows, bit it means common packages are listed in the same places in both files after this PR. Fixes https://github.com/AdoptOpenJDK/openjdk-infrastructure/issues/498 - I've removed `expat-devel` as I've no idea why it was in there (@smlambert if you know, shout now!) and it wasn't in the CentOS playbook (We use CentOS build machines on x64 and ppc64le without problems...), so if there's a problem we'll see it at some point in the future.

```
[sxa@sxat470p vars]$ diff CentOS.yml RedHat.yml
3c3
< # CentOS #
---
> # RedHat #
11a12
>   - bzip2
26,27d26
<   - java-1.7.0-openjdk-devel
<   - java-1.8.0-openjdk-devel
29a29,30
>   - libffi-devel
>   - libmpc-devel
34d34
<   - lbzip2
38d37
<   - numactl-devel
42d40
<   - perl-DBI
44,46c42
<   - perl-GD
<   - perl-libwww-perl
<   - perl-Time-HiRes
---
>   - pkgconfig
52,62c48
< gcc48_devtoolset_compiler:
<   - devtoolset-2-gcc
<   - devtorolset-2-binutils
<   - devtoolset-2-gcc-c++
< 
< gcc73_devtoolset_compiler:
<   - devtoolset-7-gcc
<   - devtoolset-7-binutils
<   - devtoolset-7-gcc-c++
< 
< Additional_Build_Tools_CentOS7:
---
> Additional_Build_Tools_RHEL7:
65,66c51,63
< Additional_Build_Tools_x86_64:
<   - zulu-9
---
> Additional_Build_Tools_RHEL7_PPC64LE:
>   - libstdc++.so.5
> 
> Additional_Build_Tools_RHEL_x86_64:
>   - glibc-devel.i686
> 
> Java_NOT_RHEL6_PPC64:
>   - java-1.7.0-openjdk-devel
>   - java-1.8.0-openjdk-devel
> 
> Java_RHEL6_PPC64:
>   - java-1.7.0-ibm-devel
>   - java-1.8.0-ibm-devel
69c66
<   - mercurial
---
>   - acl
72d68
<   - xorg-x11-server-Xorg
75c71
< crontab_Patching: "/usr/bin/yum -y update"
---
> crontab_Patching: "/usr/bin/yum -y update && yum clean packages"
```