### PR TITLE
Modify the install location of Rust

### DIFF
--- a/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/roles/Rust/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/roles/Rust/tasks/main.yml
@@ -18,7 +18,7 @@
   tags: Rust
 
 - name: Install Rust
-  raw: C:\temp\rust.msi /quiet
+  raw: msiexec /i C:\temp\rust.msi INSTALLDIR="c:\rust" /quiet
   ignore_errors: yes
   when: (rust_installed.stat.exists == false)
   tags: Rust


### PR DESCRIPTION
The IcedTea-Web makefiles can not handle the default installer
path for Rust. The path appears to not be able to have spaces in
it. This change installs rust in `c:\rust' instead of the default.

Signed-off-by: Charlie Gracie <charlie.gracie@gmail.com>