### PR TITLE
Remove version_compare deprecation warnings from UNIX Playbooks

### DIFF
--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/GIT_Source/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/GIT_Source/tasks/main.yml
@@ -32,7 +32,7 @@
     dest: /tmp/git-2.15.0.tar.xz
     mode: 0440
   when:
-    - (git_installed.rc != 0 ) or (git_installed.rc == 0 and git_version.stdout | version_compare('2.15', operator='lt') )
+    - (git_installed.rc != 0 ) or (git_installed.rc == 0 and git_version.stdout is version_compare('2.15', operator='lt') )
     - ansible_distribution != "FreeBSD"
   tags: git_source
 
@@ -42,7 +42,7 @@
     dest: /tmp/
     copy: False
   when:
-    - (git_installed.rc != 0 ) or (git_installed.rc == 0 and git_version.stdout | version_compare('2.15', operator='lt') )
+    - (git_installed.rc != 0 ) or (git_installed.rc == 0 and git_version.stdout is version_compare('2.15', operator='lt') )
     - ansible_distribution != "FreeBSD"
   tags: git_source
 
@@ -58,7 +58,7 @@
   shell: cd /tmp/git-2.15.0 && ./configure --with-curl=/usr/local/curl-7.61.1 --prefix=/usr/local --without-tcltk && make clean && make -j {{ ansible_processor_vcpus }} && sudo make install
   become: yes
   when:
-    - (git_installed.rc != 0 ) or (git_installed.rc == 0 and git_version.stdout | version_compare('2.15', operator='lt') )
+    - (git_installed.rc != 0 ) or (git_installed.rc == 0 and git_version.stdout is version_compare('2.15', operator='lt') )
     - ansible_architecture != "s390x"
     - (( ansible_distribution == "RedHat" or ansible_distribution == "CentOS") and ansible_distribution_major_version == "6")
   tags: git_source
@@ -67,7 +67,7 @@
   shell: cd /tmp/git-2.15.0 && ./configure --prefix=/usr/local --without-tcltk && make clean && make -j {{ ansible_processor_vcpus }} && sudo make install
   become: yes
   when:
-    - (git_installed.rc != 0 ) or (git_installed.rc == 0 and git_version.stdout | version_compare('2.15', operator='lt') )
+    - (git_installed.rc != 0 ) or (git_installed.rc == 0 and git_version.stdout is version_compare('2.15', operator='lt') )
     - ansible_architecture != "s390x"
     - ansible_distribution != "FreeBSD"
     - ! (( ansible_distribution == "RedHat" or ansible_distribution == "CentOS") and ansible_distribution_major_version == "6")
@@ -77,7 +77,7 @@
   shell: cd /tmp/git-2.15.0 && ./configure --prefix=/usr/local --without-tcltk && make -j {{ ansible_processor_cores }} && sudo make install
   become: yes
   when:
-    - (git_installed.rc != 0 ) or (git_installed.rc == 0 and git_version.stdout | version_compare('2.15', operator='lt') )
+    - (git_installed.rc != 0 ) or (git_installed.rc == 0 and git_version.stdout is version_compare('2.15', operator='lt') )
     - ansible_architecture == "s390x"
     - ansible_distribution != "FreeBSD"
   tags: git_source
@@ -89,7 +89,7 @@
       - perl-Git
     state: absent
   when:
-    - (git_installed.rc != 0 ) or (git_installed.rc == 0 and git_version.stdout | version_compare('2.15', operator='lt') )
+    - (git_installed.rc != 0 ) or (git_installed.rc == 0 and git_version.stdout is version_compare('2.15', operator='lt') )
     - ansible_distribution == "CentOS" or ansible_distribution == "RedHat"
   tags:
     - git_source
@@ -100,7 +100,7 @@
     name: git
     state: absent
   when:
-    - (git_installed.rc != 0 ) or (git_installed.rc == 0 and git_version.stdout | version_compare('2.15', operator='lt') )
+    - (git_installed.rc != 0 ) or (git_installed.rc == 0 and git_version.stdout is version_compare('2.15', operator='lt') )
     - ansible_distribution == "SLES"
   tags:
     - git_source

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Version/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Version/tasks/main.yml
@@ -5,5 +5,5 @@
 - name: Verify if Ansible version is 2.4 or above
   assert:
     that:
-      - "{{ ansible_version.string | version_compare('2.4', '>=') }}"
+      - "{{ ansible_version.string is version_compare('2.4', '>=') }}"
     msg: "Ansible 2.4 or above is required"

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/curl/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/curl/tasks/main.yml
@@ -28,7 +28,7 @@
     timeout: 25
     validate_certs: no
   when:
-    - ((curl_version.stdout == '') or ((curl_version.stdout != '') and (curl_version.stdout | version_compare('7.20.0', operator='lt', strict=True))))
+    - ((curl_version.stdout == '') or ((curl_version.stdout != '') and (curl_version.stdout is version_compare('7.20.0', operator='lt', strict=True))))
   tags: curl
 
 - name: Extract curl
@@ -37,13 +37,13 @@
     dest: /tmp/
     copy: False
   when:
-    - ((curl_version.stdout == '') or ((curl_version.stdout != '') and (curl_version.stdout | version_compare('7.20.0', operator='lt', strict=True))))
+    - ((curl_version.stdout == '') or ((curl_version.stdout != '') and (curl_version.stdout is version_compare('7.20.0', operator='lt', strict=True))))
   tags: curl
 
 - name: Build and install curl {{ curl_latest }} in /usr/local
   shell: cd /tmp/curl-{{ curl_latest }} && ./configure --prefix=/usr/local/curl-{{ curl_latest }} && make && make install
   when:
-    - ((curl_version.stdout == '') or ((curl_version.stdout != '') and (curl_version.stdout | version_compare('7.20.0', operator='lt', strict=True))))
+    - ((curl_version.stdout == '') or ((curl_version.stdout != '') and (curl_version.stdout is version_compare('7.20.0', operator='lt', strict=True))))
   tags: curl
 
 - name: Create /usr/local/bin/curl symlink
@@ -54,7 +54,7 @@
     group: root
     state: link
   when:
-    - ((curl_version.stdout == '') or ((curl_version.stdout != '') and (curl_version.stdout | version_compare('7.20.0', operator='lt', strict=True))))
+    - ((curl_version.stdout == '') or ((curl_version.stdout != '') and (curl_version.stdout is version_compare('7.20.0', operator='lt', strict=True))))
   tags: curl
 
 - name: Remove downloaded packages for curl {{ curl_latest }}
@@ -66,5 +66,5 @@
     - /tmp/curl-{{ curl_latest }}
   ignore_errors: yes
   when:
-    - ((curl_version.stdout == '') or ((curl_version.stdout != '') and (curl_version.stdout | version_compare('7.20.0', operator='lt', strict=True))))
+    - ((curl_version.stdout == '') or ((curl_version.stdout != '') and (curl_version.stdout is version_compare('7.20.0', operator='lt', strict=True))))
   tags: curl


### PR DESCRIPTION
ansible 2.5.1 (included in Ubuntu 18.04) throws the following warnings at various steps. This PR will remove those warnings:

`[DEPRECATION WARNING]: Using tests as filters is deprecated. Instead of using 'result|version_compare' instead use 'result is version_compare'. This feature will be removed in version 2.9.`

~~Need to validate that our AWX server is using a version of ansible that won't object to this - the [ansible 2.4 docs](https://docs.ansible.com/ansible) (we test for that as a minimum) does show the old format:~~ EDIT: Our AWX uses 2.4.3.0 and it works with the updated syntax so this change should be safe.

Signed-off-by: Stewart Addison <sxa@uk.ibm.com>