### PR TITLE
[WIP] Bump ansible-lint to v4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ install:
   # Install ansible
   - pip install ansible
   - pip install yamllint==1.13.0
-  - pip install ansible-lint==3.5.1
+  - pip install ansible-lint==4.1.0
 
   # Check ansible version
   - ansible --version


### PR DESCRIPTION
This initial PR bumps ansible-lint to version 4. This change alone will break the build, but I will leave this open and add fixes for the new default rules piecemeal.