### PR TITLE
Remove X11 packages from Windows playbook

### DIFF
--- a/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/roles/cygwin/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/roles/cygwin/tasks/main.yml
@@ -50,9 +50,6 @@
     - libpng15
     - libpng-devel
     - perl-Text-CSV
-    - xinit
-    - xorg-server
-    - xterm
   tags: cygwin
 
 ###############################################################################


### PR DESCRIPTION
Signed-off-by: Stewart Addison <sxa@uk.ibm.com>

Spotted the windows playbook trying to install the X11 packages under cygwin (xinit, xorg-server, xterm) but after looking at https://github.com/search?q=org%3AAdoptOpenJDK+xinit&type=Issues and after discussions with @smlambert we cannot see any reason why they are required therefore I am removing them for now. If this turns out to be a mistake, we can re-enable it with a suitable explanatory comment.