### PR TITLE
ansible: Remove junit install on SLES as test team does not require it

### DIFF
--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Ant-Contrib/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Ant-Contrib/tasks/main.yml
@@ -43,22 +43,3 @@
   when:
     - antcontrib_status.stat.exists == False
   tags: ant-contrib
-
-- name: Download junit - SLES
-  get_url:
-    url: https://ftp5.gwdg.de/pub/opensuse/discontinued/distribution/11.4/repo/oss/suse/noarch/junit-3.8.2-8.1.noarch.rpm
-    dest: /tmp/
-    mode: 0440
-    timeout: 25
-    validate_certs: no
-  when:
-    - ansible_distribution == "SLES"
-  tags: ant-contrib
-
-- name: Install junit from rpm - SLES
-  zypper:
-    name: /tmp/junit-3.8.2-8.1.noarch.rpm
-    state: present
-  when:
-    - ansible_distribution == "SLES"
-  tags: ant-contrib


### PR DESCRIPTION
Part of https://github.com/AdoptOpenJDK/openjdk-infrastructure/issues/607, supercedes https://github.com/AdoptOpenJDK/openjdk-infrastructure/pull/611 #CanOfWorms #YakShaving :-)

Spoke to @smlambert who says this isn't needed, and it's causing a failure. If needed again Junit 4.1 can be installed from the SLES12 zypper repo.
```
build-marist-sles12-s390x-1:/tmp # zypper --non-interactive install --type package --auto-agree-with-licenses --no-recommends -- /tmp/junit-3.8.2-8.1.noarch.rpm
Refreshing service 'SMT-http_lxslsmt'.
Loading repository data...
Reading installed packages...
Resolving package dependencies...

The following NEW package is going to be installed:
  junit

The following package has no support information from it's vendor:
  junit

1 new package to install.
Overall download size: 189.6 KiB. Already cached: 0 B. After the operation, additional 232.5 KiB will be used.
Continue? [y/n/...? shows all options] (y): y
Retrieving package junit-3.8.2-8.1.noarch                                                                                                                                     (1/1), 189.6 KiB (232.5 KiB unpacked)
junit-3.8.2-8.1.noarch.rpm:
    Header V3 RSA/SHA256 Signature, key ID 3dbdc284: NOKEY
    V3 RSA/SHA256 Signature, key ID 3dbdc284: NOKEY

junit-3.8.2-8.1.noarch (Plain RPM files cache): Signature verification failed [4-Signatures public key is not available]
Abort, retry, ignore? [a/r/i] (a): a
Problem occurred during or after installation or removal of packages:
Installation aborted by user
Please see the above error message for a hint.
build-marist-sles12-s390x-1:/tmp # 
```