### PR TITLE
Fix problem setting PATH with erroneous quote in SQLServer path

### DIFF
--- a/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/roles/cygwin/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/roles/cygwin/tasks/main.yml
@@ -80,8 +80,10 @@
     state: absent
   tags: cygwin
 
+# NOTE: This construct is because an SQL Server entry is being added to
+# the path which has an erroneous quote in it which causes problems for SETX
 - name: Add c:\cygwin64\bin to front of %PATH%
-  win_shell: 'setx /M PATH "C:\cygwin64\bin;%PATH%"'
+  win_shell: 'setx /M PATH "C:\cygwin64\bin;%PATH:\"=%"'
   args:
     executable: cmd
   tags:


### PR DESCRIPTION
This should fix the issue caused by the entry with an erroneous `"` mark in the SQL Server PATH that causes `SETX` to get very confused resulting in this error:

```
TASK [cygwin : Add c:\cygwin64\bin to front of %PATH%] *************************
fatal: [40.121.164.56]: FAILED! => {"changed": true, "cmd": "setx /M PATH \"C:\\cygwin64\\bin;%PATH%\"", "delta": "0:00:00.125003", "end": "2019-05-28 03:32:41.392060", "msg": "non-zero return code", "rc": 1, "start": "2019-05-28 03:32:41.267057", "stderr": "ERROR: Invalid syntax. Default option is not allowed more than '2' time(s).\r\nType \"SETX /?\" for usage.\r\n", "stderr_lines": ["ERROR: Invalid syntax. Default option is not allowed more than '2' time(s).", "Type \"SETX /?\" for usage."], "stdout": "", "stdout_lines": []}
	to retry, use: --limit @/root/openjdk-infrastructure/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/main.retry
```

Signed-off-by: Stewart Addison <sxa@uk.ibm.com>