### PR TITLE
Ansible: Remove duplicate jdk11 task on aix

### DIFF
--- a/ansible/playbooks/aix.yml
+++ b/ansible/playbooks/aix.yml
@@ -222,7 +222,7 @@
           ignore_errors: True
 
       ##############
-      # IBM Java 7 #
+      # Boot JDK 7 #
       ##############
         - name: Check for Java7 availability
           stat:
@@ -245,7 +245,7 @@
           tags: java7
 
       ##############
-      # IBM Java 8 #
+      # Boot JDK 8 #
       ##############
         - name: Get java8 path information
           stat:
@@ -268,7 +268,7 @@
           tags: java8
 
       ##############
-      # IBM Java 9 #
+      # Boot JDK 9 #
       ##############
         - name: Check for Java9 availability
           stat:
@@ -291,9 +291,9 @@
           tags: java9
 
 
-      ##############
-      # IBM Java 10 #
-      ##############
+      #################
+      # OpenJ9 JDK 10 #
+      #################
         - name: Check for Java10 availability
           stat:
             path: /usr/java10_64
@@ -314,9 +314,9 @@
           when: java10.stat.isdir is not defined
           tags: java10
 
-        ##############
-        # IBM Java 11 #
-        ##############
+        #################
+        # OpenJ9 JDK 11 #
+        #################
         - name: Check for Java11 availability
           stat:
             path: /usr/java11_64
@@ -336,48 +336,6 @@
             remote_src: yes
           when: java11.stat.isdir is not defined
           tags: java11
-
-      ###############
-      # Boot JDK 11 #
-      ###############
-        - name: Check for Java11 install
-          stat:
-            path: /usr/java11_64
-          register: java11
-          tags: java11
-
-        - debug:
-            msg: "Java11 found, skipping download and installation"
-          when: java11.stat.isdir is defined
-          tags: java11
-
-        - name: Create Java11 directory
-          file:
-            path: /usr/java11_64
-            state: directory
-          when: java11.stat.isdir is not defined
-          tags: java11
-
-        - name: Download and Extract Java11
-          unarchive:
-            src: https://api.adoptopenjdk.net/v2/binary/releases/openjdk11?openjdk_impl=openj9&os=aix&arch=ppc64&release=latest&type=jdk&heap_size=normal
-            dest: /usr/java11_64
-            remote_src: yes
-            extra_opts:
-              - --strip=1
-          when: java11.stat.isdir is not defined
-          tags: java11
-
-        - name: Test Java11
-          command: /usr/java11_64/bin/java -version
-          register: java11_version
-          tags: java11
-
-        - name: Display Java11 version information
-          debug:
-            msg: "{{ java11_version }}"
-          tags: java11
-
 
       #########################################################################
       # Install X11 extensions                                                #


### PR DESCRIPTION
- Removed redundant installation of JDK 11

fyi @jdekonin 
Signed-off-by: HusainYusufali <husainyusufali7@gmail.com>