### PR TITLE
Remove trailing backslashes from Java roles in Windows Playbook

### DIFF
--- a/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/roles/Java11/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/roles/Java11/tasks/main.yml
@@ -35,6 +35,6 @@
   tags: Java11
 
 - name: Create symlink to Java11
-  raw: cmd /c mklink /D "C:\openjdk\jdk11\" "C:\Program Files\Java\jdk-11.0.1+13\"
+  raw: cmd /c mklink /D "C:\openjdk\jdk11" "C:\Program Files\Java\jdk-11.0.1+13"
   when: (java11_symlink.stat.exists == false)
   tags: Java11

--- a/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/roles/Java7/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/roles/Java7/tasks/main.yml
@@ -37,6 +37,6 @@
   tags: Java7
 
 - name: Create symlink to Java 7
-  raw: cmd /c mklink /D "C:\openjdk\jdk7\" "C:\Program Files\Java\java-se-7u75-ri\"
+  raw: cmd /c mklink /D "C:\openjdk\jdk7" "C:\Program Files\Java\java-se-7u75-ri"
   when: (java7_symlink.stat.exists == false)
   tags: Java7

--- a/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/roles/Java8/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/roles/Java8/tasks/main.yml
@@ -35,7 +35,7 @@
   tags: Java8
 
 - name: Create symlink to Java 8
-  raw: cmd /c mklink /D "C:\openjdk\jdk8\" "C:\Program Files\Java\jdk8u172-b11\"
+  raw: cmd /c mklink /D "C:\openjdk\jdk8" "C:\Program Files\Java\jdk8u172-b11"
   when: (java8_symlink.stat.exists == false)
   tags: Java8
 

--- a/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/roles/Java9/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/roles/Java9/tasks/main.yml
@@ -35,6 +35,6 @@
   tags: Java9
 
 - name: Create symlink to Java 9
-  raw: cmd /c mklink /D "C:\openjdk\jdk9\" "C:\Program Files\Java\jdk-9+181\"
+  raw: cmd /c mklink /D "C:\openjdk\jdk9" "C:\Program Files\Java\jdk-9+181"
   when: (java9_symlink.stat.exists == false)
   tags: Java9

--- a/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/roles/Java9/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/roles/Java9/tasks/main.yml
@@ -35,6 +35,6 @@
   tags: Java9
 
 - name: Create symlink to Java 9
-  raw: cmd /c mklink /D "C:\openjdk\jdk9" "C:\Program Files\Java\jdk-9+181"
+  raw: cmd /c mklink /D "C:\openjdk\jdk9" "C:\Program Files\Java\jdk-9.0.4+11"
   when: (java9_symlink.stat.exists == false)
   tags: Java9


### PR DESCRIPTION
* remove trailing backslashes from Java 7, 8, 9, 11 symlinks

* found an incorrect symlink in Java 9 while testing

* Java 9 symlink has been fixed to point to correct location  


Signed-off-by: Husain Yusufali husainyusufali7@gmail.com