### PR TITLE
Added arguments to buildDocker.sh

### DIFF
--- a/ansible/pbTestScripts/buildDocker.sh
+++ b/ansible/pbTestScripts/buildDocker.sh
@@ -84,7 +84,7 @@ removeBuild()
 
 buildDocker()
 {
-	local commandString="./makejdk-any-platform.sh --clean-docker-build"
+	local commandString="./makejdk-any-platform.sh --docker --clean-docker-build"
 	if [ -n "$bootDir" ]; then
 		commandString="$commandString -J $bootDir"
 	fi


### PR DESCRIPTION
Apparently `./make-any-platform.sh --clean-docker-build` does not cause the JDK to be made in a Docker container, but instead just make a clean one. The addition of the `--docker` argument is required to make it build in the container.