### PR TITLE
Allow curl to update in AIX playbook

### DIFF
--- a/ansible/playbooks/aix.yml
+++ b/ansible/playbooks/aix.yml
@@ -167,7 +167,6 @@
             update_cache: yes
             name: '*'
             state: latest
-            exclude: curl*, python-pycurl*
           tags:
             - yum
             #TODO: Package installs should not use latest

--- a/ansible/playbooks/aix.yml
+++ b/ansible/playbooks/aix.yml
@@ -167,7 +167,7 @@
             update_cache: yes
             name: '*'
             state: latest
-            exclude: curl*
+            exclude: curl*, python-pycurl*
           tags:
             - yum
             #TODO: Package installs should not use latest


### PR DESCRIPTION
Running the playbooks on AIX is currently causing a yum breakage due to `python-pycurl` being upgraded and it being incompatible with `curl`. We have an entry in the playbook to stop `curl` being upgraded. This PR will stop `python-pycurl` being upgraded too.

We may need to revisit why curl is being excluded and see if we can reinstate it, but this will at least stop terminally breaking yum (Can be unbroken by force removing python-pycurl and reinstalling the one in the AIX toolbox download ...)

```
# yum update
There was a problem importing one of the Python modules
required to run yum. The error leading to this problem was:

   pycurl: libcurl link-time version (7.52.1) is older than compile-time version (7.56.1)

Please install a package which provides this module, or
verify that the module is installed correctly.

It's possible that the above module doesn't match the
current version of Python, which is:
2.7.16 (default, Mar 12 2019, 21:23:24) 
[GCC 6.3.0]

If you cannot solve this problem yourself, please go to 
the yum faq at:
  http://yum.baseurl.org/wiki/Faq
  

# rpm -qa | grep python-pycurl
python-pycurl-7.43.0-1.ppc
# rpm -e python-pycurl
error: Failed dependencies:
        python-pycurl >= 7.19.3 is needed by (installed) python-urlgrabber-3.10.1-1.noarch
# rpm -e --nodeps python-pycurl 
# ls *pycurl*
python-pycurl-7.19.3-1.aix6.1.ppc.rpm
# rpm -ivh python-pycurl-7.19.3-1.aix6.1.ppc.rpm
Preparing...                          ################################# [100%]
Updating / installing...
   1:python-pycurl-7.19.3-1           ################################# [100%]
```

Signed-off-by: Stewart Addison <sxa@uk.ibm.com>