### PR TITLE
ansible: handle jdk9 in either jdk-9+191 or jdk-9.0.4 path

### DIFF
--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/adoptopenjdk9/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/adoptopenjdk9/tasks/main.yml
@@ -18,7 +18,7 @@
   tags: adoptopenjdk9
 
 - name: Check if jdk9 is already installed in the target location
-  shell: ls -ld /usr/lib/jvm/jdk-9.* >/dev/null 2>&1
+  shell: ls -ld /usr/lib/jvm/jdk-9* >/dev/null 2>&1
   ignore_errors: yes
   register: adoptopenjdk9_installed
   tags:
@@ -47,7 +47,7 @@
   tags: adoptopenjdk9
 
 - name: Get /usr/lib/jvm/jdk9.* full path name
-  shell: ls -ld /usr/lib/jvm/jdk-9.* 2>/dev/null | awk '{print $9}'
+  shell: ls -ld /usr/lib/jvm/jdk-9* 2>/dev/null | awk '{print $9}'
   register: adoptopenjdk9_dir
   when: adoptopenjdk9_installed.rc != 0
   tags: adoptopenjdk9


### PR DESCRIPTION
Signed-off-by: Stewart Addison <sxa@uk.ibm.com>

Some machines have the adoptopenjdk9 code in `/usr/lib/jvm/jdk-9+191` which is not being correctly by the playbooks which are looking for `/usr/lib/jvm/jdk-9.*` ... We could either replace the `.` with `[.+]` or just trap any case by looking for `jdk-9*` which is what I've done in this PR