### PR TITLE
ansible: Stop symlinking new make to /usr/bin

### DIFF
--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/gmake/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/gmake/tasks/main.yml
@@ -50,7 +50,7 @@
 - name: Create symlink for /usr/bin/gmake to our built 4.1 in /usr/local/bin/make
   file:
     src: /usr/local/bin/make
-    dest: /usr/bin/gmake
+    dest: /usr/local/bin/gmake
     owner: root
     group: root
     state: link


### PR DESCRIPTION
No longer needed after https://github.com/AdoptOpenJDK/openjdk-build/pull/759 is been committed (I hope)

This pretty much repeats https://github.com/AdoptOpenJDK/openjdk-infrastructure/commit/19b3c388e828229ebffcb39610b767458ec5f6c9#diff-b21149752cf9be3ad357fc6cdd81cc9c with a better solution after that was backed out again ...