### PR TITLE
add mac playbooks and new macincloud test machines

### DIFF
--- a/ansible/MANUAL_STEPS.md
+++ b/ansible/MANUAL_STEPS.md
@@ -1,0 +1,18 @@
+# Manual steps required to run ansible on machines
+
+## macOS
+1. Update Sudoers file:
+
+this requires `NOPASSWD` to be added to the sudoers file to enable elevation
+
+`sudo visudo`
+and change:
+`%admin          ALL = (ALL) ALL`
+to
+`%admin          ALL = (ALL) NOPASSWD:ALL`
+
+2. Allow ssh access
+
+```bash
+sudo systemsetup -setremotelogin on
+```

--- a/ansible/inventory.yml
+++ b/ansible/inventory.yml
@@ -90,6 +90,12 @@ hosts:
       - macincloud:
           macos1010-x64-1: {ip: 74.80.250.151, user: admin}
           macos1010-x64-2: {ip: 74.80.250.173, user: admin}
+          macos1012-x64-1: {ip: 92.63.141.139, user: admin}
+          macos1013-x64-1: {ip: 46.20.235.28, user: admin}
+          macos1013-x64-2: {ip: 92.63.134.23, user: admin}
+          macos1014-x64-1: {ip: 87.237.62.57, user: admin}
+          macos1014-x64-2: {ip: 92.63.134.40, user: admin}
+          macos1014-x64-3: {ip: 74.80.249.207, user: admin}
 
       - marist:
           sles12-s390x-1: {ip: 148.100.110.56}

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/main.yml
@@ -2,7 +2,7 @@
 ###################################
 # AdoptOpenJDK - Ansible Playbook #
 ###################################
-- hosts: "{{ groups['Vendor_groups'] | default('localhost:build:test:!*zos*:!*win*:!*macos*:!*aix*') }}"
+- hosts: "{{ groups['Vendor_groups'] | default('localhost:build:test:!*zos*:!*win*:!*aix*') }}"
   gather_facts: yes
   tasks:
     - block:

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/CPAN/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/CPAN/tasks/main.yml
@@ -8,8 +8,9 @@
   shell: "curl -L https://cpanmin.us | perl - App::cpanminus"
   ignore_errors: yes
   when:
-    - (ansible_distribution == "RedHat" and ansible_distribution_major_version == "6") or (ansible_distribution == "CentOS" and ansible_distribution_major_version == "6") or (ansible_distribution == "SLES")
+    - (ansible_distribution == "RedHat" and ansible_distribution_major_version == "6") or (ansible_distribution == "CentOS" and ansible_distribution_major_version == "6") or (ansible_distribution == "SLES") or os|startswith("macos")
   tags:
+    - cpan
     - test_tools
     - skip_ansible_lint
     #TODO: curl used in place of get_url or uri module
@@ -20,11 +21,13 @@
     state: installed
   when:
     - (ansible_distribution == "RedHat" and ansible_distribution_major_version == "7") or (ansible_distribution == "CentOS" and ansible_distribution_major_version == "7")
-  tags: test_tools
+  tags:
+    - cpan
+    - test_tools
 
 # All
 - name: Install JSON
-  command: cpanm --with-recommends JSON
+  command: cpanm --with-recommends --sudo JSON
   tags:
     - cpan
     - json
@@ -32,7 +35,7 @@
     - skip_ansible_lint
 
 - name: Install Text::CSV
-  command: cpanm --with-recommends Text::CSV
+  command: cpanm --with-recommends --sudo Text::CSV
   tags:
     - cpan
     - text_csv
@@ -40,7 +43,7 @@
     - skip_ansible_lint
 
 - name: Install XML::Parser
-  command: cpanm --with-recommends XML::Parser
+  command: cpanm --with-recommends --sudo XML::Parser
   tags:
     - cpan
     - xml_parser

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/scripts/install-homebrew.sh
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/scripts/install-homebrew.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+yes | /usr/bin/ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)"

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/scripts/install-xcode.sh
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/scripts/install-xcode.sh
@@ -1,0 +1,44 @@
+#!/bin/bash
+osx_vers=$(sw_vers -productVersion | awk -F "." '{print $2}')
+cmd_line_tools_temp_file="/tmp/.com.apple.dt.CommandLineTools.installondemand.in-progress"
+
+# Installing the latest Xcode command line tools on 10.9.x or higher
+
+if [[ "$osx_vers" -ge 9 ]]; then
+touch "$cmd_line_tools_temp_file";
+PROD=$(softwareupdate -l |
+  grep "\*.*Command Line" |
+  head -n 1 | awk -F"*" '{print $2}' |
+  sed -e 's/^ *//' |
+tr -d '\n')
+softwareupdate -i "$PROD";
+fi
+
+# Installing the latest Xcode command line tools on 10.7.x and 10.8.x
+
+# on 10.7/10.8, instead of using the software update feed, the command line tools are downloaded
+# instead from public download URLs, which can be found in the dvtdownloadableindex:
+# https://devimages.apple.com.edgekey.net/downloads/xcode/simulators/index-3905972D-B609-49CE-8D06-51ADC78E07BC.dvtdownloadableindex
+
+if [[ "$osx_vers" -eq 7 ]] || [[ "$osx_vers" -eq 8 ]]; then
+
+	if [[ "$osx_vers" -eq 7 ]]; then
+		DMGURL=http://devimages.apple.com/downloads/xcode/command_line_tools_for_xcode_os_x_lion_april_2013.dmg
+	fi
+
+	if [[ "$osx_vers" -eq 8 ]]; then
+		 DMGURL=http://devimages.apple.com/downloads/xcode/command_line_tools_for_osx_mountain_lion_april_2014.dmg
+	fi
+
+		TOOLS=cltools.dmg
+		curl "$DMGURL" -o "$TOOLS"
+		TMPMOUNT=`/usr/bin/mktemp -d /tmp/clitools.XXXX`
+		hdiutil attach "$TOOLS" -mountpoint "$TMPMOUNT" -nobrowse
+		# The "-allowUntrusted" flag has been added to the installer
+		# command to accomodate for now-expired certificates used
+		# to sign the downloaded command line tools.
+		installer -allowUntrusted -pkg "$(find $TMPMOUNT -name '*.mpkg')" -target /
+		hdiutil detach "$TMPMOUNT"
+		rm -rf "$TMPMOUNT"
+		rm "$TOOLS"
+fi

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/scripts/install-xcode.sh
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/scripts/install-xcode.sh
@@ -5,12 +5,12 @@ cmd_line_tools_temp_file="/tmp/.com.apple.dt.CommandLineTools.installondemand.in
 # Installing the latest Xcode command line tools on 10.9.x or higher
 
 if [[ "$osx_vers" -ge 9 ]]; then
-touch "$cmd_line_tools_temp_file";
-PROD=$(softwareupdate -l |
-  grep "\*.*Command Line" |
-  head -n 1 | awk -F"*" '{print $2}' |
-  sed -e 's/^ *//' |
-  tr -d '\n')
+  touch "$cmd_line_tools_temp_file";
+  PROD=$(softwareupdate -l |
+    grep "\*.*Command Line" |
+    head -n 1 | awk -F"*" '{print $2}' |
+    sed -e 's/^ *//' |
+    tr -d '\n')
   softwareupdate -i "$PROD";
 fi
 

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/scripts/install-xcode.sh
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/scripts/install-xcode.sh
@@ -10,8 +10,8 @@ PROD=$(softwareupdate -l |
   grep "\*.*Command Line" |
   head -n 1 | awk -F"*" '{print $2}' |
   sed -e 's/^ *//' |
-tr -d '\n')
-softwareupdate -i "$PROD";
+  tr -d '\n')
+  softwareupdate -i "$PROD";
 fi
 
 # Installing the latest Xcode command line tools on 10.7.x and 10.8.x

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/tasks/MacOSX.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/tasks/MacOSX.yml
@@ -1,0 +1,67 @@
+---
+
+#
+# Updates all packages for macos-based distributions
+#
+
+- name: Check for xcode-tools
+  raw: xcode-select --print-path &> /dev/null
+  register: xcode
+  ignore_errors: yes
+
+- name: Install xcode-tools
+  script: scripts/install-xcode.sh
+  when: xcode.rc > 1
+
+- name: Check if Homebrew is already installed
+  stat:
+    path: /usr/local/bin/brew
+  register: brew
+
+- name: Install Homebrew
+  become_user: admin
+  script: scripts/install-homebrew.sh
+  when: not brew.stat.exists
+
+- name: Upgrade installed packages
+  become_user: admin
+  homebrew:
+    upgrade_all: yes
+
+- name: Install brew cu
+  become_user: admin
+  homebrew_tap:
+    name: buo/cask-upgrade
+
+- name: Add AdoptOpenJDK Java Repo
+  become_user: admin
+  homebrew_tap:
+    name: AdoptOpenJDK/openjdk
+
+- name: Update Casks
+  become_user: admin
+  command: /usr/local/bin/brew cu
+
+- name: Install Build Tool Packages
+  become_user: admin
+  homebrew: "name={{ item }} state=present"
+  with_items: "{{ Build_Tool_Packages }}"
+  tags: build_tools
+
+- name: Install Build Tool Casks
+  become_user: admin
+  homebrew_cask: "name={{ item }} state=present"
+  with_items: "{{ Build_Tool_Casks }}"
+  tags: build_tools
+
+- name: Install Test Tool Packages
+  become_user: admin
+  homebrew: "name={{ item }} state=present"
+  with_items: "{{ Test_Tool_Packages }}"
+  tags: test_tools
+
+- name: Install Test Tool Casks
+  become_user: admin
+  homebrew_cask: "name={{ item }} state=present"
+  with_items: "{{ Test_Tool_Casks }}"
+  tags: test_tools

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/tasks/main.yml
@@ -35,8 +35,16 @@
 - name: Set hostname to inventory_hostname
   hostname:
     name: "{{ inventory_hostname }}.{{ Domain }}"
-  when: Domain == "adoptopenjdk.net"
+  when: Domain == "adoptopenjdk.net" and not os|startswith("macos")
   tags: hostname
+
+- name: Set hostname to inventory_hostname (macOS)
+  command: "{{ item }}"
+  with_items:
+    - "sudo scutil --set HostName {{ inventory_hostname }}.adoptopenjdk.net"
+    - "sudo scutil --set ComputerName {{ inventory_hostname }}.adoptopenjdk.net"
+    - "dscacheutil -flushcache"
+  when: Domain == "adoptopenjdk.net" and os|startswith("macos")
 
 #####################
 # Update /etc/hosts #

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/vars/MacOSX.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/vars/MacOSX.yml
@@ -1,0 +1,21 @@
+---
+##########
+# macOS #
+##########
+
+# Command Build Tool Packages
+
+Build_Tool_Packages:
+  - gnu-tar
+  - wget
+
+Build_Tool_Casks:
+  - adoptopenjdk8
+
+Test_Tool_Packages:
+  - mercurial
+  - pulseaudio
+  - cpanminus
+
+Test_Tool_Casks:
+  - xquartz

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Jenkins_User/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Jenkins_User/tasks/main.yml
@@ -41,6 +41,7 @@
     - adoptopenjdk
     # TODO: write a condition when NOT to run this step
     - skip_ansible_lint
+  when: not os|startswith("macos")
 
 - name: Unset expiry on user account for Redhat for root
   command: chage -M -1 -E -1 root
@@ -49,3 +50,4 @@
     - adoptopenjdk
     # TODO: write a condition when NOT to run this step
     - skip_ansible_lint
+  when: not os|startswith("macos")

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Superuser/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Superuser/tasks/main.yml
@@ -39,14 +39,14 @@
 - name: Superuser account policy - expire date
   command: chage -E -1 zeus
   when:
-    - Superuser_Account == "Enabled"
-    - ansible_distribution != "FreeBSD"
+    - Superuser_Account == "Enabled" and not os|startswith("macos")
+    - ansible_distribution != "FreeBSD" and not os|startswith("macos")
 
   tags: [superuser, adoptopenjdk]
 
 - name: Superuser account policy - max days
   command: chage -M -1 zeus
   when:
-    - Superuser_Account == "Enabled"
-    - ansible_distribution != "FreeBSD"
+    - Superuser_Account == "Enabled" and not os|startswith("macos")
+    - ansible_distribution != "FreeBSD" and not os|startswith("macos")
   tags: [superuser, adoptopenjdk]

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/ant/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/ant/tasks/main.yml
@@ -41,7 +41,18 @@
     group: root
     state: link
   when:
-    - ant_installed.rc != 0
+    - ant_installed.rc != 0 and not os|startswith("macos")
+  tags: ant
+
+- name: Create /usr/local/bin/ant symlink macOS
+  file:
+    src: /usr/local/apache-ant-1.10.5/bin/ant
+    dest: /usr/local/bin/ant
+    owner: admin
+    group: wheel
+    state: link
+  when:
+    - ant_installed.rc != 0 and os|startswith("macos")
   tags: ant
 
 - name: Clean up downloaded packages

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/freemarker/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/freemarker/tasks/main.yml
@@ -21,5 +21,10 @@
 
 - name: Move freemarker.jar to /home/{{ Jenkins_Username }} folder
   command: mv /tmp/freemarker-2.3.8/lib/freemarker.jar /home/{{ Jenkins_Username }}
-  when: freemarker.stat.exists == False
+  when: freemarker.stat.exists == False and not os|startswith("macos")
+  tags: [freemarker, adoptopenjdk]
+
+- name: Move freemarker.jar to /Users/{{ Jenkins_Username }} folder (macOS)
+  command: mv /tmp/freemarker-2.3.8/lib/freemarker.jar /Users/{{ Jenkins_Username }}
+  when: freemarker.stat.exists == False and os|startswith("macos")
   tags: [freemarker, adoptopenjdk]

--- a/ansible/yamllint.yml
+++ b/ansible/yamllint.yml
@@ -4,5 +4,5 @@ rules:
   line-length:
     max: 120
     level: warning
-  #mixed style truthy values are OK for Ansible code
+  # mixed style truthy values are OK for Ansible code
   truthy: disable


### PR DESCRIPTION
This adds the initial macOS playbooks for test machines. It's probably missing build deps but we'll get to that when we add a new build mac.