### PR TITLE
Put in a more useful error message for Ansible's version check

### DIFF
--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/tasks/main.yml
@@ -86,6 +86,7 @@
 ##############################
 # OS setup and configuration #
 ##############################
+# If this errors, upgrade ansible to >=2.4
 - name: Perform OS setup and configuration
   include_tasks: "{{ ansible_distribution }}.yml"
   tags: main


### PR DESCRIPTION
Relates to #341 

The pull request in #573 doesn't seem to have fixed the issue when running on an Ubuntu 16.04 VM. It appears to be a syntax error from reading the files before executing any of them, therefore it will fail before getting to the "version" task in the Unix Playbook. Therefore, I've commented in a message so when this error occurs, it tells the user to update to Ansible >=2.4, as that will fix the issue, and we can't automatically update ansible from within a playbook.