### PR TITLE
Ansible: Fix and change MSVS 2017 install flags

### DIFF
--- a/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/roles/MSVS_2017/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/roles/MSVS_2017/tasks/main.yml
@@ -18,9 +18,10 @@
   tags: MSVS_2017
 
 - name: Install Visual Studio Community 2017
-  raw: 'C:\TEMP\vs_community.exe /Silent /NoRestart
-        /Log C:\TEMP\vs2017_install_log.txt'
+  win_command: 'C:\temp\vs_community.exe --wait --add Microsoft.VisualStudio.Workload.NativeDesktop;includeRecommended;includeOptional --quiet --norestart'
   when: (vs2017_installed.stat.exists == false)
+  register: vs2017_error
+  failed_when: vs2017_error.rc != 1 and vs2017_error.rc != 0
   tags: MSVS_2017
 
 - name: Register Visual Studio Community 2017 DIA SDK shared libraries


### PR DESCRIPTION
* Changed install flag syntax for Visual Studio 2017
* Install package for [Desktop development with C++](https://docs.microsoft.com/en-us/visualstudio/install/workload-component-id-vs-community?view=vs-2017#desktop-development-with-c) that installs DIA SDK

* During testing after successfully installing VS 2017 the playbook would error out with return code 1.

```
fatal: [test-win-12rt31.fyre.ibm.com]: FAILED! => 
{"changed": true, "cmd": "C:\\temp\\vs_community.exe --wait --add Microsoft.VisualStudio.Workload.NativeDesktop;includeRecommended;includeOptional --quiet --norestart", 
"delta": "0:50:05.466202", "end": "2019-01-09 08:59:17.644974", "msg": "non-zero return code", "rc": 1, 
"start": "2019-01-09 08:09:12.178771", "stderr": "", "stderr_lines": [], "stdout": "
Preparing: C:\\Users\\ADMINI~1\\AppData\\Local\\Temp\\6c0d9a2f5596d39f21e5f6e999\\vs_bootstrapper_d15\\HelpFile\\2052\\help.html...\r\r\n
Preparing: C:\\Users\\ADMINI~1\\AppData\\Local\\Temp\\6c0d9a2f5596d39f21e5f6e999\\vs_bootstrapper_d15\\HelpFile\\1028\\help.html...\r\r\n
Preparing: C:\\Users\\ADMINI~1\\AppData\\Local\\Temp\\6c0d9a2f5596d39f21e5f6e999\\vs_bootstrapper_d15\\HelpFile\\1029\\help.html...\r\r\n
Preparing: C:\\Users\\ADMINI~1\\AppData\\Local\\Temp\\6c0d9a2f5596d39f21e5f6e999\\vs_bootstrapper_d15\\HelpFile\\1031\\help.html...\r\r\n
Preparing: C:\\Users\\ADMINI~1\\AppData\\Local\\Temp\\6c0d9a2…
```

* I tried various methods using other ansible modules like `win_shell` and `raw` which would hang during the installation

* Added an error exception for the installation so that return code 1 is ignored

Signed-off-by: HusainYusufali <husainyusufali7@gmail.com>