### PR TITLE
Add hotspot jdk and openj9 parameter to AIX

### DIFF
--- a/ansible/playbooks/adoptopenjdk_variables.yml
+++ b/ansible/playbooks/adoptopenjdk_variables.yml
@@ -13,3 +13,5 @@ Asian_Locales: Disabled
 # Jcktestr User Variables:
 Jcktestr_Username: jcktestr
 Jcktestr_User_SSHKey: /Vendor_Files/keys/keybox.key
+# AIX variable
+bootjdk: openj9

--- a/ansible/playbooks/aix.yml
+++ b/ansible/playbooks/aix.yml
@@ -261,7 +261,7 @@
 
         - name: Transfer and Extract Java8
           unarchive:
-            src: https://api.adoptopenjdk.net/v2/binary/releases/openjdk8?openjdk_impl=openj9&os=aix&arch=ppc64&release=latest&type=jdk
+            src: https://api.adoptopenjdk.net/v2/binary/releases/openjdk8?openjdk_impl={{ bootjdk }}&os=aix&arch=ppc64&release=latest&type=jdk
             dest: /usr/java8_64
             remote_src: yes
           when: java8.stat.isdir is not defined
@@ -284,7 +284,7 @@
 
         - name: Transfer and Extract Java9
           unarchive:
-            src: https://api.adoptopenjdk.net/v2/binary/releases/openjdk9?openjdk_impl=openj9&os=aix&arch=ppc64&release=latest&type=jdk
+            src: https://api.adoptopenjdk.net/v2/binary/releases/openjdk9?openjdk_impl={{ bootjdk }}&os=aix&arch=ppc64&release=latest&type=jdk
             dest: /usr/java9_64
             remote_src: yes
           when: java9.stat.isdir is not defined


### PR DESCRIPTION
- When using the AIX playbook, Java 8 & 9 by default is the hotspot jdk
- If OpenJ9 Java 8 & 9 are to be installed instead of hotspot the extra variable `bootjdk = openj9` must be specified at runtime
- Issue #708 

fyi @jdekonin 
Signed-off-by: HusainYusufali <husainyusufali7@gmail.com>