### PR TITLE
ansible: Changing 7-Zip installation directory in Windows Playbook

### DIFF
--- a/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/roles/7-Zip/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/roles/7-Zip/tasks/main.yml
@@ -16,5 +16,5 @@
     path: 'C:\temp\7z.exe'
     creates_path: 'C:\7-Zip\7z.exe'
     state: present
-    arguments: /S
+    arguments: /S /D="C:\7-Zip"
   tags: 7zip


### PR DESCRIPTION
* Change the 7-Zip installation directory by adding an argument

* Tested to make sure installation directory is `C:\7-Zip` and playbook will skip installation if 7-Zip is already is installed 

* Fixes pull request #644 

Signed-off-by: HusainYusufali <husainyusufali7@gmail.com>