### PR TITLE
fix linter problem in inventory.yml (but makes it less pretty)

### DIFF
--- a/ansible/inventory.yml
+++ b/ansible/inventory.yml
@@ -78,8 +78,8 @@ hosts:
 
       - godaddy:
           win2016-x64-1: {ip: 160.153.234.27, user: adoptopenjdk}
-          win2016-x64-2: {ip: 160.153.234.5,  user: adoptopenjdk}
-          win2016-x64-3: {ip: 160.153.234.8,  user: adoptopenjdk}
+          win2016-x64-2: {ip: 160.153.234.5, user: adoptopenjdk}
+          win2016-x64-3: {ip: 160.153.234.8, user: adoptopenjdk}
           win2016-x64-4: {ip: 160.153.234.22, user: adoptopenjdk}
 
       - osuosl:


### PR DESCRIPTION
Introduced in https://github.com/AdoptOpenJDK/openjdk-infrastructure/pull/824

I still think my version looks better - seems a bit overkill not to allow an extra space after the : to line the entries up

Signed-off-by: Stewart Addison <sxa@uk.ibm.com>