### PR TITLE
 Add ansible scripts to set up git-hg/jenkins relief box

### DIFF
--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/infra_githg.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/infra_githg.yml
@@ -1,0 +1,33 @@
+---
+#######################################################
+# AdoptOpenJDK - Ansible Playbook for git-hg machines #
+#######################################################
+- hosts: "{{ groups['Vendor_groups'] | default('localhost:infra') }}"
+  gather_facts: yes
+  tasks:
+    - block:
+      # Set standard variables
+      - name: Load AdoptOpenJDKs variable file
+        include_vars: group_vars/all/adoptopenjdk_variables.yml
+  environment:
+    PATH: "/usr/local/bin:{{ ansible_env.PATH }}"
+
+  #########
+  # Roles #
+  #########
+  roles:
+    - Debug
+    - Version
+    - git-hg                      # Mercurial client for mirror jobs
+    - GIT_Source
+    - Jenkins_User                # AdoptOpenJDK Infrastructure
+    - Superuser                   # AdoptOpenJDK Infrastructure
+    - Swap_File
+    - Crontab
+    - NTP_TIME
+    - Nagios_Plugins              # AdoptOpenJDK Infrastructure
+    - Nagios_Master_Config        # AdoptOpenJDK Infrastructure
+    - Nagios_Tunnel               # AdoptOpenJDK Infrastructure
+    - Clean_Up
+    - Security
+    - Vendor

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/main.yml
@@ -7,8 +7,8 @@
   tasks:
     - block:
       # Set standard variables
-        - name: Load AdoptOpenJDKs variable file
-          include_vars: group_vars/all/adoptopenjdk_variables.yml
+      - name: Load AdoptOpenJDKs variable file
+        include_vars: group_vars/all/adoptopenjdk_variables.yml
   environment:
     PATH: "/usr/local/bin:{{ ansible_env.PATH }}"
 

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/git-hg/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/git-hg/tasks/main.yml
@@ -1,0 +1,36 @@
+---
+##################################################
+# AdoptOpenJDK - Prereqs for running git-hg jobs #
+##################################################
+- name: Install packages for java and git
+  apt:
+    name: "{{ packages }}"
+  vars:
+    packages:
+    - openjdk-8-jre-headless
+    - mercurial
+    - git
+- name: Create /usr/local/bin
+  file: path=/usr/local/bin state=directory
+- name: Download git-remote-hg
+  get_url:
+    url: https://raw.github.com/felipec/git-remote-hg/master/git-remote-hg
+    dest: /usr/local/bin/git-remote-hg
+    mode: 0555
+- name: Install prereqs needed for git-hg jobs
+  apt:
+    name: "{{ packages }}"
+  vars:
+    packages:
+    - gcc
+    - zlib1g-dev
+    - libcurl4-openssl-dev
+    - gettext
+- name: Install prereqs needed for other jobs which will runon the machine (jtreg, jemmy, jtharness)
+  apt:
+    name: "{{ packages }}"
+  vars:
+    packages:
+    - unzip
+    - zip
+    - ant


### PR DESCRIPTION
Only controvesial thing in this could be the inclusion of the Ubuntu java within the `git-hg` role when it's not directly needed for `git-hg` but it is for the jenkins agent that will go onto the machine.

Finalised / fixes https://github.com/AdoptOpenJDK/openjdk-infrastructure/issues/819

Signed-off-by: Stewart Addison <sxa@uk.ibm.com>