### PR TITLE
Windows LanguagePack installation

### DIFF
--- a/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/main.yml
@@ -52,3 +52,4 @@
     - Clang_32bit                 # OpenJ9
     - OpenSSL                     # OpenJ9
     - nasm                        # OpenJ9
+    - LangPack                    # Internationalization tests

--- a/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/roles/LangPack/tasks/en.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/roles/LangPack/tasks/en.yml
@@ -1,0 +1,34 @@
+---
+##############################
+# Switch language to English #
+##############################
+
+- name: Test if language pack en is installed
+  win_shell: |
+      DISM.exe /Online /Get-Intl /English |
+      Select-String -SimpleMatch 'Installed language(s)'|
+      ForEach-Object { if($_ -match 'en-US'){ $Matches[0] }}
+  register: lang_installed
+  failed_when: lang_installed.stdout | length == 0
+  tags: langpack
+
+- name: Set Languagelist
+  win_shell: Set-WinUserLanguageList -LanguageList en-US -Force
+  tags: langpack
+
+- name: Overwrite UI language
+  win_shell: Set-WinUILanguageOverride -Language en-US
+  tags: langpack
+
+- name: Region Setting
+  win_region:
+    copy_settings: "true"
+    format: en-US
+    unicode_language: en-US
+  register: result
+  tags: langpack
+
+- name: Change Region - Reboot
+  win_reboot:
+  when: result.restart_required
+  tags: langpack

--- a/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/roles/LangPack/tasks/ja.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/roles/LangPack/tasks/ja.yml
@@ -1,0 +1,35 @@
+---
+###############################
+# Switch language to Japanese #
+###############################
+
+# Prerequisite: Japanese language pack was installed
+- name: Test if language pack ja is installed
+  win_shell: |
+      DISM.exe /Online /Get-Intl /English |
+      Select-String -SimpleMatch 'Installed language(s)'|
+      ForEach-Object { if($_ -match 'ja-JP'){ $Matches[0] }}
+  register: lang_installed
+  failed_when: lang_installed.stdout | length == 0
+  tags: langpack
+
+- name: Set Languagelist
+  win_shell: Set-WinUserLanguageList -LanguageList ja-JP,en-US -Force
+  tags: langpack
+
+- name: Overwrite UI language
+  win_shell: Set-WinUILanguageOverride -Language ja-JP
+  tags: langpack
+
+- name: Region Setting
+  win_region:
+    copy_settings: "true"
+    format: ja-JP
+    unicode_language: ja-JP
+  register: result
+  tags: langpack
+
+- name: Change Region - Reboot
+  win_reboot:
+  when: result.restart_required
+  tags: langpack

--- a/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/roles/LangPack/tasks/ko.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/roles/LangPack/tasks/ko.yml
@@ -1,0 +1,35 @@
+---
+#############################
+# Switch language to Korean #
+#############################
+
+# Prerequisite: Korean language pack was installed
+- name: Test if language pack ko is installed
+  win_shell: |
+      DISM.exe /Online /Get-Intl /English |
+      Select-String -SimpleMatch 'Installed language(s)'|
+      ForEach-Object { if($_ -match 'ko-KR'){ $Matches[0] }}
+  register: lang_installed
+  failed_when: lang_installed.stdout | length == 0
+  tags: langpack
+
+- name: Set Languagelist
+  win_shell: Set-WinUserLanguageList -LanguageList ko-KR,en-US -Force
+  tags: langpack
+
+- name: Overwrite UI language
+  win_shell: Set-WinUILanguageOverride -Language ko-KR
+  tags: langpack
+
+- name: Region Setting
+  win_region:
+    copy_settings: "true"
+    format: ko-KR
+    unicode_language: ko-KR
+  register: result
+  tags: langpack
+
+- name: Change Region - Reboot
+  win_reboot:
+  when: result.restart_required
+  tags: langpack

--- a/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/roles/LangPack/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/roles/LangPack/tasks/main.yml
@@ -1,0 +1,13 @@
+---
+# Switch language
+- include: en.yml
+  when: lang == 'en'
+  tags: langpack
+
+- include: ja.yml
+  when: lang == 'ja'
+  tags: langpack
+
+- include: ko.yml
+  when: lang == 'ko'
+  tags: langpack


### PR DESCRIPTION
For new internationalization tests, install Windows Language pack and set the language.
In this phase, Japanese or Korean will be set up if Host variable has "lang=ja" or "lang=ko".

Reboot is required twice; after Language Pack install and after switching to new language.

/Vendor_Files/langpack/Win2012R2/jp/lp.cab
/Vendor_Files/langpack/Win2012R2/kr/lp.cab
They need to be extracted from Windows Language Pack media.

Reference: #635 