### PR TITLE
Added/Modified Scripts to verify OpenJDK builds

### DIFF
--- a/ansible/pbTestScripts/buildJDK.sh
+++ b/ansible/pbTestScripts/buildJDK.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+set -eu
+export TARGET_OS=linux
+export ARCHITECTURE=x64
+export JAVA_TO_BUILD=jdk8u
+export VARIANT=openj9
+export JDK7_BOOT_DIR=/usr/lib/jvm/java-1.7.0
+export JDK_BOOT_DIR=/usr/lib/jvm/java-8-openjdk-amd64
+cd ~/openjdk-build
+build-farm/make-adopt-build-farm.sh

--- a/ansible/pbTestScripts/buildJDK.sh
+++ b/ansible/pbTestScripts/buildJDK.sh
@@ -8,3 +8,4 @@ export JDK7_BOOT_DIR=/usr/lib/jvm/java-1.7.0
 export JDK_BOOT_DIR=/usr/lib/jvm/java-8-openjdk-amd64
 cd ~/openjdk-build
 build-farm/make-adopt-build-farm.sh
+

--- a/ansible/pbTestScripts/testScript.sh
+++ b/ansible/pbTestScripts/testScript.sh
@@ -43,7 +43,7 @@ startVMPlaybook()
 	cd ~/adoptopenjdkPBTests/$2/ansible
 	#Alias the correct vagrant file
 	ln -sf Vagrantfile.$1 Vagrantfile
-	vagrant  up
+	vagrant up
 	# Remotely moves to the correct directory in the VM and builds the playbook. Then logs the VM's output to a file, in a separate directory
 	vagrant ssh -c "cd /vagrant/playbooks/AdoptOpenJDK_Unix_Playbook && sudo ansible-playbook --skip-tags "adoptopenjdk,jenkins" main.yml" 2>&1 | tee ~/adoptopenjdkPBTests/logFiles/$2.$1.log
 	testBuild

--- a/ansible/pbTestScripts/testScript.sh
+++ b/ansible/pbTestScripts/testScript.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 set -eu
-#takes all arguments from the script
+
+# Takes all arguments from the script
 processArgs() 
 {
 	if [ $# -lt 2 ]; then
@@ -18,8 +19,8 @@ setupFiles()
 	mkdir -p logFiles || true
 }
 
-#Takes in git URL as arg 1, foldername as arg 2
-setupGit()	
+# Takes in git URL as arg 1, foldername as arg 2
+setupGit()
 {
 	cd ~/adoptopenjdkPBTests
 	if [ ! -d "$2" ]; then		#if folder doesn't exist
@@ -36,8 +37,8 @@ testBuild()
 	vagrant ssh -c "cd /vagrant/pbTestScripts && ./buildJDK.sh"
 }
 
-#Takes the OS as arg 1, foldername as arg 2
-startVMPlaybook()	
+# Takes the OS as arg 1, foldername as arg 2
+startVMPlaybook()
 {
 	cd ~/adoptopenjdkPBTests/$2/ansible
 	ln -sf Vagrantfile.$1 Vagrantfile	#Alias the correct vagrant file
@@ -55,8 +56,8 @@ destroyVM()
 	vagrant destroy -f
 }
 
-#Takes in OS as arg 1
-searchLogFiles() 
+# Takes in OS as arg 1
+searchLogFiles()
 {
 	cd ~/adoptopenjdkPBTests/logFiles
 	if grep -q 'failed=[1-9]' *$1.log 
@@ -76,7 +77,7 @@ processArgs $*
 setupFiles 
 setupGit $1 $folderName
 
-#For all tested OSs / Playbooks
+# For all tested OSs / Playbooks
 for OS in Ubuntu1804 Ubuntu1604 CentOS6		
 do 	
 	startVMPlaybook $OS $folderName
@@ -89,6 +90,4 @@ for OS in Ubuntu1804 Ubuntu1604 CentOS6
 do
 	searchLogFiles $OS
 done
-
-	
 

--- a/ansible/pbTestScripts/testScript.sh
+++ b/ansible/pbTestScripts/testScript.sh
@@ -2,7 +2,7 @@
 set -eu
 
 # Takes all arguments from the script
-processArgs() 
+processArgs()
 {
 	if [ $# -lt 2 ]; then
 		printf "\nScript takes 2 input arguments\n"
@@ -13,7 +13,7 @@ processArgs()
 
 setupFiles()
 {
-	cd ~					
+	cd ~
 	mkdir -p adoptopenjdkPBTests || true
 	cd adoptopenjdkPBTests
 	mkdir -p logFiles || true
@@ -41,11 +41,11 @@ testBuild()
 startVMPlaybook()
 {
 	cd ~/adoptopenjdkPBTests/$2/ansible
-	ln -sf Vagrantfile.$1 Vagrantfile	#Alias the correct vagrant file
+	#Alias the correct vagrant file
+	ln -sf Vagrantfile.$1 Vagrantfile
 	vagrant  up
+	# Remotely moves to the correct directory in the VM and builds the playbook. Then logs the VM's output to a file, in a separate directory
 	vagrant ssh -c "cd /vagrant/playbooks/AdoptOpenJDK_Unix_Playbook && sudo ansible-playbook --skip-tags "adoptopenjdk,jenkins" main.yml" 2>&1 | tee ~/adoptopenjdkPBTests/logFiles/$2.$1.log
-
-		# ^ Remotely moves to the correct directory in the VM and builds the playbook. Then logs the VM's output to a file, in a separate directory
 	testBuild
 	vagrant halt
 }
@@ -60,10 +60,10 @@ destroyVM()
 searchLogFiles()
 {
 	cd ~/adoptopenjdkPBTests/logFiles
-	if grep -q 'failed=[1-9]' *$1.log 
-	then 
+	if grep -q 'failed=[1-9]' *$1.log
+	then
 		printf "\n$1 Failed\n"
-	elif grep -q '\[ERROR\]' *$1.log 
+	elif grep -q '\[ERROR\]' *$1.log
 	then
 		printf "\n$1 playbook was stopped\n"
 	else
@@ -74,20 +74,18 @@ searchLogFiles()
 # var1 = GitURL, var2 = y/n for VM retention
 folderName=${1##*/}
 processArgs $*
-setupFiles 
+setupFiles
 setupGit $1 $folderName
-
 # For all tested OSs / Playbooks
-for OS in Ubuntu1804 Ubuntu1604 CentOS6		
-do 	
+for OS in Ubuntu1804 Ubuntu1604 CentOS6
+do
 	startVMPlaybook $OS $folderName
 	if [[ $2 = "n" ]]
 	then
 		destroyVM
 	fi
 done
-for OS in Ubuntu1804 Ubuntu1604 CentOS6 
+for OS in Ubuntu1804 Ubuntu1604 CentOS6
 do
 	searchLogFiles $OS
 done
-


### PR DESCRIPTION
Added into the script that builds the vagrant machines to test the playbooks, the scripts to run and build openJDk on the machines, to ensure the ansible playbook correctly installed everything.
