### PR TITLE
Ansible: Change the syntax of removing and adding cygwin to PATH

### DIFF
--- a/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/roles/cygwin/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/roles/cygwin/tasks/main.yml
@@ -76,14 +76,23 @@
 
 - name: Remove c:\cygwin64\bin from the path if it exists
   win_path:
+    name: PATH
     elements:
       - 'C:\cygwin64\bin'
+    scope: machine
     state: absent
   tags: cygwin
 
-- name: Add c:\cygwin64\bin to the start of the %PATH%
-  raw: setx PATH "C:\cygwin64\bin;$env:Path" /m
+- name: Add c:\cygwin64\bin to front of %PATH%
+  win_shell: 'setx /M PATH "C:\cygwin64\bin;%PATH%"'
+  args:
+    executable: cmd
   tags:
     - cygwin
     # TODO: write a condition when NOT to run this step
     - skip_ansible_lint
+
+- name: Reboot machine for PATH changes to take effect
+  win_reboot:
+    reboot_timeout: 1800
+  tags: cygwin


### PR DESCRIPTION
* Add the name of the environment variable
* Make sure that the PATH is available on the entire machine's users instead of just the Administrator user
* This change gets rid of an error when the cygwin path portion of the playbook is rerun against a machine

Signed-off-by: HusainYusufali <husainyusufali7@gmail.com>