### PR TITLE
Revert "Remove freetype from windows playbook (#766)"

### DIFF
--- a/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/main.yml
@@ -39,7 +39,6 @@
     - Firefox
     - Strawberry_Perl             # Testing
     - Freemarker                  # OpenJ9
-    - Freetype
     - cmake                       # OpenJ9
     - GIT
     - Java7                       # JDK8 build bootstrap

--- a/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/main.yml
@@ -39,6 +39,7 @@
     - Firefox
     - Strawberry_Perl             # Testing
     - Freemarker                  # OpenJ9
+    - Freetype
     - cmake                       # OpenJ9
     - GIT
     - Java7                       # JDK8 build bootstrap

--- a/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/roles/Freetype/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/roles/Freetype/tasks/main.yml
@@ -1,0 +1,69 @@
+---
+###################
+# freetype v2.5.3 #
+###################
+
+- name: Test if freetype is already installed
+  win_stat:
+    path: 'C:\openjdk\freetype-2.5.3'
+  register: freetype_installed
+  tags: Freetype
+
+- name: Test if freetype is already downloaded
+  win_stat:
+    path: 'C:\temp\ft253.zip'
+  register: freetype_download
+  tags: Freetype
+
+- name: Download freetype 2.5.3
+  win_get_url:
+    url: https://sourceforge.net/projects/freetype/files/freetype2/2.5.3/ft253.zip/download
+    dest: C:\temp\ft253.zip
+  when: (freetype_installed.stat.exists == false) and (freetype_download.stat.exists == false)
+  tags: Freetype
+
+- name: Unpack freetype
+  win_unzip:
+    src: C:\temp\ft253.zip
+    dest: C:\openjdk
+    delete_archive: yes
+  when: (freetype_installed.stat.exists == false) and (freetype_download.stat.exists == false)
+  tags: Freetype
+
+- name: Add modify, write permissions for jenkins user
+  win_acl:
+    path: C:\openjdk\freetype-2.5.3
+    user: "{{ Jenkins_Username }}"
+    rights: Read,Write,Modify,FullControl,Delete
+    type: allow
+    state: present
+  when: (freetype_installed.stat.exists == false)
+  tags: Freetype
+
+- name: Check if freetype 32bit has been built
+  win_stat:
+    path: 'C:\openjdk\freetype-2.5.3\lib32'
+  register: freetype32_built
+  tags: Freetype
+
+- name: Check if freetype 64bit has been built
+  win_stat:
+    path: 'C:\openjdk\freetype-2.5.3\lib64'
+  register: freetype64_built
+  tags: Freetype
+
+- name: Build freetype-2.5.3 32bit
+  win_shell: .\vcvarsall.bat && msbuild.exe C:/openjdk/freetype-2.5.3/builds/windows/vc2010/freetype.vcxproj /p:PlatformToolset=v100 /p:Configuration="Release Multithreaded" /p:PlatformTarget=x86 /p:ConfigurationType=DynamicLibrary /p:TargetName=freetype /p:OutDir="C:/openjdk/freetype-2.5.3/lib32/" /p:IntDir="C:/openjdk/freetype-2.5.3/obj32/" > C:/temp/freetype32.log && msbuild.exe C:/openjdk/freetype-2.5.3/builds/windows/vc2010/freetype.vcxproj /p:PlatformToolset=v100 /p:Configuration="Release Multithreaded" /p:PlatformTarget=x86 /p:ConfigurationType=StaticLibrary /p:TargetName=freetype /p:OutDir="C:/openjdk/freetype-2.5.3/lib32/" /p:IntDir="C:/openjdk/freetype-2.5.3/obj32/" >> C:/temp/freetype32.log
+  args:
+    chdir: 'C:\Program Files (x86)\Microsoft Visual Studio 10.0\VC'
+    executable: C:\Windows\system32\cmd.exe
+  when: (freetype32_built.stat.exists == false)
+  tags: Freetype
+
+- name: Build freetype-2.5.3 64bit
+  win_shell: .\vcvarsall.bat && msbuild.exe C:/openjdk/freetype-2.5.3/builds/windows/vc2010/freetype.vcxproj /p:PlatformToolset=v100 /p:Configuration="Release Multithreaded" /p:Platform=x64 /p:ConfigurationType=DynamicLibrary /p:TargetName=freetype /p:OutDir="C:/openjdk/freetype-2.5.3/lib64/" /p:IntDir="C:/openjdk/freetype-2.5.3/obj64/" > C:/temp/freetype64.log && msbuild.exe C:/openjdk/freetype-2.5.3/builds/windows/vc2010/freetype.vcxproj /p:PlatformToolset=v100 /p:Configuration="Release Multithreaded" /p:Platform=x64 /p:ConfigurationType=StaticLibrary /p:TargetName=freetype /p:OutDir="C:/openjdk/freetype-2.5.3/lib64/" /p:IntDir="C:/openjdk/freetype-2.5.3/obj64/" >> C:/temp/freetype64.log
+  args:
+    chdir: 'C:\Program Files (x86)\Microsoft Visual Studio 10.0\VC'
+    executable: C:\Windows\system32\cmd.exe
+  when: (freetype64_built.stat.exists == false)
+  tags: Freetype


### PR DESCRIPTION
This reverts commit 0628f935dccbc37a2ffdde135ec5222ce43b1828.

@jdekonin @karianna this PR reverts #766. 

Is it ok if we remove `freetype` from `main.yml` but leave the role definition?