### PR TITLE
Ansible: Change lib install location for freetype 32 bit on Windows

### DIFF
--- a/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/roles/Freetype/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/roles/Freetype/tasks/main.yml
@@ -42,7 +42,7 @@
 
 - name: Check if freetype 32bit has been built
   win_stat:
-    path: 'C:\openjdk\freetype-2.5.3\lib32'
+    path: 'C:\openjdk\freetype-2.5.3\lib'
   register: freetype32_built
   tags: Freetype
 
@@ -53,7 +53,7 @@
   tags: Freetype
 
 - name: Build freetype-2.5.3 32bit
-  win_shell: .\vcvarsall.bat && msbuild.exe C:/openjdk/freetype-2.5.3/builds/windows/vc2010/freetype.vcxproj /p:PlatformToolset=v100 /p:Configuration="Release Multithreaded" /p:PlatformTarget=x86 /p:ConfigurationType=DynamicLibrary /p:TargetName=freetype /p:OutDir="C:/openjdk/freetype-2.5.3/lib32/" /p:IntDir="C:/openjdk/freetype-2.5.3/obj32/" > C:/temp/freetype32.log && msbuild.exe C:/openjdk/freetype-2.5.3/builds/windows/vc2010/freetype.vcxproj /p:PlatformToolset=v100 /p:Configuration="Release Multithreaded" /p:PlatformTarget=x86 /p:ConfigurationType=StaticLibrary /p:TargetName=freetype /p:OutDir="C:/openjdk/freetype-2.5.3/lib32/" /p:IntDir="C:/openjdk/freetype-2.5.3/obj32/" >> C:/temp/freetype32.log
+  win_shell: .\vcvarsall.bat && msbuild.exe C:/openjdk/freetype-2.5.3/builds/windows/vc2010/freetype.vcxproj /p:PlatformToolset=v100 /p:Configuration="Release Multithreaded" /p:PlatformTarget=x86 /p:ConfigurationType=DynamicLibrary /p:TargetName=freetype /p:OutDir="C:/openjdk/freetype-2.5.3/lib/" /p:IntDir="C:/openjdk/freetype-2.5.3/obj32/" > C:/temp/freetype32.log && msbuild.exe C:/openjdk/freetype-2.5.3/builds/windows/vc2010/freetype.vcxproj /p:PlatformToolset=v100 /p:Configuration="Release Multithreaded" /p:PlatformTarget=x86 /p:ConfigurationType=StaticLibrary /p:TargetName=freetype /p:OutDir="C:/openjdk/freetype-2.5.3/lib/" /p:IntDir="C:/openjdk/freetype-2.5.3/obj32/" >> C:/temp/freetype32.log
   args:
     chdir: 'C:\Program Files (x86)\Microsoft Visual Studio 10.0\VC'
     executable: C:\Windows\system32\cmd.exe


### PR DESCRIPTION
* create a symlink to point `/cygdrive/c/openjdk/freetype-2.5.3/lib` to `/cygdrive/c/openjdk/freetype-2.5.3/lib32`

* symlink was created because `/cygdrive/c/openjdk/freetype-2.5.3/lib` is the freetype location for 32-bit builds in windows build scripts

Fixes issue #747 
fyi @sxa555 

Signed-off-by: HusainYusufali <husainyusufali7@gmail.com>