### PR TITLE
Added nasm role to Windows playbook

### DIFF
--- a/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/main.yml
@@ -49,3 +49,4 @@
     - 7-Zip
     - MinGW-W64
     - OpenSSL
+    - nasm

--- a/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/roles/nasm/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/roles/nasm/tasks/main.yml
@@ -1,0 +1,24 @@
+---
+########
+# nasm #
+########
+- name: Check if nasm is installed
+  win_stat:
+    path: C:\openjdk\nasm-2.13.03
+  register: nasm_installed
+  tags: nasm
+
+- name: Download nasm
+  win_get_url:
+    url: https://www.nasm.us/pub/nasm/releasebuilds/2.13.03/win64/nasm-2.13.03-win64.zip
+    dest: C:\temp\nasm-2.13.03.zip
+  when: (nasm_installed.stat.exists == false)
+  tags: nasm
+
+- name: Unzip nasm
+  win_unzip:
+    src: C:\temp\nasm-2.13.03.zip
+    dest: C:\openjdk
+    delete_archive: yes
+  when: (nasm_installed.stat.exists == false)
+  tags: nasm


### PR DESCRIPTION
Windows playbook will now install nasm-2.13.03 into C:\openjdk

Signed-off-by: Colton Mills <millscolt3@gmail.com>