### PR TITLE
Update to testScript.sh to allow for Parallelisation

### DIFF
--- a/ansible/pbTestScripts/testScript.sh
+++ b/ansible/pbTestScripts/testScript.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -u
 
-branchName='NULL'
+branchName=''
 folderName=''
 gitURL=''
 vagrantOS=''
@@ -102,7 +102,7 @@ setupFiles()
 setupGit()
 {
 	cd $WORKSPACE/adoptopenjdkPBTests
-	if [ "$branchName" == "NULL" ]; then
+	if [ "$branchName" == "" ]; then
 		echo "Detected as the master branch"
 		if [ ! -d "$folderName-master" ]; then
    			git clone $gitURL
@@ -133,7 +133,7 @@ testBuild()
 startVMPlaybook()
 {
 	local OS=$1
-	if [ "$branchName" == "NULL" ]; then
+	if [ "$branchName" == "" ]; then
 		cd $WORKSPACE/adoptopenjdkPBTests/$folderName-master/ansible
 		branchName="master"
 	else


### PR DESCRIPTION
Requested by @sxa555 .
Changes to the script include:
- Option to build a single, user specified OS, VM, or all of them as before.
- Option to build a JDK on the VM, or not, thereby allowing JUST playbook testing if needed.
- Tidied up passing arguments to the script.
- Added a usage message.