### PR TITLE
Ansible: Installing VS2017 using cmd instead of powershell

### DIFF
--- a/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/roles/MSVS_2017/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/roles/MSVS_2017/tasks/main.yml
@@ -18,7 +18,9 @@
   tags: MSVS_2017
 
 - name: Install Visual Studio Community 2017
-  win_command: 'C:\temp\vs_community.exe --wait --add Microsoft.VisualStudio.Workload.NativeDesktop;includeRecommended;includeOptional --quiet --norestart'
+  win_shell: 'C:\temp\vs_community.exe --wait --add Microsoft.VisualStudio.Workload.NativeDesktop;includeRecommended;includeOptional --quiet --norestart'
+  args:
+    executable: cmd
   when: (vs2017_installed.stat.exists == false)
   register: vs2017_error
   failed_when: vs2017_error.rc != 1 and vs2017_error.rc != 0


### PR DESCRIPTION
- Changing the `win_command` module to `win_shell` in order to use the cmd line instead of powershell
- Still causes an error that needs to be ignored, but no longer hangs indefinitely on the task that install VS 2017 

Signed-off-by: HusainYusufali <husainyusufali7@gmail.com>