### PR TITLE
ansible: Do not install EPEL on s390x

### DIFF
--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/tasks/RedHat.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/tasks/RedHat.yml
@@ -20,6 +20,7 @@
   shell: |
     rpm -ivh https://dl.fedoraproject.org/pub/epel/epel-release-latest-{{ ansible_distribution_major_version }}.noarch.rpm
   ignore_errors: yes
+  when: ansible_architecture != "s390x"
   tags: patch_update
 
 - name: YUM upgrade all packages


### PR DESCRIPTION
Was added in https://github.com/AdoptOpenJDK/openjdk-infrastructure/commit/86bccd2e3625e64eecd2ae22619906cb08a8f820 but is causing subsequent yum operations in the playbooks to fail. If it was only needed to support an extra package on ppc64le then we might get away with just not enabling this. If it's needed for other things then this is a once in a lifetime opportunity change to document it ;-)

Any comments / suggestions / experience welcome ;-)