### PR TITLE
[WIP] ansible: Reference correct default PATH to 7-zip when extracting mingw

### DIFF
--- a/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/roles/MinGW-W64/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/roles/MinGW-W64/tasks/main.yml
@@ -20,6 +20,6 @@
   tags: mingw
 
 - name: Install MinGW-W64
-  raw: C:\7-Zip\7z.exe x C:\temp\x86_64-8.1.0-release-win32-seh-rt_v6-rev0.7z -oC:\mingw-w64\x86_64-8.1.0-win32-seh-rt_v6-rev0\
+  raw: "C:\Program Files\7-Zip\7z.exe" x C:\temp\x86_64-8.1.0-release-win32-seh-rt_v6-rev0.7z -oC:\mingw-w64\x86_64-8.1.0-win32-seh-rt_v6-rev0\
   when: mingw_installed.stat.exists == false
   tags: mingw


### PR DESCRIPTION
Signed-off-by: Stewart Addison <sxa@uk.ibm.com>

WIP as needs to be tested.
Alternative solution is to adjust the 7-Zip role to install to `C:\7-Zip` (probably the better solution ... This is really just a placeholder to ensure someone comes up with a solution!