### PR TITLE
ansible: Fix Java 9 test cases

### DIFF
--- a/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/roles/Java9/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/roles/Java9/tasks/main.yml
@@ -4,26 +4,26 @@
 ##########
 - name: Test if Java 9 is already installed
   win_stat:
-    path: 'C:\Program Files\Java\jdk-9+181'
+    path: 'C:\Program Files\Java\jdk-9.0.4+11'
   register: java9_installed
   tags: Java9
 
 - name: Check if Java 9 is already downloaded
   win_stat:
-    path: 'C:\temp\jdk-9+181.zip'
+    path: 'C:\temp\jdk-9.0.4+11.zip'
   register: java9_download
   tags: Java9
 
 - name: Download Java 9
   win_get_url:
     url: https://github.com/AdoptOpenJDK/openjdk9-nightly/releases/download/jdk-9%2B181-20180611/OpenJDK9_x64_Win_20180611.zip
-    dest: 'C:\temp\jdk-9+181.zip'
+    dest: 'C:\temp\jdk-9.0.4+11.zip'
   when: (java9_download.stat.exists == false) and (java9_installed.stat.exists == false)
   tags: Java9
 
 - name: Install Java 9
   win_unzip:
-    src: C:\temp\jdk-9+181.zip
+    src: C:\temp\jdk-9.0.4+11.zip
     dest: C:\Program Files\Java
   when: (java9_installed.stat.exists == false)
   tags: Java9


### PR DESCRIPTION
* Change Java 9 download and extracted file name to satisfy the test cases and match symlink functions that were changed in PR #652  

* Test cases work correctly and do not reinstall or download Java if it is already installed or downloaded

* Has been tested on clean VM to verify changes made work

Signed-off-by: HusainYusufali <husainyusufali7@gmail.com>