### PR TITLE
Fix variable name for Ubuntu/s390x build tools

### DIFF
--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/tasks/Ubuntu.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/tasks/Ubuntu.yml
@@ -86,9 +86,9 @@
     - ansible_architecture == "ppc64le"
   tags: build_tools
 
-- name: Install additional build tools for S390
+- name: Install additional build tools for S390x
   package: "name={{ item }} state=latest"
-  with_items: "{{ Additional_Build_Tools_s390 }}"
+  with_items: "{{ Additional_Build_Tools_s390x }}"
   when:
     - ansible_architecture == "s390x"
   tags: build_tools


### PR DESCRIPTION
Variable name in the task doesn't match the definition

Signed-off-by: Stewart Addison <sxa@uk.ibm.com>