### PR TITLE
install bash v4 or later on macOS

### DIFF
--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/vars/MacOSX.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/vars/MacOSX.yml
@@ -7,7 +7,7 @@
 
 Build_Tool_Packages:
   - autoconf
-  - bash
+  - bash # OpenJ9 needs bash v4 or later
   - coreutils
   - gnu-tar
   - wget

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/vars/MacOSX.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/vars/MacOSX.yml
@@ -7,6 +7,7 @@
 
 Build_Tool_Packages:
   - autoconf
+  - bash
   - coreutils
   - gnu-tar
   - wget


### PR DESCRIPTION
needed for openj9