### PR TITLE
Fixed Azul signing keys for Ubuntu

### DIFF
--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/tasks/Ubuntu.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/tasks/Ubuntu.yml
@@ -18,12 +18,6 @@
     - ansible_architecture != "armv7l"
   tags: patch_update
 
-- name: Add Azul Zulu repository for x86_64
-  apt_repository: repo='deb http://repos.azulsystems.com/ubuntu stable main'
-  when:
-    - ansible_architecture == "x86_64"
-  tags: patch_update
-
 - name: Add Azul Zulu GPG Package Signing Key for x86_64
   apt_key:
     url: http://repos.azulsystems.com/RPM-GPG-KEY-azulsystems
@@ -31,6 +25,12 @@
   when:
     - ansible_architecture == "x86_64"
   tags: [patch_update, azul-key]
+
+- name: Add Azul Zulu repository for x86_64
+  apt_repository: repo='deb http://repos.azulsystems.com/ubuntu stable main'
+  when:
+    - ansible_architecture == "x86_64"
+  tags: patch_update
 
 - name: Add additional repositories for BeagleBone
   apt_repository: repo={{ item }}


### PR DESCRIPTION
Fixes the key signing problem for Azul on the Ubuntu Playbook by swapping 2 of the tasks.

Fixes: https://github.com/AdoptOpenJDK/openjdk-infrastructure/issues/836