### PR TITLE
Added directory check for the Ant role

### DIFF
--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/ant/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/ant/tasks/main.yml
@@ -33,14 +33,11 @@
     - ant_installed.rc != 0
   tags: ant
 
-- name: Check usr/local/bin exists
-  stat:
+- name: Create /usr/local/bin if it doesn't exist
+  file:
     path: /usr/local/bin
-  register: ant_folder_directory
-
-- name: Create /usr/local/bin
-  shell: cd /usr/local && mkdir bin
-  when: ant_folder_directory.stat.exists == False
+    state: directory
+    mode: '0755'
 
 - name: Create /usr/local/bin/ant symlink
   file:

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/ant/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/ant/tasks/main.yml
@@ -38,6 +38,7 @@
     path: /usr/local/bin
     state: directory
     mode: '0755'
+  when: ansible_distribution != "MacOSX"
 
 - name: Create /usr/local/bin/ant symlink
   file:

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/ant/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/ant/tasks/main.yml
@@ -33,6 +33,15 @@
     - ant_installed.rc != 0
   tags: ant
 
+- name: Check usr/local/bin exists
+  stat:
+    path: /usr/local/bin
+  register: ant_folder_directory
+
+- name: Create /usr/local/bin
+  shell: cd /usr/local && mkdir bin
+  when: ant_folder_directory.stat.exists == False
+
 - name: Create /usr/local/bin/ant symlink
   file:
     src: /usr/local/apache-ant-1.10.5/bin/ant


### PR DESCRIPTION
Fixes the playbook failure that occurs when there is no usr/local/bin directory when trying to create a symlink for ant, by checking and subsequently creating the directory if it's not there.

Fixes: #666 