### PR TITLE
Changed condition of setup of ant symlink

### DIFF
--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/ant/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/ant/tasks/main.yml
@@ -41,7 +41,7 @@
     group: root
     state: link
   when:
-    - ant_installed.rc != 0 and (ansible_distribution == "MacOSX")
+    - ant_installed.rc != 0 and (ansible_distribution != "MacOSX")
   tags: ant
 
 - name: Create /usr/local/bin/ant symlink macOS


### PR DESCRIPTION
There are two tasks meant for setting up an ant symlink, one for Mac,
and one for other any other OS. Although both tasks have when statements
that specify to only run on MacOS, causing non Mac hosts to not have ant
set up properly. This change fixes the when statement on the task that
sets up a symlink on a non Mac host.

Signed-off-by: Colton Mills <millscolt3@gmail.com>