### PR TITLE
Switch Vagrant file from using ubuntu/trusty64 to generic/ubuntu1604

### DIFF
--- a/ansible/Vagrantfile
+++ b/ansible/Vagrantfile
@@ -30,7 +30,8 @@ SCRIPT
 Vagrant.configure("2") do |config|
 
   config.vm.define :adoptopenjdk do |adoptopenjdk|
-    adoptopenjdk.vm.box = "ubuntu/trusty64"
+    adoptopenjdk.vm.box = "generic/ubuntu1604"
+    adoptopenjdk.vm.synced_folder ".", "/vagrant"
     adoptopenjdk.vm.hostname = "adoptopenjdk"
     adoptopenjdk.vm.network :private_network, type: "dhcp"
     adoptopenjdk.vm.provision "shell", inline: $script, privileged: false


### PR DESCRIPTION
This will move the image up from 14.04 (which isn't our main platform) to 16.04 and also use an image that will work with providers other than VirtualBox (generic/ubuntu1604 supports):
 - hyperv
 - libvirt
 - parallels
 - virtualbox
 - vmware_desktop

Explicit entry for /vagrant is because it wasn't working for me by default

Reviewers: PLEASE test this on your setup and let me know if it works (especially the `/vagrant` mount) and whether it causes regressions compared to the previous image - I'm going to leave this as WIP for at least a few days until I'm confident it doesn't break anything.