### PR TITLE
Fixed 7-zip role

### DIFF
--- a/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/roles/7-Zip/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/roles/7-Zip/tasks/main.yml
@@ -16,4 +16,5 @@
     path: 'C:\temp\7z.exe'
     creates_path: 'C:\7-Zip\7z.exe'
     state: present
+    arguments: /S
   tags: 7zip


### PR DESCRIPTION
7-zip role was not being executed by ansible, so tasks
directory was created and main.yml moved inside. Added
the /S option to the 7-zip installation so it wouldn't
hang waiting for input.

Signed-off-by: Colton Mills <millscolt3@gmail.com>