### PR TITLE
Altered CPAN's conditional so it doesn't skip installing cpanminus on CentOS6

### DIFF
--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/CPAN/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/CPAN/tasks/main.yml
@@ -8,10 +8,10 @@
   shell: "curl -L https://cpanmin.us | perl - App::cpanminus"
   ignore_errors: yes
   when:
-    - (ansible_distribution == "RedHat" and ansible_distribution_major_version == "6")
-    - (ansible_distribution == "CentOS" and ansible_distribution_major_version == "6")
-    - ansible_distribution == "SLES"
-    - ansible_distribution == "MacOSX"
+    - (ansible_distribution == "RedHat" and ansible_distribution_major_version == "6") or
+      (ansible_distribution == "CentOS" and ansible_distribution_major_version == "6") or
+      ansible_distribution == "SLES" or
+      ansible_distribution == "MacOSX"
   tags:
     - cpan
     - test_tools


### PR DESCRIPTION
Found issue whilst working with the CentOS6 playbook. The `Install JSON` task would fail due to the `Install cpanminus RedHat 6, CentOS 6 and SLES` task skipping, despite being on CentOS6.

With issue #696 closed and this, the CentOS6 playbook runs to completion.
Fixes: #807 