### PR TITLE
ansible: Switch adoptopenjdk11 role to install OpenJ9 on s390x

### DIFF
--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/adoptopenjdk10/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/adoptopenjdk10/tasks/main.yml
@@ -37,7 +37,7 @@
 
 - name: Install latest OpenJ9 release if one not already installed (Linux/s390x)
   unarchive:
-    src: https://api.adoptopenjdk.net/v2/binary/releases/openjdk10?openjdk_impl=hotspot&os=linux&arch=s390x&release=latest&type=jdk
+    src: https://api.adoptopenjdk.net/v2/binary/releases/openjdk10?openjdk_impl=openj9&os=linux&arch=s390x&release=latest&type=jdk
     dest: /usr/lib/jvm
     remote_src: yes
   when:

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/adoptopenjdk11/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/adoptopenjdk11/tasks/main.yml
@@ -37,7 +37,7 @@
 
 - name: Install latest OpenJ9 release if one not already installed (Linux/s390x)
   unarchive:
-    src: https://api.adoptopenjdk.net/v2/binary/releases/openjdk11?openjdk_impl=hotspot&os=linux&arch=s390x&release=latest&type=jdk
+    src: https://api.adoptopenjdk.net/v2/binary/releases/openjdk11?openjdk_impl=openj9&os=linux&arch=s390x&release=latest&type=jdk
     dest: /usr/lib/jvm
     remote_src: yes
   when:


### PR DESCRIPTION
Puts correct change into s390x section of the adoptopenjdk11 setup (Now matches the comment)
Fixes https://github.com/AdoptOpenJDK/openjdk-infrastructure/issues/594