### PR TITLE
Changed NVidia_Cuda_Toolkit role to fully install on Windows

### DIFF
--- a/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/roles/NVidia_Cuda_Toolkit/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/roles/NVidia_Cuda_Toolkit/tasks/main.yml
@@ -16,7 +16,7 @@
   tags: NVidia_Cuda_Toolkit
 
 - name: Install NVidia CUDA toolkit - Windows 7,8 and Server 2008,2012
-  win_shell: C:\temp\cuda_9.0.176_windows_network-exe.exe -s CUDAToolkit_9.0
+  win_shell: C:\temp\cuda_9.0.176_windows_network-exe.exe -s compiler_9.0
   when: (cuda_installed.stat.exists == false) and (ansible_distribution_major_version == "5" or ansible_distribution_major_version == "6")
   tags: NVidia_Cuda_Toolkit
 
@@ -35,7 +35,7 @@
   tags: NVidia_Cuda_Toolkit
 
 - name: Install NVidia CUDA toolkit - Windows 10 and Server 2016
-  win_shell: C:\temp\cuda_9.0.176_win10_network-exe.exe -s CUDAToolkit_9.0
+  win_shell: C:\temp\cuda_9.0.176_win10_network-exe.exe -s compiler_9.0
   when: (cuda_installed.stat.exists == false and ansible_distribution_major_version == "10")
   tags: NVidia_Cuda_Toolkit
 


### PR DESCRIPTION
Changed as per the conversation on #851 .
Tested on a Windows 2012R2 Vagrant VM. Once playbook was ran with the changes, `include` is in the `C:/Program Files/NVIDIA GPU Computing Toolkit/CUDA/v9.0` directory, and contains `cuda.h`, as that's what the build checks for.