### PR TITLE
Updated cygwin role

### DIFF
--- a/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/roles/cygwin/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/roles/cygwin/tasks/main.yml
@@ -82,7 +82,7 @@
   tags: cygwin
 
 - name: Add c:\cygwin64\bin to the start of the %PATH%
-  raw: setx PATH "C:\cygwin64\bin;$env:Path"
+  raw: setx PATH "C:\cygwin64\bin;$env:Path" /m
   tags:
     - cygwin
     # TODO: write a condition when NOT to run this step


### PR DESCRIPTION
Cygwin will now be added to the system path instead of
the User path.

Signed-off-by: Colton Mills <millscolt3@gmail.com>