### PR TITLE
Changed ansible_processor_vcpus variable for cmake

### DIFF
--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/cmake/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/cmake/tasks/main.yml
@@ -3,6 +3,13 @@
 # cmake  - required by OpenJ9 and OpenJFX builds - requires C++11 compiler #
 ############################################################################
 
+- name: Set ansible_processor_vcpus
+  set_fact:
+    ansible_processor_vcpus: "{{ ansible_processor_cores }}"
+  when:
+    - ansible_architecture == "s390x"
+  tags: cmake
+
 - name: Test if cmake is installed on path
   shell: cmake >/dev/null 2>&1
   ignore_errors: yes


### PR DESCRIPTION
On zlinux machines the ansible_processor_vcpus variable isn't defined,
but the ansible_processor_cores variable is. This change will set the
ansible_processor_vcpus variable to equal ansible_processor_cores so
the cmake role won't fail on zlinux.

Signed-off-by: Colton Mills <millscolt3@gmail.com>