### PR TITLE
Ansible: Stop playbook failing on adoptopenjdk9 role on arm32

### DIFF
--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/adoptopenjdk9/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/adoptopenjdk9/tasks/main.yml
@@ -49,7 +49,9 @@
 - name: Get /usr/lib/jvm/jdk9.* full path name
   shell: ls -ld /usr/lib/jvm/jdk-9* 2>/dev/null | awk '{print $9}'
   register: adoptopenjdk9_dir
-  when: adoptopenjdk9_installed.rc != 0
+  when:
+    - adoptopenjdk9_installed.rc != 0
+    - ansible_architecture != "armv7l"
   tags: adoptopenjdk9
 
 - name: Chown /usr/lib/jvm/jdk9.*
@@ -59,5 +61,7 @@
     owner: root
     group: root
     recurse: yes
-  when: adoptopenjdk9_installed.rc != 0
+  when:
+    - adoptopenjdk9_installed.rc != 0
+    - ansible_architecture != "armv7l"
   tags: adoptopenjdk9


### PR DESCRIPTION
We don't have an arm32 JDK9 available to download, therefore this will stop the playbook aborting when it can't access the directory it expects to find it.

Without it, this is the failure:

```
TASK [adoptopenjdk9 : Check if jdk9 is already installed in the target location] ***
19:18:14
fatal: [build-scaleway-ubuntu1604-armv7-2]: FAILED! => {"changed": true, "cmd": "ls -ld /usr/lib/jvm/jdk-9* >/dev/null 2>&1", "delta": "0:00:00.028071", "end": "2019-04-02 18:18:15.722551", "failed": true, "msg": "non-zero return code", "rc": 2, "start": "2019-04-02 18:18:15.694480", "stderr": "", "stderr_lines": [], "stdout": "", "stdout_lines": []}
...ignoring
TASK [adoptopenjdk9 : Install latest release if one not already installed] *****
19:18:15
skipping: [build-scaleway-ubuntu1604-armv7-2]
TASK [adoptopenjdk9 : Install latest release if one not already installed] *****
19:18:16
skipping: [build-scaleway-ubuntu1604-armv7-2]
TASK [adoptopenjdk9 : Get /usr/lib/jvm/jdk9.* full path name] ******************
19:18:16
changed: [build-scaleway-ubuntu1604-armv7-2]
TASK [adoptopenjdk9 : Chown /usr/lib/jvm/jdk9.*] *******************************
19:18:17
fatal: [build-scaleway-ubuntu1604-armv7-2]: FAILED! => {"changed": false, "failed": true, "msg": "There was an issue creating  as requested: [Errno 2] No such file or directory: ''", "path": "", "state": "absent"}
PLAY RECAP *********************************************************************
19:18:19
build-scaleway-ubuntu1604-armv7-2 : ok=74   changed=39   unreachable=0    failed=1   
```

Signed-off-by: Stewart Addison <sxa@uk.ibm.com>