### PR TITLE
Add heap size variable for Windows playbook

### DIFF
--- a/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/group_vars/all/adoptopenjdk_variables.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/group_vars/all/adoptopenjdk_variables.yml
@@ -11,3 +11,4 @@ Nagios_Plugins: Disabled
 
 ### Default JDK ###
 bootjdk: hotspot
+heapsize: normal

--- a/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/roles/Java11/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/roles/Java11/tasks/main.yml
@@ -16,7 +16,7 @@
 
 - name: Download Java11
   win_get_url:
-    url: https://api.adoptopenjdk.net/v2/binary/releases/openjdk11?openjdk_impl={{ bootjdk }}&os=windows&arch=x64&release=latest&type=jdk
+    url: https://api.adoptopenjdk.net/v2/binary/releases/openjdk11?openjdk_impl={{ bootjdk }}&os=windows&arch=x64&release=latest&type=jdk&heap_size={{ heapsize }}
     dest: 'C:\temp\jdk-11.zip'
   when: (java11_download.stat.exists == false) and (java11_installed.stat.exists == false)
   tags: Java11

--- a/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/roles/Java12/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/roles/Java12/tasks/main.yml
@@ -16,7 +16,7 @@
 
 - name: Download Java12
   win_get_url:
-    url: https://api.adoptopenjdk.net/v2/binary/releases/openjdk12?openjdk_impl={{ bootjdk }}&os=windows&arch=x64&release=latest&type=jdk
+    url: https://api.adoptopenjdk.net/v2/binary/releases/openjdk12?openjdk_impl={{ bootjdk }}&os=windows&arch=x64&release=latest&type=jdk&heap_size={{ heapsize }}
     dest: 'C:\temp\jdk-12.zip'
   when: (java12_download.stat.exists == false) and (java12_installed.stat.exists == false)
   tags: Java12

--- a/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/roles/Java8/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/roles/Java8/tasks/main.yml
@@ -16,7 +16,7 @@
 
 - name: Download Java 8
   win_get_url:
-    url: https://api.adoptopenjdk.net/v2/binary/releases/openjdk8?openjdk_impl={{ bootjdk }}&os=windows&arch=x64&release=latest&type=jdk
+    url: https://api.adoptopenjdk.net/v2/binary/releases/openjdk8?openjdk_impl={{ bootjdk }}&os=windows&arch=x64&release=latest&type=jdk&heap_size={{ heapsize }}
     dest: 'C:\temp\jdk-8.zip'
   when: (java8_download.stat.exists == false) and (java8_installed.stat.exists == false)
   tags: Java8


### PR DESCRIPTION
- Heap size variable added to playbook. It defaults to normal
- To change heap size the extra variable must be added when running the playbook
- Playbook tested and still install hotspot with normal heap_size as the default
- Fixes #882 
Signed-off-by: HusainYusufali <husainyusufali7@gmail.com>