### PR TITLE
Stopped libgstreamer Issue with Ubuntu 1804

### DIFF
--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/vars/Ubuntu.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/vars/Ubuntu.yml
@@ -49,8 +49,6 @@ OpenJFX_Build_Tool_Packages:
   - libavcodec-dev
   - libavformat-dev
   - libgl1-mesa-dev
-  - libgstreamer0.10-dev
-  - libgstreamer-plugins-base0.10-dev
   - libgtk2.0-dev
   - libgtk-3-dev
   - libjpeg-dev


### PR DESCRIPTION
Found an issue whilst fixing #836 , the libgstreamer package was attempting to download an Ubuntu 16.04 version, whilst using an 18.04 VM. Just removed a couple lines, as it's installed later on anyway.