### PR TITLE
Adding correct tags to the Windows Playbook

### DIFF
--- a/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/roles/Freemarker/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/roles/Freemarker/tasks/main.yml
@@ -7,11 +7,15 @@
   win_stat:
     path: 'C:\openjdk\freemarker.jar'
   register: freemarker_installed
-  tags: Freemarker
+  tags:
+    - Freemarker
+    - adoptopenjdk
 
 - name: Download freemarker
   win_get_url:
     url: http://central.maven.org/maven2/freemarker/freemarker/2.3.8/freemarker-2.3.8.jar
     dest: 'C:\openjdk\freemarker.jar'
   when: (freemarker_installed.stat.exists == false)
-  tags: Freemarker
+  tags:
+    - Freemarker
+    - adoptopenjdk

--- a/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/roles/Jenkins/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/roles/Jenkins/tasks/main.yml
@@ -11,9 +11,7 @@
     password_never_expires: true
     groups:
       - Users, Remote Desktop Users
-  tags:
-    - jenkins_user
-    - jenkins
+  tags: jenkins
 
 
 #######################################################################
@@ -37,6 +35,4 @@
     username: SYSTEM
     state: present
     enabled: true
-  tags:
-    - jenkins_workspace
-    - jenkins
+  tags: jenkins

--- a/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/roles/Jenkins/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/roles/Jenkins/tasks/main.yml
@@ -11,7 +11,9 @@
     password_never_expires: true
     groups:
       - Users, Remote Desktop Users
-  tags: jenkins_user
+  tags:
+    - jenkins_user
+    - jenkins
 
 
 #######################################################################
@@ -35,4 +37,6 @@
     username: SYSTEM
     state: present
     enabled: true
-  tags: jenkins_workspace
+  tags:
+    - jenkins_workspace
+    - jenkins


### PR DESCRIPTION
As per @sxa555 's request.
The addition of these tags are to remain consistent with the Unix playbook's Jenkins tag, and allows testing of the playbook that don't require parts of the `Vendor_Files` folder.
