### PR TITLE
Add download_prerequisites to RHEL6/GCC48 build

### DIFF
--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/gcc_48/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/gcc_48/tasks/main.yml
@@ -38,7 +38,7 @@
   tags: gcc-4.8
 
 - name: Running configure, compile and install for gcc-4.8.5
-  shell: cd /tmp/gcc-4.8.5 && ./configure --prefix=/opt/gcc-4.8.5 && make -j {{ ansible_processor_vcpus }} && make install
+  shell: cd /tmp/gcc-4.8.5 && contrib/download_prerequisites && ./configure --prefix=/opt/gcc-4.8.5 && make -j {{ ansible_processor_vcpus }} && make install
   when:
     - gcc_installed.rc != 0
     - ansible_distribution == "RedHat"


### PR DESCRIPTION
Signed-off-by: Stewart Addison <sxa@uk.ibm.com>

Build is missing a step. Surprised this wasn't spotted previously but I guess few people are using RHEL6 :-)