### PR TITLE
Add expat_devel on RHEL/CentOS (dep of CPAN XML::Parser)

### DIFF
--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/vars/CentOS.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/vars/CentOS.yml
@@ -13,6 +13,7 @@ Build_Tool_Packages:
   - cpio
   - cups-devel
   - elfutils-libelf-devel
+  - expat-devel                   # Used for buiding the XML::Parser CPAN module
   - flex                          # OpenJ9
   - fontconfig-devel
   - freetype-devel

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/vars/RedHat.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/vars/RedHat.yml
@@ -13,6 +13,7 @@ Build_Tool_Packages:
   - cpio
   - cups-devel
   - elfutils-libelf-devel
+  - expat-devel                   # Used for buiding the XML::Parser CPAN module
   - flex                          # OpenJ9
   - fontconfig-devel
   - freetype-devel


### PR DESCRIPTION
Signed-off-by: Stewart Addison <sxa@uk.ibm.com>

Without this extra dependency the `XML::Parser` role fails as it cannot locate the `expat.h` header file