### PR TITLE
Add OpenSSL 1.0.2 prereq on CentOS/RHEL6 for OpenJ9

### DIFF
--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/main.yml
@@ -51,6 +51,7 @@
       when:
         - (ansible_distribution == "RedHat" or ansible_distribution == "CentOS" or ansible_distribution == "Ubuntu" or ansible_distribution == "SLES")
         - ansible_architecture == "x86_64"
+    - OpenSSL102                  # OpenJ9
     - Nagios_Plugins              # AdoptOpenJDK Infrastructure
     - Nagios_Master_Config        # AdoptOpenJDK Infrastructure
     - Nagios_Tunnel               # AdoptOpenJDK Infrastructure

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/OpenSSL102/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/OpenSSL102/tasks/main.yml
@@ -1,0 +1,58 @@
+---
+###################################################
+# OpenSSL v1.0.2r for building OpenJ9 on CentOS 6 #
+###################################################
+
+- name: Test if OpenSSL v1.0.2r is installed
+  shell: export LD_LIBRARY_PATH=/usr/local/openssl-1.0.2/lib &&  /usr/local/openssl-1.0.2/bin/openssl version | awk '{print $2}' | cut -c 1-5
+  when:
+    - (ansible_distribution == "RedHat" or ansible_distribution == "CentOS")
+    - ansible_distribution_major_version == "6"
+  register: openssl_version
+  tags: openssl
+
+- name: Download OpenSSL v1.0.2r
+  get_url:
+    url: https://www.openssl.org/source/openssl-1.0.2r.tar.gz
+    dest: /tmp/openssl-1.0.2r.tar.gz
+    force: no
+    mode: 0755
+    validate_certs: no
+  when:
+    - (ansible_distribution == "RedHat" or ansible_distribution == "CentOS")
+    - ansible_distribution_major_version == "6"
+    - ((openssl_version.stdout == '') or ((openssl_version.stdout != '') and (openssl_version.stdout | version_compare('1.0.2', operator='lt', strict=True))))
+  tags: openssl
+
+- name: Extract OpenSSL v1.0.2r
+  unarchive:
+    src: /tmp/openssl-1.0.2r.tar.gz
+    dest: /tmp
+    copy: False
+  when:
+    - (ansible_distribution == "RedHat" or ansible_distribution == "CentOS")
+    - ansible_distribution_major_version == "6"
+    - ((openssl_version.stdout == '') or ((openssl_version.stdout != '') and (openssl_version.stdout | version_compare('1.0.2', operator='lt', strict=True))))
+  tags: openssl
+
+- name: Build and install OpenSSL v1.0.2r
+  shell: cd /tmp/openssl-1.0.2r && ./config --prefix=/usr/local/openssl-1.0.2 shared && make && make install
+  when:
+    - (ansible_distribution == "RedHat" or ansible_distribution == "CentOS")
+    - ansible_distribution_major_version == "6"
+    - ((openssl_version.stdout == '') or ((openssl_version.stdout != '') and (openssl_version.stdout | version_compare('1.0.2', operator='lt', strict=True))))
+  tags: openssl
+
+- name: Remove downloaded packages for OpenSSL v1.0.2r
+  file:
+    path: "{{ item }}"
+    state: absent
+  with_items:
+    - /tmp/openssl-1.0.2r.tar.gz
+    - /tmp/openssl-1.0.2r
+  ignore_errors: yes
+  when:
+    - (ansible_distribution == "RedHat" or ansible_distribution == "CentOS")
+    - ansible_distribution_major_version == "6"
+    - ((openssl_version.stdout == '') or ((openssl_version.stdout != '') and (openssl_version.stdout | version_compare('1.0.2', operator='lt', strict=True))))
+  tags: openssl


### PR DESCRIPTION
This can be downloaded live, but I'd rather have it cached. CentOS6 (used on x64 for building) has openssl 1.0.1 which cannot be used by OpenJ9.
Separate PR in to the build repository to start using this https://github.com/AdoptOpenJDK/openjdk-build/pull/1023