### PR TITLE
Updated Windows_Updates role

### DIFF
--- a/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/roles/Windows_Updates/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/roles/Windows_Updates/tasks/main.yml
@@ -4,13 +4,12 @@
 ###################
 - name: Download and Install Windows Updates
   win_updates:
-    register: update_result
+  register: update_result
   ignore_errors: yes
   tags: Windows_Updates
 
 - name: Reboot machine if necessary
   win_reboot:
-    shutdown_timeout: 3600
     reboot_timeout: 3600
-    when: update_result.reboot_required
+  when: update_result.reboot_required
   tags: Windows_Updates


### PR DESCRIPTION
Ansible thinks the when statement is a part of the
win_reboot module, and the register statement is a
part of the win_updates module causing errors. Removed
spaces so when and register statements will work. Removed
shutdown_timeout as it is deprecated

Signed-off-by: Colton Mills <millscolt3@gmail.com>