### PR TITLE
Ansible: NVidia Toolkit Role, Fix syntax of cleanup task

### DIFF
--- a/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/roles/NVidia_Cuda_Toolkit/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/roles/NVidia_Cuda_Toolkit/tasks/main.yml
@@ -21,7 +21,7 @@
   tags: NVidia_Cuda_Toolkit
 
 - name: Cleanup NVidia CUDA toolkit - Windows 7,8 and Server 2008,2012
-  file:
+  win_file:
     path: C:\temp\cuda_9.0.176_windows_network-exe.exe
     state: absent
   when: (cuda_installed.stat.exists == false) and (ansible_distribution_major_version == "5" or ansible_distribution_major_version == "6")


### PR DESCRIPTION
* Errors were caused due to using `file` module instead of  the `win_file` module

* Testing cleans downloaded files and allows playbooks to pass

Signed-off-by: HusainYusufali <husainyusufali7@gmail.com>