### PR TITLE
Java versions subdirectories fix & java8 symlink made

### DIFF
--- a/ansible/playbooks/aix.yml
+++ b/ansible/playbooks/aix.yml
@@ -241,22 +241,8 @@
           when: java7.stat.isdir is not defined
           tags: java7
 
-        - name: Find java7 directory
-          find:
-            file_type: directory
-            paths: /usr
-            patterns: 'jdk7u*'
-          when: java7.stat.isdir is not defined
-          register: java7_files_matched
-          tags: java7
-
-        - name: Symlink to java7_64
-          file:
-            src: "{{ item.path }}"
-            dest: /usr/java7_64
-            state: link
-          with_items:
-            - "{{ java7_files_matched.files }}"
+        - name: Rename j2sdk_image to java7_64
+          command: mv /usr/j2sdk_image /usr/java7_64
           when: java7.stat.isdir is not defined
           tags: java7
 

--- a/ansible/playbooks/aix.yml
+++ b/ansible/playbooks/aix.yml
@@ -233,19 +233,27 @@
           register: java7
           tags: java7
 
-        - name: Create /usr/java7_64 if it does not exist
-          file:
-            path: /usr/java7_64
-            state: directory
-          when: java7.stat.isdir is not defined
-
         - name: Transfer and Extract Java7
           unarchive:
             src: /Vendor_Files/aix/openjdk-7u-aix.tar
-            dest: /usr/java7_64
+            dest: /usr
             remote_src: no
           when: java7.stat.isdir is not defined
           tags: java7
+
+        - name: Find java7 directory
+          find:
+            file_type: directory
+            paths: /usr
+            patterns: 'jdk7u*'
+          register: java7_files_matched
+          tags: java7
+
+        - name: Rename to java7_64
+          command: mv "{{ item.path }}" /usr/java7_64
+          with_items:
+            - "{{ java7_files_matched.files }}"
+          tags: java7	  
 
       ##############
       # Boot JDK 8 #
@@ -256,19 +264,30 @@
           register: java8
           tags: java8
 
-        - name: Create /usr/java8_64 if it does not exist
-          file:
-            path: /usr/java8_64
-            state: directory
-          when: java8.stat.isdir is not defined
-          tags: java8
-
         - name: Transfer and Extract AdoptOpenJDK 8
           unarchive:
             src: https://api.adoptopenjdk.net/v2/binary/releases/openjdk8?openjdk_impl={{ bootjdk }}&os=aix&arch=ppc64&release=latest&type=jdk
-            dest: /usr/java8_64
+            dest: /usr
             remote_src: yes
           when: java8.stat.isdir is not defined
+          tags: java8
+
+        - name: Find java8 directory
+          find:
+            file_type: directory
+            paths: /usr
+            patterns: 'jdk8u*'
+          register: java8_files_matched
+          tags: java8
+
+        - name: Rename to java8_64
+          command: mv "{{ item.path }}" /usr/java8_64
+          with_items:
+            - "{{ java8_files_matched.files }}"
+          tags: java8
+
+        - name: Setting Java 8 as default
+          command: ln -s /usr/java8_64/jre/bin/java usr/bin/java
           tags: java8
 
       ##############
@@ -280,19 +299,26 @@
           register: java9
           tags: java9
 
-        - name: Create /usr/java9_64 if it does not exist
-          file:
-            path: /usr/java9_64
-            state: directory
-          when: java9.stat.isdir is not defined
-          tags: java9
-
         - name: Transfer and Extract AdoptOpenJDK 9
           unarchive:
             src: https://api.adoptopenjdk.net/v2/binary/releases/openjdk9?openjdk_impl={{ bootjdk }}&os=aix&arch=ppc64&release=latest&type=jdk
-            dest: /usr/java9_64
+            dest: /usr
             remote_src: yes
           when: java9.stat.isdir is not defined
+          tags: java9
+
+        - name: Find java9 directory
+          find:
+            file_type: directory
+            paths: /usr
+            patterns: 'jdk9*'
+          register: java9_files_matched
+          tags: java9
+
+        - name: Rename to java9_64
+          command: mv "{{ item.path }}" /usr/java9_64
+          with_items:
+            - "{{ java9_files_matched.files }}"
           tags: java9
 
 
@@ -305,20 +331,28 @@
           register: java10
           tags: java10
 
-        - name: Create /usr/java10_64 if it does not exist
-          file:
-            path: /usr/java10_64
-            state: directory
-          when: java10.stat.isdir is not defined
-          tags: java10
-
         - name: Transfer and Extract AdoptOpenJDK 10
           unarchive:
             src: https://api.adoptopenjdk.net/v2/binary/releases/openjdk10?openjdk_impl=openj9&os=aix&arch=ppc64&release=latest&type=jdk
-            dest: /usr/java10_64
+            dest: /usr
             remote_src: yes
           when: java10.stat.isdir is not defined
           tags: java10
+
+        - name: Find java10 directory
+          find:
+            file_type: directory
+            paths: /usr
+            patterns: 'jdk10*'
+          register: java10_files_matched
+          tags: java10
+
+        - name: Rename to java10_64
+          command: mv "{{ item.path }}" /usr/java10_64
+          with_items:
+            - "{{ java10_files_matched.files }}"
+          tags: java10
+
 
         #################
         # OpenJ9 JDK 11 #
@@ -329,18 +363,27 @@
           register: java11
           tags: java11
 
-        - name: Create /usr/java11_64 if it does not exist
-          file:
-            path: /usr/java11_64
-            state: directory
-          when: java11.stat.isdir is not defined
-          tags: java11
-
         - name: Transfer and Extract AdoptOpenJDK 11
           unarchive:
             src: https://api.adoptopenjdk.net/v2/binary/releases/openjdk11?openjdk_impl=openj9&os=aix&arch=ppc64&release=latest&type=jdk
-            dest: /usr/java11_64
+            dest: /usr
             remote_src: yes
+          when: java11.stat.isdir is not defined
+          tags: java11
+
+        - name: Find java11 directory
+          find:
+            file_type: directory
+            paths: /usr
+            patterns: 'jdk11*'
+          when: java11.stat.isdir is not defined
+          register: java11_files_matched
+          tags: java11
+
+        - name: Rename to java11_64
+          command: mv "{{ item.path }}" /usr/java11_64
+          with_items:
+            - "{{ java11_files_matched.files }}"
           when: java11.stat.isdir is not defined
           tags: java11
 
@@ -353,18 +396,27 @@
           register: java12
           tags: java12
 
-        - name: Create /usr/java12_64 if it does not exist
-          file:
-            path: /usr/java12_64
-            state: directory
-          when: java12.stat.isdir is not defined
-          tags: java12
-
         - name: Transfer and Extract AdoptOpenJDK 12
           unarchive:
             src: https://api.adoptopenjdk.net/v2/binary/releases/openjdk12?openjdk_impl=openj9&os=aix&arch=ppc64&release=latest&type=jdk
-            dest: /usr/java12_64
+            dest: /usr
             remote_src: yes
+          when: java12.stat.isdir is not defined
+          tags: java12
+
+        - name: Find java12 directory
+          find:
+            file_type: directory
+            paths: /usr
+            patterns: 'jdk12*'
+          when: java12.stat.isdir is not defined
+          register: java12_files_matched
+          tags: java12
+
+        - name: Rename to java12_64
+          command: mv "{{ item.path }}" /usr/java12_64
+          with_items:
+            - "{{ java12_files_matched.files }}"
           when: java12.stat.isdir is not defined
           tags: java12
 

--- a/ansible/playbooks/aix.yml
+++ b/ansible/playbooks/aix.yml
@@ -246,14 +246,19 @@
             file_type: directory
             paths: /usr
             patterns: 'jdk7u*'
+          when: java7.stat.isdir is not defined
           register: java7_files_matched
           tags: java7
 
-        - name: Rename to java7_64
-          command: mv "{{ item.path }}" /usr/java7_64
+        - name: Symlink to java7_64
+          file:
+            src: "{{ item.path }}"
+            dest: /usr/java7_64
+            state: link
           with_items:
             - "{{ java7_files_matched.files }}"
-          tags: java7	  
+          when: java7.stat.isdir is not defined
+          tags: java7
 
       ##############
       # Boot JDK 8 #
@@ -277,17 +282,25 @@
             file_type: directory
             paths: /usr
             patterns: 'jdk8u*'
+          when: java8.stat.isdir is not defined
           register: java8_files_matched
           tags: java8
 
-        - name: Rename to java8_64
-          command: mv "{{ item.path }}" /usr/java8_64
+        - name: Symlink to java8_64
+          file:
+            src: "{{ item.path }}"
+            dest: /usr/java8_64
+            state: link
           with_items:
             - "{{ java8_files_matched.files }}"
+          when: java8.stat.isdir is not defined
           tags: java8
 
         - name: Setting Java 8 as default
-          command: ln -s /usr/java8_64/jre/bin/java usr/bin/java
+          file:
+            src: /usr/java8_64
+            dest: /usr/bin/java
+            state: link
           tags: java8
 
       ##############
@@ -311,14 +324,19 @@
           find:
             file_type: directory
             paths: /usr
-            patterns: 'jdk9*'
+            patterns: 'jdk-9*'
+          when: java9.stat.isdir is not defined
           register: java9_files_matched
           tags: java9
 
-        - name: Rename to java9_64
-          command: mv "{{ item.path }}" /usr/java9_64
+        - name: Symlink to java9_64
+          file:
+            src: "{{ item.path }}"
+            dest: /usr/java9_64
+            state: link
           with_items:
             - "{{ java9_files_matched.files }}"
+          when: java9.stat.isdir is not defined
           tags: java9
 
 
@@ -343,14 +361,19 @@
           find:
             file_type: directory
             paths: /usr
-            patterns: 'jdk10*'
+            patterns: 'jdk-10*'
+          when: java10.stat.isdir is not defined
           register: java10_files_matched
           tags: java10
 
-        - name: Rename to java10_64
-          command: mv "{{ item.path }}" /usr/java10_64
+        - name: Symlink to java10_64
+          file:
+            src: "{{ item.path }}"
+            dest: /usr/java10_64
+            state: link
           with_items:
             - "{{ java10_files_matched.files }}"
+          when: java10.stat.isdir is not defined
           tags: java10
 
 
@@ -375,13 +398,16 @@
           find:
             file_type: directory
             paths: /usr
-            patterns: 'jdk11*'
+            patterns: 'jdk-11*'
           when: java11.stat.isdir is not defined
           register: java11_files_matched
           tags: java11
 
-        - name: Rename to java11_64
-          command: mv "{{ item.path }}" /usr/java11_64
+        - name: Symlink to java11_64
+          file:
+            src: "{{ item.path }}"
+            dest: /usr/java11_64
+            state: link
           with_items:
             - "{{ java11_files_matched.files }}"
           when: java11.stat.isdir is not defined
@@ -408,13 +434,16 @@
           find:
             file_type: directory
             paths: /usr
-            patterns: 'jdk12*'
+            patterns: 'jdk-12*'
           when: java12.stat.isdir is not defined
           register: java12_files_matched
           tags: java12
 
-        - name: Rename to java12_64
-          command: mv "{{ item.path }}" /usr/java12_64
+        - name: Symlink to java12_64
+          file:
+            src: "{{ item.path }}"
+            dest: /usr/java12_64
+            state: link
           with_items:
             - "{{ java12_files_matched.files }}"
           when: java12.stat.isdir is not defined


### PR DESCRIPTION
In the AIX playbook, the java will now extract the Java versions to `/usr`, and then rename them to `JavaX_64`, as opposed to making the subdirectory.
Sets Java8 to be the default Java once extracting.

Fixes #858 