### PR TITLE
ansible: Add tag to openjfx prereqs so can be excluded

### DIFF
--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/tasks/Ubuntu.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/tasks/Ubuntu.yml
@@ -63,6 +63,7 @@
 - name: Call Build Packages and Tools Task for OpenJFX
   package: "name={{ item }} state=latest"
   with_items: "{{ OpenJFX_Build_Tool_Packages }}"
+  tags: [build_tools, build_tools_jfx]
 
 - name: Install GCC G++ on supported platforms
   package: "name={{ item }} state=latest"


### PR DESCRIPTION
OpenJFX prereqs won't be needed by most people, therefore have those sections tagged appropriately so they can be exlcuded with `--skip-tags`

Should assist with https://github.com/AdoptOpenJDK/openjdk-infrastructure/issues/532