### PR TITLE
Adding libssl-dev role into Unix PB for Ubuntu

### DIFF
--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/vars/Ubuntu.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/vars/Ubuntu.yml
@@ -28,6 +28,7 @@ Build_Tool_Packages:
   - libgmp3-dev
   - libmpfr-dev
   - libmpfr-doc
+  - libssl-dev
   - libwww-perl
   - libx11-dev
   - libxext-dev


### PR DESCRIPTION
This is required as test builds fail due to inability to finding an PKG_CONFIG file- `openssl.pc`. This is because the OpenSSL version that is normally installed with the Ubuntu OS isn't the development version.