### PR TITLE
Install Rust in Windows playbook

### DIFF
--- a/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/main.yml
@@ -52,3 +52,4 @@
     - Clang_32bit                 # OpenJ9
     - OpenSSL                     # OpenJ9
     - nasm                        # OpenJ9
+    - Rust                        # IcedTea-Web

--- a/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/roles/Rust/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/roles/Rust/tasks/main.yml
@@ -1,0 +1,31 @@
+---
+#########
+# Rust #
+#########
+
+- name: Test if Rust is already installed
+  win_stat:
+    path: 'C:\Program Files\Rust stable MSVC 1.33\bin\rustc.exe'
+  register: rust_installed
+  tags: Rust
+
+- name: Download Rust installer
+  win_get_url:
+    url: https://static.rust-lang.org/dist/rust-1.33.0-x86_64-pc-windows-msvc.msi
+    dest: 'C:\temp\rust.msi'
+    force: no
+  when: (rust_installed.stat.exists == false)
+  tags: Rust
+
+- name: Install Rust
+  raw: C:\temp\rust.msi /quiet
+  ignore_errors: yes
+  when: (rust_installed.stat.exists == false)
+  tags: Rust
+
+- name: Cleanup Rust
+  win_file:
+    path: C:\temp\rust.msi
+    state: absent
+  ignore_errors: yes
+  tags: Rust


### PR DESCRIPTION
Rust is required to compile IcedTea-Web. The Rust role will
ensure that Rust is installed and on the path.

Signed-off-by: Charlie Gracie <charlie.gracie@gmail.com>