### PR TITLE
ansible: Add libpng-devel to CentOS/RHEL (required for freetype build)

### DIFF
--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/vars/CentOS.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/vars/CentOS.yml
@@ -28,6 +28,7 @@ Build_Tool_Packages:
   - java-1.8.0-openjdk-devel
   - libcurl-devel
   - libdwarf-devel
+  - libpng-devel
   - libXext-devel
   - libXrender-devel
   - libXt-devel

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/vars/RedHat.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/vars/RedHat.yml
@@ -24,6 +24,7 @@ Build_Tool_Packages:
   - libdwarf-devel
   - libffi-devel
   - libmpc-devel
+  - libpng-devel
   - libXext-devel
   - libXrender-devel
   - libXt-devel


### PR DESCRIPTION
Required for https://github.com/AdoptOpenJDK/openjdk-build/pull/758