### PR TITLE
ansible: Linux: Add 'adoptopenjdk' tag to make exclusions easier

### DIFF
--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Jenkins_User/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Jenkins_User/tasks/main.yml
@@ -5,7 +5,7 @@
 - name: Create Jenkins user
   action: user name={{ Jenkins_Username }} state=present shell=/bin/bash
   ignore_errors: yes
-  tags: jenkins_user
+  tags: [jenkins_user, adoptopenjdk]
 
 - name: Create Jenkins user's home folder
   file:
@@ -16,14 +16,14 @@
     mode: 0700
   when:
     - ansible_architecture == "s390x"
-  tags: jenkins_user
+  tags: [jenkins_user, adoptopenjdk]
 
 - name: Set authorized key for Jenkins user
   authorized_key:
     user: "{{ Jenkins_Username }}"
     state: present
     key: "{{ lookup('file', '{{ Jenkins_User_SSHKey }}') }}"
-  tags: [jenkins_user, jenkins_authorized_key]
+  tags: [jenkins_user, jenkins_authorized_key, adoptopenjdk]
 
 - name: Add Jenkins user to the audio group
   user: name={{ Jenkins_Username }}
@@ -32,12 +32,13 @@
   when:
     - (ansible_distribution == "Ubuntu" or ansible_distribution == "SLES")
     - ansible_architecture != "armv7l"
-  tags: jenkins_user
+  tags: [jenkins_user, adoptopenjdk]
 
 - name: Unset expiry on user account for Redhat for Jenkins user
   command: chage -M -1 -E -1 {{ Jenkins_Username }}
   tags:
     - jenkins_user
+    - adoptopenjdk
     # TODO: write a condition when NOT to run this step
     - skip_ansible_lint
 
@@ -45,5 +46,6 @@
   command: chage -M -1 -E -1 root
   tags:
     - jenkins_user
+    - adoptopenjdk
     # TODO: write a condition when NOT to run this step
     - skip_ansible_lint

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Nagios_Master_Config/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Nagios_Master_Config/tasks/main.yml
@@ -20,11 +20,11 @@
   set_fact: ansible_port="22"
   when:
     - ansible_port is not defined
-  tags: nagios_master_config
+  tags: [nagios_master_config, adoptopenjdk]
 
 - name: SSH into the Nagios Master and excute the Nagios_Ansible_Config_tool.sh script
   local_action: command ssh -o StrictHostKeyChecking=no root@{{ Nagios_Master_IP }} "/usr/local/nagios/Nagios_Ansible_Config_tool/Nagios_Ansible_Config_tool.sh  {{ ansible_distribution }} {{ ansible_architecture }} {{ inventory_hostname  }} {{ ansible_host }} {{ provider }} {{ ansible_port }} "
   when:
     - Nagios_Monitoring == "Enabled"
     - Nagios_Master_IP is defined
-  tags: nagios_master_config
+  tags: [nagios_master_config, adoptopenjdk]

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Nagios_Plugins/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Nagios_Plugins/tasks/main.yml
@@ -19,7 +19,7 @@
   ignore_errors: yes
   when:
     - Nagios_Plugins == "Enabled"
-  tags: nagios_plugins
+  tags: [nagios_plugins, adoptopenjdk]
 
 - name: Set authorized key for Nagios user
   authorized_key:
@@ -28,7 +28,7 @@
     key: "{{ lookup('file', '{{ Nagios_User_SSHKey }}') }}"
   when:
     - Nagios_Plugins == "Enabled"
-  tags: nagios_plugins
+  tags: [nagios_plugins, adoptopenjdk]
 
   ################################
   # Require OS specific playbook #
@@ -37,7 +37,7 @@
   include_tasks: nagios_{{ ansible_distribution }}.yml
   when:
     - Nagios_Plugins == "Enabled"
-  tags: nagios_plugins
+  tags: [nagios_plugins, adoptopenjdk]
 
   ##############################
   # Install additional plugins #
@@ -49,4 +49,4 @@
     mode: 0755
   when:
     - Nagios_Plugins == "Enabled"
-  tags: nagios_plugins
+  tags: [nagios_plugins, adoptopenjdk]

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Nagios_Plugins/tasks/nagios_CentOS.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Nagios_Plugins/tasks/nagios_CentOS.yml
@@ -16,7 +16,7 @@
     echo "nagios ALL = NOPASSWD: /usr/bin/yum --security check-update" >> /etc/sudoers
   when:
     - ansible_architecture == "x86_64"
-  tags: nagios_plugins
+  tags: [nagios_plugins, adoptopenjdk]
 
 ###################
 # Install plugins #
@@ -25,18 +25,18 @@
   yum:
     name: nagios-plugins-all
     state: latest
-  tags: nagios_plugins
+  tags: [nagios_plugins, adoptopenjdk]
 
 ##########
 # Layout #
 ##########
 - name: Creates Nagios folder
   file: path=/usr/local/nagios/ state=directory mode=0755 owner=nagios
-  tags: nagios_plugins
+  tags: [nagios_plugins, adoptopenjdk]
 
 - name: Create symlink to plugins
   file: src=/usr/lib64/nagios/plugins dest=/usr/local/nagios/libexec state=link
-  tags: nagios_plugins
+  tags: [nagios_plugins, adoptopenjdk]
 
 ##############################
 # Install additional plugins #
@@ -46,4 +46,4 @@
     url: https://raw.githubusercontent.com/AdoptOpenJDK/openjdk-infrastructure/master/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Nagios_Plugins/tasks/additional_plugins/check_yum
     dest: /usr/local/nagios/libexec/check_yum
     mode: 0755
-  tags: nagios_plugins
+  tags: [nagios_plugins, adoptopenjdk]

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Nagios_Plugins/tasks/nagios_FreeBSD.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Nagios_Plugins/tasks/nagios_FreeBSD.yml
@@ -15,12 +15,12 @@
 - name: Allow Nagios to use pkg while restricting it to audit only
   shell: |
     echo "nagios ALL = NOPASSWD: /usr/sbin/pkg audit -F" >> /etc/sudoers
-  tags: nagios_plugins
+  tags: [nagios_plugins, adoptopenjdk]
 
 - name: Allow Nagios to use pkg while restricting it to upgrade --dry-run only
   shell: |
     echo "nagios ALL = NOPASSWD: /usr/sbin/pkg upgrade --dry-run" >> /etc/sudoers
-  tags: nagios_plugins
+  tags: [nagios_plugins, adoptopenjdk]
 
 ###################
 # Install plugins #
@@ -31,19 +31,19 @@
     dest: /tmp/
     mode: 0440
     timeout: 25
-  tags: nagios_plugins
+  tags: [nagios_plugins, adoptopenjdk]
 
 - name: Extract nagios-plugins
   unarchive:
     src: /tmp/nagios-plugins-2.2.1.tar.gz
     dest: /tmp/
     copy: False
-  tags: nagios_plugins
+  tags: [nagios_plugins, adoptopenjdk]
 
 - name: Configure, make and make install nagios-plugins
   shell: cd /tmp/nagios-plugins-2.2.1/ && ./configure --prefix=/usr/local/nagios && make -j {{ ansible_processor_vcpus }} && make install
   become: yes
-  tags: nagios_plugins
+  tags: [nagios_plugins, adoptopenjdk]
 
 ##############################
 # Install additional plugins #
@@ -53,4 +53,4 @@
     url: https://raw.githubusercontent.com/AdoptOpenJDK/openjdk-infrastructure/master/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Nagios_Plugins/tasks/additional_plugins/check_pkg
     dest: /usr/local/nagios/libexec/check_pkg
     mode: 0755
-  tags: nagios_plugins
+  tags: [nagios_plugins, adoptopenjdk]

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Nagios_Plugins/tasks/nagios_RedHat.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Nagios_Plugins/tasks/nagios_RedHat.yml
@@ -15,7 +15,7 @@
 - name: Allow Nagios to use yum while restricting it to check-update only
   shell: |
     echo "nagios ALL = NOPASSWD: /usr/bin/yum --security check-update" >> /etc/sudoers
-  tags: nagios_plugins
+  tags: [nagios_plugins, adoptopenjdk]
 
 # Can't find nagios-plugins-all on RHEL74/s390x so removing this
 # ###################
@@ -59,7 +59,7 @@
   when:
 #      - ansible_distribution_major_version == "6"
     - not folder_nagios.stat.exists
-  tags: nagios_plugins
+  tags: [nagios_plugins, adoptopenjdk]
 
 - name: Extract nagios-plugins
   unarchive:
@@ -69,7 +69,7 @@
   when:
 #      - ansible_distribution_major_version == "6"
     - not folder_nagios.stat.exists
-  tags: nagios_plugins
+  tags: [nagios_plugins, adoptopenjdk]
 
 - name: Configure, make and make install nagios-plugins
   shell: cd /tmp/nagios-plugins-2.2.1/ && ./configure --prefix=/usr/local/nagios && make -j {{ ansible_processor_vcpus }} && make install
@@ -77,7 +77,7 @@
   when:
 #      - ansible_distribution_major_version == "6"
     - not folder_nagios.stat.exists
-  tags: nagios_plugins
+  tags: [nagios_plugins, adoptopenjdk]
 
 ##############################
 # Install additional plugins #
@@ -87,4 +87,4 @@
     url: https://raw.githubusercontent.com/AdoptOpenJDK/openjdk-infrastructure/master/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Nagios_Plugins/tasks/additional_plugins/check_yum
     dest: /usr/local/nagios/libexec/check_yum
     mode: 0755
-  tags: nagios_plugins
+  tags: [nagios_plugins, adoptopenjdk]

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Nagios_Plugins/tasks/nagios_SLES.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Nagios_Plugins/tasks/nagios_SLES.yml
@@ -19,7 +19,7 @@
     - gcc
     - make
     - xinetd
-  tags: nagios_plugins
+  tags: [nagios_plugins, adoptopenjdk]
 
 ###############
 # Nagios user #
@@ -28,7 +28,7 @@
   shell: |
     echo "nagios ALL = NOPASSWD: /usr/bin/zypper ref" >> /etc/sudoers
     echo "nagios ALL = NOPASSWD: /usr/bin/zypper list-patches" >> /etc/sudoers
-  tags: nagios_plugins
+  tags: [nagios_plugins, adoptopenjdk]
 
 ###################
 # Install plugins #
@@ -39,19 +39,19 @@
     dest: /tmp/
     mode: 0440
     timeout: 25
-  tags: nagios_plugins
+  tags: [nagios_plugins, adoptopenjdk]
 
 - name: Extract nagios-plugins
   unarchive:
     src: /tmp/nagios-plugins-2.2.1.tar.gz
     dest: /tmp/
     copy: False
-  tags: nagios_plugins
+  tags: [nagios_plugins, adoptopenjdk]
 
 - name: Configure, make and make install nagios-plugins
   shell: cd /tmp/nagios-plugins-2.2.1/ && ./configure --prefix=/usr/local/nagios && make -j {{ ansible_processor_vcpus }} && make install
   become: yes
-  tags: nagios_plugins
+  tags: [nagios_plugins, adoptopenjdk]
 
 ##############################
 # Install additional plugins #
@@ -61,4 +61,4 @@
     url: https://raw.githubusercontent.com/AdoptOpenJDK/openjdk-infrastructure/master/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Nagios_Plugins/tasks/additional_plugins/check_zypper
     dest: /usr/local/nagios/libexec/check_zypper
     mode: 0755
-  tags: nagios_plugins
+  tags: [nagios_plugins, adoptopenjdk]

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Nagios_Plugins/tasks/nagios_Ubuntu.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Nagios_Plugins/tasks/nagios_Ubuntu.yml
@@ -21,15 +21,15 @@
     - nagios-plugins-common
     - perl
     - qstat
-  tags: nagios_plugins
+  tags: [nagios_plugins, adoptopenjdk]
 
 ##########
 # Layout #
 ##########
 - name: Creates Nagios folder
   file: path=/usr/local/nagios/ state=directory mode=0755 owner=nagios
-  tags: nagios_plugins
+  tags: [nagios_plugins, adoptopenjdk]
 
 - name: Create symlink to plugins
   file: src=/usr/lib/nagios/plugins dest=/usr/local/nagios/libexec state=link
-  tags: nagios_plugins
+  tags: [nagios_plugins, adoptopenjdk]

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Nagios_Tunnel/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Nagios_Tunnel/tasks/main.yml
@@ -21,7 +21,7 @@
     - Nagios_Monitoring == "Enabled"
     - Nagios_Master_IP is defined
     - tunnel_script_result.stat.exists == False
-  tags: nagios_tunnel
+  tags: [nagios_tunnel, adoptopenjdk]
 
 - name: Download Nagios_RemoteTunnel.sh script
   get_url:
@@ -33,7 +33,7 @@
     - Nagios_Monitoring == "Enabled"
     - Nagios_Master_IP is defined
     - tunnel_script_result.stat.exists == False
-  tags: nagios_tunnel
+  tags: [nagios_tunnel, adoptopenjdk]
 
 - name: Update Nagios_RemoteTunnel.sh - ReplaceNAGIOSMASTERADDRESS with {{ Nagios_Master_IP }}
   replace:
@@ -45,7 +45,7 @@
     - Nagios_Monitoring == "Enabled"
     - Nagios_Master_IP is defined
     - tunnel_script_result.stat.exists == False
-  tags: nagios_tunnel
+  tags: [nagios_tunnel, adoptopenjdk]
 
 - name: Update Nagios_RemoteTunnel.sh - ReplacePortNumber with {{ ansible_port }}
   replace:
@@ -57,7 +57,7 @@
     - Nagios_Monitoring == "Enabled"
     - Nagios_Master_IP is defined
     - tunnel_script_result.stat.exists == False
-  tags: nagios_tunnel
+  tags: [nagios_tunnel, adoptopenjdk]
 
 - name: Add cron job to keep reverse tunnel alive for nagios user
   cron: name="Keep Nagios reverse tunnel alive"
@@ -72,4 +72,4 @@
     - Nagios_Monitoring == "Enabled"
     - Nagios_Master_IP is defined
     - tunnel_script_result.stat.exists == False
-  tags: nagios_tunnel
+  tags: [nagios_tunnel, adoptopenjdk]

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Security/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Security/tasks/main.yml
@@ -13,7 +13,7 @@
     regexp: '^no-agent-forwarding'
   when:
     - Security == "Enabled"
-  tags: security
+  tags: [security, adoptopenjdk]
 
 - name: Ensure keybox's ssh key is applied to root's authorized_key file
   authorized_key:
@@ -22,7 +22,7 @@
     key: "{{ lookup('file', '{{ Keybox_SSHKey }}') }}"
   when:
     - Security == "Enabled"
-  tags: security
+  tags: [security, adoptopenjdk]
 
 ###############
 # sshd_config #
@@ -34,7 +34,7 @@
               state=present
   when:
     - Security == "Enabled"
-  tags: security
+  tags: [security, adoptopenjdk]
 
 - name: Security - Disable Password Authentication for root user
   lineinfile: dest=/etc/ssh/sshd_config
@@ -43,7 +43,7 @@
               state=present
   when:
     - Security == "Enabled"
-  tags: security
+  tags: [security, adoptopenjdk]
 
 - name: Security - Disable ChallengeResponseAuthentication for all users
   lineinfile: dest=/etc/ssh/sshd_config
@@ -52,7 +52,7 @@
               state=present
   when:
     - Security == "Enabled"
-  tags: security
+  tags: [security, adoptopenjdk]
 
 - name: Restart ssh service
   service:
@@ -62,7 +62,7 @@
   ignore_errors: yes
   when:
     - Security == "Enabled"
-  tags: security
+  tags: [security, adoptopenjdk]
 
 - name: Restart sshd service
   service:
@@ -72,7 +72,7 @@
   ignore_errors: yes
   when:
     - Security == "Enabled"
-  tags: security
+  tags: [security, adoptopenjdk]
 
 ##################
 # Account Policy #
@@ -88,7 +88,7 @@
   when:
     - Security == "Enabled"
     - ansible_distribution != "FreeBSD"
-  tags: security
+  tags: [security, adoptopenjdk]
 
 - name: Account policy - max days
   command: chage -M -1 "{{ item }}"
@@ -101,4 +101,4 @@
   when:
     - Security == "Enabled"
     - ansible_distribution != "FreeBSD"
-  tags: security
+  tags: [security, adoptopenjdk]

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Superuser/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Superuser/tasks/main.yml
@@ -5,7 +5,7 @@
 - name: Create Superuser account - zeus
   action: user name=zeus state=present shell=/bin/bash
   when: Superuser_Account == "Enabled"
-  tags: superuser
+  tags: [superuser, adoptopenjdk]
 
 - name: Create Superuser account home folder for s390x
   file:
@@ -17,7 +17,7 @@
   when:
     - ansible_architecture == "s390x"
     - Superuser_Account == "Enabled"
-  tags: superuser
+  tags: [superuser, adoptopenjdk]
 
 - name: Set authorized key for Superuser account
   authorized_key:
@@ -25,7 +25,7 @@
     state: present
     key: "{{ lookup('file', '{{ Zeus_User_SSHKey }}') }}"
   when: Superuser_Account == "Enabled"
-  tags: superuser
+  tags: [superuser, adoptopenjdk]
 
 - name: Grant Superuser sudo powers
   lineinfile:
@@ -34,7 +34,7 @@
     regexp: '^zeus'
     line: 'zeus ALL=(ALL) NOPASSWD: ALL'
   when: Superuser_Account == "Enabled"
-  tags: superuser
+  tags: [superuser, adoptopenjdk]
 
 - name: Superuser account policy - expire date
   command: chage -E -1 zeus
@@ -42,11 +42,11 @@
     - Superuser_Account == "Enabled"
     - ansible_distribution != "FreeBSD"
 
-  tags: superuser
+  tags: [superuser, adoptopenjdk]
 
 - name: Superuser account policy - max days
   command: chage -M -1 zeus
   when:
     - Superuser_Account == "Enabled"
     - ansible_distribution != "FreeBSD"
-  tags: superuser
+  tags: [superuser, adoptopenjdk]

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/freemarker/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/freemarker/tasks/main.yml
@@ -6,7 +6,7 @@
   stat:
     path: /home/{{ Jenkins_Username }}/freemarker.jar
   register: freemarker
-  tags: freemarker
+  tags: [freemarker, adoptopenjdk]
 
 # Originally downloaded from
 # https://sourceforge.net/projects/freemarker/files/freemarker/2.3.8/freemarker-2.3.8.tar.gz
@@ -17,9 +17,9 @@
     remote_src: yes
     mode: 0755
   when: freemarker.stat.exists == False
-  tags: freemarker
+  tags: [freemarker, adoptopenjdk]
 
 - name: Move freemarker.jar to /home/{{ Jenkins_Username }} folder
   command: mv /tmp/freemarker-2.3.8/lib/freemarker.jar /home/{{ Jenkins_Username }}
   when: freemarker.stat.exists == False
-  tags: freemarker
+  tags: [freemarker, adoptopenjdk]

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/x11/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/x11/tasks/main.yml
@@ -11,7 +11,10 @@
     group: "{{ root_group }}"
     owner: root
     mode: 0644
-  tags: x11
+  tags:
+    - x11
+    - adoptopenjdk
+    - test_tools
 
 - name: Start X11
   become: yes
@@ -21,5 +24,7 @@
   no_log: True
   tags:
     - x11
+    - test_tools
+    - adoptopenjdk
     # TODO: write a condition when NOT to run this step
     - skip_ansible_lint


### PR DESCRIPTION
Signed-off-by: Stewart Addison <sxa@uk.ibm.com>

Fixes https://github.com/AdoptOpenJDK/openjdk-infrastructure/issues/532 https://github.com/AdoptOpenJDK/openjdk-infrastructure/issues/626

May remove the x11 role entirely is it's not persistent ... But for now this will stop "normal" people having to exclude a billion tags to make the playbooks work, after this change `--skip-tags=adoptopenjdk,test_tools` on the `ansible-playbook` command should be enough