### PR TITLE
Fixed Docker issue with Ubuntu 1804

### DIFF
--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/vars/Ubuntu.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/vars/Ubuntu.yml
@@ -49,8 +49,6 @@ OpenJFX_Build_Tool_Packages:
   - libavcodec-dev
   - libavformat-dev
   - libgl1-mesa-dev
-  - libgstreamer0.10-dev
-  - libgstreamer-plugins-base0.10-dev
   - libgtk2.0-dev
   - libgtk-3-dev
   - libjpeg-dev

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Docker/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Docker/tasks/main.yml
@@ -12,6 +12,11 @@
     - skip_ansible_lint
 
 # Ubuntu
+- name: Add Docker GPG apt Key
+  apt_key:
+    url: https://download.docker.com/linux/ubuntu/gpg
+    state: present
+
 - name: Add Docker Repo for Ubuntu x86_64
   apt_repository:
     repo: "deb [arch=amd64] https://download.docker.com/linux/ubuntu {{ ansible_distribution_release }} stable"


### PR DESCRIPTION
Found another issue when fixing #836 , the Task "Add Docker repo for Ubuntu x86_64" would fail when executing the Ubuntu playbook on Ubuntu 18.04, but not on ubuntu 16.04. I've added the task to get the GPG key before adding this repo. This appears to have fixed the problem for Ubuntu 18.04, whilst not breaking anything for Ubuntu 16.04