### PR TITLE
Ansible: Add bootjdk variable to install hotspot or openj9 on Windows

### DIFF
--- a/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/group_vars/all/adoptopenjdk_variables.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/group_vars/all/adoptopenjdk_variables.yml
@@ -7,4 +7,7 @@ Jenkins_Username: jenkins
 Nagios_Plugins: Disabled
 
 ##### This needs to be set before running ######
-ansible_password: CHANGE_ME
+#ansible_password: CHANGE_ME
+
+### Default JDK ###
+bootjdk: hotspot

--- a/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/main.yml
@@ -20,6 +20,10 @@
 - hosts: "{{ groups['Vendor_groups'] | default('build*win*:test*win*') }}"
   gather_facts: yes
   tasks:
+    - block:
+      # Set standard variables
+        - name: Load AdoptOpenJDKs variable file
+          include_vars: group_vars/all/adoptopenjdk_variables.yml
 
   #########
   # Roles #

--- a/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/roles/Java11/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/roles/Java11/tasks/main.yml
@@ -4,37 +4,44 @@
 ###########
 - name: Test if Java11 is already installed
   win_stat:
-    path: 'C:\Program Files\Java\jdk-11.0.1+13'
+    path: 'C:\openjdk\jdk-11\bin'
   register: java11_installed
   tags: Java11
 
 - name: Check if Java11 is already downloaded
   win_stat:
-    path: 'C:\temp\jdk-11.0.1+13.zip'
+    path: 'C:\temp\jdk-11.zip'
   register: java11_download
   tags: Java11
 
 - name: Download Java11
   win_get_url:
-    url: https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-11.0.1%2B13/OpenJDK11U-jdk_x64_windows_hotspot_11.0.1_13.zip
-    dest: 'C:\temp\jdk-11.0.1+13.zip'
+    url: https://api.adoptopenjdk.net/v2/binary/releases/openjdk11?openjdk_impl={{ bootjdk }}&os=windows&arch=x64&release=latest&type=jdk
+    dest: 'C:\temp\jdk-11.zip'
   when: (java11_download.stat.exists == false) and (java11_installed.stat.exists == false)
   tags: Java11
 
 - name: Install Java11
   win_unzip:
-    src: C:\temp\jdk-11.0.1+13.zip
+    src: C:\temp\jdk-11.zip
     dest: C:\Program Files\Java
   when: (java11_installed.stat.exists == false)
   tags: Java11
 
 - name: Test if Java11 symlink is already created
   win_stat:
-    path: 'C:\openjdk\jdk11'
+    path: 'C:\openjdk\jdk-11'
   register: java11_symlink
   tags: Java11
 
-- name: Create symlink to Java11
-  raw: cmd /c mklink /D "C:\openjdk\jdk11" "C:\Program Files\Java\jdk-11.0.1+13"
+- name: Get Java 11 Folder name to create symlink
+  win_shell: powershell ([Environment]::SetEnvironmentVariable("Java11_Folder", (Get-ChildItem -Path 'C:\Program Files\Java\jdk-11*' | Select-String -Pattern 'C*'), "Machine"))
+  when: (java11_symlink.stat.exists == false)
+  tags: Java11
+
+- name: Create symlink to Java 11
+  win_shell: New-Item -Path 'C:\openjdk\jdk-11' -ItemType SymbolicLink -Value ([Environment]::GetEnvironmentVariable("Java11_Folder", "Machine"))
+  args:
+    executable: powershell
   when: (java11_symlink.stat.exists == false)
   tags: Java11

--- a/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/roles/Java8/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/roles/Java8/tasks/main.yml
@@ -4,46 +4,52 @@
 ##########
 - name: Test if Java 8 is already installed
   win_stat:
-    path: 'C:\Program Files\Java\jdk8u172-b11'
+    path: 'C:\openjdk\jdk-8\bin'
   register: java8_installed
   tags: Java8
 
 - name: Check if Java 8 is already downloaded
   win_stat:
-    path: 'C:\temp\jdk8u172-b11.zip'
+    path: 'C:\temp\jdk-8.zip'
   register: java8_download
   tags: Java8
 
 - name: Download Java 8
   win_get_url:
-    url: https://github.com/AdoptOpenJDK/openjdk8-releases/releases/download/jdk8u172-b11/OpenJDK8_x64_Win_jdk8u172-b11.zip
-    dest: 'C:\temp\jdk8u172-b11.zip'
+    url: https://api.adoptopenjdk.net/v2/binary/releases/openjdk8?openjdk_impl={{ bootjdk }}&os=windows&arch=x64&release=latest&type=jdk
+    dest: 'C:\temp\jdk-8.zip'
   when: (java8_download.stat.exists == false) and (java8_installed.stat.exists == false)
   tags: Java8
 
 - name: Install Java 8
   win_unzip:
-    src: C:\temp\jdk8u172-b11.zip
+    src: C:\temp\jdk-8.zip
     dest: C:\Program Files\Java
   when: (java8_installed.stat.exists == false)
   tags: Java8
 
 - name: Test if Java 8 symlink is already created
   win_stat:
-    path: 'C:\openjdk\jdk8'
+    path: 'C:\openjdk\jdk-8'
   register: java8_symlink
   tags: Java8
 
+- name: Get Java 8 Folder name to create symlink
+  win_shell: powershell ([Environment]::SetEnvironmentVariable("Java8_Folder", (Get-ChildItem -Path 'C:\Program Files\Java\jdk8*' | Select-String -Pattern 'C*'), "Machine"))
+  when: (java8_symlink.stat.exists == false)
+  tags: Java8
+
 - name: Create symlink to Java 8
-  raw: cmd /c mklink /D "C:\openjdk\jdk8" "C:\Program Files\Java\jdk8u172-b11"
+  win_shell: New-Item -Path 'C:\openjdk\jdk-8' -ItemType SymbolicLink -Value ([Environment]::GetEnvironmentVariable("Java8_Folder", "Machine"))
+  args:
+    executable: powershell
   when: (java8_symlink.stat.exists == false)
   tags: Java8
 
 - name: Set JAVA_HOME to version 8
   win_path:
     name: JAVA_HOME
-    elements:
-      - 'C:\Program Files\Java\jdk8u172-b11'
+    elements: C:\openjdk\jdk-8
     scope: machine
     state: present
   when: (java8_installed.stat.exists == false)
@@ -52,8 +58,8 @@
 - name: Add JAVA_HOME/bin to Path
   win_path:
     name: Path
-    elements:
-      - 'C:\Program Files\Java\jdk8u172-b11\bin'
+    elements: C:\openjdk\jdk-8\bin
     scope: machine
     state: present
+  when: (java8_installed.stat.exists == false)
   tags: Java8

--- a/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/roles/Java9/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/roles/Java9/tasks/main.yml
@@ -4,37 +4,44 @@
 ##########
 - name: Test if Java 9 is already installed
   win_stat:
-    path: 'C:\Program Files\Java\jdk-9.0.4+11'
+    path: 'C:\openjdk\jdk-9\bin'
   register: java9_installed
   tags: Java9
 
 - name: Check if Java 9 is already downloaded
   win_stat:
-    path: 'C:\temp\jdk-9.0.4+11.zip'
+    path: 'C:\temp\jdk-9.zip'
   register: java9_download
   tags: Java9
 
 - name: Download Java 9
   win_get_url:
-    url: https://github.com/AdoptOpenJDK/openjdk9-nightly/releases/download/jdk-9%2B181-20180611/OpenJDK9_x64_Win_20180611.zip
-    dest: 'C:\temp\jdk-9.0.4+11.zip'
+    url: https://api.adoptopenjdk.net/v2/binary/releases/openjdk9?openjdk_impl={{ bootjdk }}&os=windows&arch=x64&release=latest&type=jdk
+    dest: 'C:\temp\jdk-9.zip'
   when: (java9_download.stat.exists == false) and (java9_installed.stat.exists == false)
   tags: Java9
 
 - name: Install Java 9
   win_unzip:
-    src: C:\temp\jdk-9.0.4+11.zip
+    src: C:\temp\jdk-9.zip
     dest: C:\Program Files\Java
   when: (java9_installed.stat.exists == false)
   tags: Java9
 
 - name: Test if Java 9 symlink is already created
   win_stat:
-    path: 'C:\openjdk\jdk9'
+    path: 'C:\openjdk\jdk-9'
   register: java9_symlink
   tags: Java9
 
+- name: Get Java 9 Folder name to create symlink
+  win_shell: powershell ([Environment]::SetEnvironmentVariable("Java9_Folder", (Get-ChildItem -Path 'C:\Program Files\Java\jdk-9*' | Select-String -Pattern 'C*'), "Machine"))
+  when: (java9_symlink.stat.exists == false)
+  tags: Java9
+
 - name: Create symlink to Java 9
-  raw: cmd /c mklink /D "C:\openjdk\jdk9" "C:\Program Files\Java\jdk-9.0.4+11"
+  win_shell: New-Item -Path 'C:\openjdk\jdk-9' -ItemType SymbolicLink -Value ([Environment]::GetEnvironmentVariable("Java9_Folder", "Machine"))
+  args:
+    executable: powershell
   when: (java9_symlink.stat.exists == false)
   tags: Java9


### PR DESCRIPTION
This pull request fixes issue #715 

* Add bootjdk variable to adoptopenjdk_variables.yml

* Load adoptopenjdk_variables.yml into the main.yml file

* Change hard link to API when downloading Windows JDK

* API downloads the latest Windows hotspot or openj9 jdk for Java[8,9,11]

* Remove versions from test cases and zip files as they can change across playbook deployments

* Powershell commands that create persistent environment variable of Java folder that is installed

* Create symlink using environment variable

* NOTE: win_shell module acts differently when creating environmental variable vs creating a symlink

fyi @jdekonin 