### PR TITLE
Added scripts for testing the Unix PBs

### DIFF
--- a/ansible/pbTestScripts/README.md
+++ b/ansible/pbTestScripts/README.md
@@ -1,0 +1,17 @@
+# Scripts to test Unix playbooks on Vagrant VMs
+
+This folder contains the scripts necessary to start separate vagrant machines with the following OSs:
+
+* Ubuntu 16.04
+* Ubuntu 18.04
+* CentOS6
+
+And subsequently test those machine’s playbooks.
+
+Start by executing _testScript.sh_ with 2 arguments; the `GitHub URL` to be tested, and a `y/n` to specify keeping the VMs alive or not.
+
+The script will then make a directory in the User’s home called _adoptopenjdkPBTests_, in which another directory containing the log files, and the Git repository is stored. Following that, the script will run each ansible playbook on their respective VMs, writing the output to the aforementioned log files.
+
+After each playbook is ran through, a summary is given, containing which OS playbooks succeeded, failed, or were cancelled. The logs can also be perused to get more in-depth error messages.
+
+If the VMs were chosen *not* to be destroyed, they can be later by running the _vmDestroy.sh_ script, which takes the `project folder` as an argument. If that folder is found, it will run through and destroy the VMs.

--- a/ansible/pbTestScripts/testScript.sh
+++ b/ansible/pbTestScripts/testScript.sh
@@ -1,0 +1,90 @@
+#!/bin/bash
+set -eu
+
+# Takes all arguments from the script
+processArgs()
+{
+	if [ $# -lt 2 ]; then
+		printf "\nScript takes 2 input arguments\n"
+		printf "Github URL, then y/n to retain VMs\n\n"
+		exit 1
+	fi
+}
+
+setupFiles()
+{
+	cd ~					
+	mkdir -p adoptopenjdkPBTests || true
+	cd adoptopenjdkPBTests
+	mkdir -p logFiles || true
+}
+
+# Takes in git URL as arg 1, foldername as arg 2
+setupGit()
+{
+	cd ~/adoptopenjdkPBTests
+	if [ ! -d "$2" ]; then		#if folder doesn't exist
+   		git clone $1
+	else				#if it does, ensure up to date
+		cd "$2"
+    		git pull $1
+	fi
+}
+
+# Takes the OS as arg 1, foldername as arg 2
+startVMPlaybook()
+{
+	cd ~/adoptopenjdkPBTests/$2/ansible
+
+	# Alias the correct vagrant file
+	ln -sf Vagrantfile.$1 Vagrantfile
+	
+	vagrant up
+
+	# Remotely moves to the correct directory in the VM and builds the playbook. Then logs the VM's output to a file, in a separate directory
+	vagrant ssh -c "cd /vagrant/playbooks/AdoptOpenJDK_Unix_Playbook && sudo ansible-playbook --skip-tags "adoptopenjdk,jenkins" main.yml" 2>&1 | tee ~/adoptopenjdkPBTests/logFiles/$2.$1.log
+
+	vagrant halt
+}
+
+destroyVM()
+{
+	printf "Destroying Machine . . .\n"
+	vagrant destroy -f
+}
+
+# Takes in OS as arg 1
+searchLogFiles()
+{
+	cd ~/adoptopenjdkPBTests/logFiles
+	if grep -q 'failed=[1-9]' *$1.log 
+	then 
+		printf "\n$1 Failed\n"
+	elif grep -q '\[ERROR\]' *$1.log 
+	then
+		printf "\n$1 playbook was stopped\n"
+	else
+		printf "\n$1 playbook succeeded\n"
+	fi
+}
+
+# var1 = GitURL, var2 = y/n for VM retention
+folderName=${1##*/}
+processArgs $*
+setupFiles 
+setupGit $1 $folderName
+
+# For all tested OSs / Playbooks
+for OS in Ubuntu1804 Ubuntu1604 CentOS6
+do 	
+	startVMPlaybook $OS $folderName
+	if [[ $2 = "n" ]]
+	then
+		destroyVM
+	fi
+done
+
+for OS in Ubuntu1804 Ubuntu1604 CentOS6 
+do
+	searchLogFiles $OS
+done

--- a/ansible/pbTestScripts/vmDestroy.sh
+++ b/ansible/pbTestScripts/vmDestroy.sh
@@ -1,0 +1,44 @@
+#!/bin/bash
+set -eu
+
+# Takes in all arguments
+processArgs()
+{
+	if [ $# -lt 1 ]; then
+		printf "\nScript takes 1 input argument\n"
+		printf "The project whose VMs are to be destroyed\n\n"
+		exit 1
+	fi
+}
+
+# akes project name as arg 1, and OS as arg 2
+destroyVM()
+{
+	cd ~/adoptopenjdkPBTests/$1/ansible
+	ln -sf Vagrantfile.$2 Vagrantfile	# Correct Vagrantfile alias
+	vagrant destroy -f			# Force destroy without question
+	printf "\nDestroyed $2 Machine\n"	
+}
+
+# Takes the project name as arg1
+checkFolder()
+{
+	cd ~/adoptopenjdkPBTests
+	if [ -d "$1" ]; then
+		printf "\n$1 found!\n"
+		return 0
+	else
+		printf "\n$1 not found\n"
+		return 1
+	fi
+}
+
+# Script takes project name as arg 1
+processArgs $*
+if checkFolder $1; then	
+ 	# For all currently supported OSs
+	for OS in Ubuntu1804 Ubuntu1604 CentOS6
+	do
+		destroyVM $1 $OS
+	done
+fi


### PR DESCRIPTION
Added a folder into the "ansible" folder that contains all the scripts (and directions on how to use it). Works by creating 3 Vagrant VMs (For Ubuntu 18, 16 and CentOS6), logging all the ansible-playbook command output and searching it to determine if it works or not. Then you can destroy the VMs, or not, if they're needed for more debugging.

Fixes: #842 