### PR TITLE
Don't upgrade cmake if it's already at 3.7.2

### DIFF
--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/main.yml
@@ -23,7 +23,7 @@
     - Ant-Contrib                 # Testing
     - GIT_Source
     - CPAN
-    - cmake                       # OpenJ9
+    - cmake                       # OpenJ9 / OpenJFX
     - gmake
     - Docker                      # Testing
     - NVidia_Cuda_Toolkit         # OpenJ9

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/cmake/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/cmake/tasks/main.yml
@@ -31,7 +31,7 @@
     force: no
     validate_certs: no
   when:
-    - (cmake_installed.rc != 0 ) or (cmake_installed.rc == 0 and cmake_version.stdout | version_compare('3.11.4', operator='lt') )
+    - (cmake_installed.rc != 0 ) or (cmake_installed.rc == 0 and cmake_version.stdout | version_compare('3.7.2', operator='lt') )
     - (ansible_architecture == "x86_64") or (ansible_architecture == "ppc64le")
   tags: cmake
 
@@ -41,14 +41,14 @@
     dest: /tmp
     copy: False
   when:
-    - (cmake_installed.rc != 0 ) or (cmake_installed.rc == 0 and cmake_version.stdout | version_compare('3.11.4', operator='lt') )
+    - (cmake_installed.rc != 0 ) or (cmake_installed.rc == 0 and cmake_version.stdout | version_compare('3.7.2', operator='lt') )
     - (ansible_architecture == "x86_64") or (ansible_architecture == "ppc64le")
   tags: cmake
 
 - name: Running ./configure & make for cmake
   shell: cd /tmp/cmake-3.11.4 && ./configure && make -j {{ ansible_processor_vcpus }} && make install
   when:
-    - (cmake_installed.rc != 0 ) or (cmake_installed.rc == 0 and cmake_version.stdout | version_compare('3.11.4', operator='lt') )
+    - (cmake_installed.rc != 0 ) or (cmake_installed.rc == 0 and cmake_version.stdout | version_compare('3.7.2', operator='lt') )
     - (ansible_architecture == "x86_64") or (ansible_architecture == "ppc64le")
   tags: cmake
 


### PR DESCRIPTION
We are installing 3.11.4 for OpenJFX, but that version is a bit of a pain to install on RHEL6.9, therefore we should tolerate having 3.7.2 for now, but install 3.11.4 for now unless it can be proven
that OpenJFX can't be built with 3.7.2.