### PR TITLE
Clang_32bit and Clang_64bit syntax fixes

### DIFF
--- a/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/roles/Clang_32bit/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/roles/Clang_32bit/tasks/main.yml
@@ -22,9 +22,9 @@
 
 - name: Install (unzip) Clang 32bit
   win_unzip:
-  src: C:\temp\llvm-7.0.0-win32.zip
-  dest: C:\
-  creates: 'C:\Program Files (x86)\LLVM\bin\clang.exe'
+    src: C:\temp\llvm-7.0.0-win32.zip
+    dest: C:\
+    creates: 'C:\Program Files (x86)\LLVM\bin\clang.exe'
   when: clang_32bit_installed.stat.exists == false
   tags: clang_32bit
 
@@ -35,7 +35,7 @@
   tags: clang_32bit
 
 - name: Create symlink to C:\openjdk\LLVM32
-  raw: cmd /c mklink /D "C:\openjdk\LLVM32\" "C:\Program Files (x86)\LLVM"
+  raw: cmd /c mklink /D "C:\openjdk\LLVM32" "C:\Program Files (x86)\LLVM"
   when: (llvm32_symlink.stat.exists == false)
   tags: clang_32bit
 

--- a/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/roles/Clang_64bit/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/roles/Clang_64bit/tasks/main.yml
@@ -24,15 +24,15 @@
   tags: clang_64bit
 
 - name: Test if LLVM64 symlink is already created
-   win_stat:
-     path: 'C:\openjdk\LLVM64'
-   register: llvm64_symlink
-   tags: clang_64bit
+  win_stat:
+    path: 'C:\openjdk\LLVM64'
+  register: llvm64_symlink
+  tags: clang_64bit
 
 - name: Create symlink to C:\openjdk\LLVM64
-   raw: cmd /c mklink /D "C:\openjdk\LLVM64\" "C:\Program Files\LLVM"
-   when: (llvm64_symlink.stat.exists == false)
-   tags: clang_64bit
+  raw: cmd /c mklink /D "C:\openjdk\LLVM64" "C:\Program Files\LLVM"
+  when: (llvm64_symlink.stat.exists == false)
+  tags: clang_64bit
 
 - name: Cleanup Clang 64bit installer
   win_file:


### PR DESCRIPTION
* remove erroneous whitespace that caused playbook errors

* remove trailing  `\` in symlink target directories causing playbook errors

* fix syntax error when unzipping llvm 32bit


Signed-off-by: Husain Yusufali husainyusufali7@gmail.com