### PR TITLE
Added checks in PB test script to allow testing of branches

### DIFF
--- a/ansible/pbTestScripts/testScript.sh
+++ b/ansible/pbTestScripts/testScript.sh
@@ -1,5 +1,9 @@
 #!/bin/bash
-set -eu
+set -u
+
+branchName='NULL'
+folderName=' '
+gitURL=' '
 
 # Takes all arguments from the script
 processArgs()
@@ -13,21 +17,34 @@ processArgs()
 
 setupFiles()
 {
-	cd ~
+	cd $HOME
 	mkdir -p adoptopenjdkPBTests || true
 	cd adoptopenjdkPBTests
 	mkdir -p logFiles || true
 }
 
-# Takes in git URL as arg 1, foldername as arg 2
+# Takes in git URL as arg 1, foldername as arg 2, branchName as arg 3
 setupGit()
 {
-	cd ~/adoptopenjdkPBTests
-	if [ ! -d "$2" ]; then		#if folder doesn't exist
-   		git clone $1
-	else				#if it does, ensure up to date
-		cd "$2"
-    		git pull $1
+	cd $HOME/adoptopenjdkPBTests
+	if [ "$3" = "NULL" ]; then
+		echo "Not a branch"
+		if [ ! -d "$2-master" ]; then
+   			git clone $1
+			mv $2 $2-master
+		else
+			cd "$2-master"
+    			git pull $1
+		fi
+	else
+		echo "Branch detected"
+		if [ ! -d "$2-$3" ]; then
+   			git clone -b $3 --single-branch $1
+			mv $2 "$2-$3"
+		else
+			cd "$2-$3"
+			git pull origin $3
+		fi
 	fi
 }
 
@@ -37,15 +54,19 @@ testBuild()
 	vagrant ssh -c "cd /vagrant/pbTestScripts && ./buildJDK.sh"
 }
 
-# Takes the OS as arg 1, foldername as arg 2
+# Takes the OS as arg 1, foldername as arg 2, branchName as arg 3
 startVMPlaybook()
 {
-	cd ~/adoptopenjdkPBTests/$2/ansible
-	#Alias the correct vagrant file
+	if [ "$3" = "NULL" ]; then	
+		cd $HOME/adoptopenjdkPBTests/$2-master/ansible
+		$3="master"
+	else
+		cd $HOME/adoptopenjdkPBTests/$2-$3/ansible
+	fi
 	ln -sf Vagrantfile.$1 Vagrantfile
 	vagrant up
 	# Remotely moves to the correct directory in the VM and builds the playbook. Then logs the VM's output to a file, in a separate directory
-	vagrant ssh -c "cd /vagrant/playbooks/AdoptOpenJDK_Unix_Playbook && sudo ansible-playbook --skip-tags "adoptopenjdk,jenkins" main.yml" 2>&1 | tee ~/adoptopenjdkPBTests/logFiles/$2.$1.log
+	vagrant ssh -c "cd /vagrant/playbooks/AdoptOpenJDK_Unix_Playbook && sudo ansible-playbook --skip-tags "adoptopenjdk,jenkins" main.yml" 2>&1 | tee ~/adoptopenjdkPBTests/logFiles/$2.$3.$1.log
 	testBuild
 	vagrant halt
 }
@@ -56,14 +77,14 @@ destroyVM()
 	vagrant destroy -f
 }
 
-# Takes in OS as arg 1
+# Takes in OS as arg 1, branchName as arg 2
 searchLogFiles()
 {
-	cd ~/adoptopenjdkPBTests/logFiles
-	if grep -q 'failed=[1-9]' *$1.log
+	cd $HOME/adoptopenjdkPBTests/logFiles
+	if grep -q 'failed=[1-9]' *$2.$1.log
 	then
 		printf "\n$1 Failed\n"
-	elif grep -q '\[ERROR\]' *$1.log
+	elif grep -q '\[ERROR\]' *$2.$1.log
 	then
 		printf "\n$1 playbook was stopped\n"
 	else
@@ -71,21 +92,41 @@ searchLogFiles()
 	fi
 }
 
+# Takes in the URL passed to the script
+splitURL()
+{
+	# breaks down url to array, and extracts info
+	IFS='/' read -r -a array <<< "$1"
+	if [ ${array[@]: -2:1} == 'tree' ]
+	then
+		branchName=${array[@]: -1:1}
+		folderName=${array[@]: -3:1}
+		unset 'array[${#array[@]}-1]'
+		unset 'array[${#array[@]}-1]'
+		for I in "${array[@]}"
+		do
+			gitURL="$gitURL$I/"
+		done
+	else
+		folderName=${array[@]: -1:1}
+		gitURL=$1
+	fi
+}
 # var1 = GitURL, var2 = y/n for VM retention
-folderName=${1##*/}
 processArgs $*
+splitURL $1
 setupFiles
-setupGit $1 $folderName
+setupGit $gitURL $folderName $branchName
 # For all tested OSs / Playbooks
-for OS in Ubuntu1804 Ubuntu1604 CentOS6
+for OS in Ubuntu1804 Ubuntu1604 CentOS6 CentOS7
 do
-	startVMPlaybook $OS $folderName
+	startVMPlaybook $OS $folderName $branchName
 	if [[ $2 = "n" ]]
 	then
 		destroyVM
 	fi
 done
-for OS in Ubuntu1804 Ubuntu1604 CentOS6
+for OS in Ubuntu1804 Ubuntu1604 CentOS6 CentOS7
 do
-	searchLogFiles $OS
+	searchLogFiles $OS $branchName
 done

--- a/ansible/pbTestScripts/vmDestroy.sh
+++ b/ansible/pbTestScripts/vmDestroy.sh
@@ -11,10 +11,10 @@ processArgs()
 	fi
 }
 
-# akes project name as arg 1, and OS as arg 2
+# Takes project name as arg 1, and OS as arg 2
 destroyVM()
 {
-	cd ~/adoptopenjdkPBTests/$1/ansible
+	cd $HOME/adoptopenjdkPBTests/$1/ansible
 	ln -sf Vagrantfile.$2 Vagrantfile	# Correct Vagrantfile alias
 	vagrant destroy -f			# Force destroy without question
 	printf "\nDestroyed $2 Machine\n"	
@@ -23,7 +23,7 @@ destroyVM()
 # Takes the project name as arg1
 checkFolder()
 {
-	cd ~/adoptopenjdkPBTests
+	cd $HOME/adoptopenjdkPBTests
 	if [ -d "$1" ]; then
 		printf "\n$1 found!\n"
 		return 0
@@ -37,7 +37,7 @@ checkFolder()
 processArgs $*
 if checkFolder $1; then	
  	# For all currently supported OSs
-	for OS in Ubuntu1804 Ubuntu1604 CentOS6
+	for OS in Ubuntu1804 Ubuntu1604 CentOS6 CentOS7
 	do
 		destroyVM $1 $OS
 	done


### PR DESCRIPTION
Added checks that determine if the URL contains the word "tree". If it does, it makes a note of the branch name, and `git clone`s that single branch to test on. 
Also some small other additions:

- Changed `~` to `$HOME`

- Added CentOS7 to the list of tested OSs.

- Changed `set -eu` to `set -u`, as `-eu` was causing the test script to cancel when failing on a particular OS, without testing the proceeding OSs.