### PR TITLE
Adding quickstart guide to readme

### DIFF
--- a/ansible/README.md
+++ b/ansible/README.md
@@ -1,5 +1,22 @@
 # Ansible playbooks to download and install dependencies for OpenJDK on various platforms
 
+# Quickstart Guide
+
+For macOS:
+
+1) Install Homebrew 2.1.7 or later
+  ```bash
+  /usr/bin/ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)"
+  ```
+2) Install Vagrant 2.2.5 or later
+  ```bash
+  brew cask install vagrant
+  ```
+3) Install Virtualbox 6.0.8 or later:
+  ```bash
+  brew cask install virtualbox
+  ```
+ 
 # Running via Vagrant and VirtualBox
 
 To test the ansible scripts you can set up a Virtual Machine isolated from your own local system.

--- a/ansible/README.md
+++ b/ansible/README.md
@@ -2,6 +2,8 @@
 
 # Quickstart Guide
 
+To test the ansible scripts, you'll need to install the following programs.
+
 For macOS:
 
 1) Install Homebrew 2.1.7 or later


### PR DESCRIPTION
Adding a quick-start guide for macOS in the /ansible/README.md allows for quickly installing programmes that are required to test the playbooks.