### PR TITLE
Set C/C++ flags for Protobuf

### DIFF
--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Protobuf/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Protobuf/tasks/main.yml
@@ -64,7 +64,7 @@
   tags: protobuf
 
 - name: Build and install Protocol Buffers v3.5.1
-  shell: cd /tmp/protobuf-3.5.1 && ./configure && make && make install && ldconfig
+  shell: cd /tmp/protobuf-3.5.1 && ./configure CFLAGS=-fPIC CXXFLAGS=-fPIC && make && make install && ldconfig
   when:
     - (ansible_distribution == "RedHat" or ansible_distribution == "CentOS" or ansible_distribution == "Ubuntu" or ansible_distribution == "SLES")
     - ansible_architecture == "x86_64"


### PR DESCRIPTION
Compile Protobuf with -fPIC floag to ensure shared and static libraries
are PIC-enabled. OpenJ9 used to dynamically link with the version of
protobuf available on the system.
eclipse/openj9#6091 changes to statically link.

Issue: https://github.com/eclipse/openj9/issues/6092

Signed-off-by: Violeta Sebe <vsebe@ca.ibm.com>