### PR TITLE
Automation of Windows playbook testing

### DIFF
--- a/ansible/Vagrantfile.Win2012
+++ b/ansible/Vagrantfile.Win2012
@@ -1,12 +1,14 @@
 # -*- mode: ruby -*-
 # vi: set ft=ruby :
 
-# Runs powershell as an administator and gets/executes an Ansible provided script that configures WinRM to allow Ansible to communicate over it.
+# Runs powershell as an administator and gets/executes an Ansible provided script that configures WinRM to allow Ansible to communicate over it. Then places a file in the shared folder of the VM that contains the IP address of the VM.
 $script = <<SCRIPT
 Start-Process powershell -Verb runAs
 wget https://raw.githubusercontent.com/ansible/ansible/devel/examples/scripts/ConfigureRemotingForAnsible.ps1 -OutFile .\\ConfigureRemotingForAnsible.ps1
 .\\ConfigureRemotingForAnsible.ps1 -EnableCredSSP
-ipConfig
+$IPArray=Get-NetIPAddress | % {$_.IPAddress }
+$IPArray -split('\n')
+echo $IPArray[5] | Out-file -Encoding ASCII -FilePath C:/vagrant/playbooks/AdoptOpenJDK_Windows_Playbook/hosts.win
 SCRIPT
 
 # 2 = version of configuration file for Vagrant 1.1+ leading up to 2.0.x

--- a/ansible/pbTestScripts/testScript.sh
+++ b/ansible/pbTestScripts/testScript.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-set -u
+set -eu
 
 branchName=''
 folderName=''
@@ -71,8 +71,10 @@ checkVagrantOS()
 			vagrantOS="CentOS6" ;;
 		"CentOS7" | "centos7" | "C7" | "c7" )
 			vagrantOS="CentOS7" ;;
+		"Windows2012" | "Win2012" | "W12" | "w12" )
+			vagrantOS="Win2012";;
 		"all" )
-			vagrantOS="Ubuntu1604 Ubuntu1804 CentOS6 CentOS7" ;;
+			vagrantOS="Ubuntu1604 Ubuntu1804 CentOS6 CentOS7 Windows2012" ;;
 		*) echo "Not a currently supported OS" ; vagrantOSList; exit 1;
 	esac
 }
@@ -84,7 +86,8 @@ vagrantOSList()
 		- Ubuntu1604
 		- Ubuntu1804
 		- CentOS6
-		- CentOS7"
+		- CentOS7
+		- Win2012"
 	echo
 }
 
@@ -149,6 +152,31 @@ startVMPlaybook()
 	vagrant halt
 }
 
+startVMPlaybookWin()
+{
+	local OS=$1
+	if [ "$branchName" == "" ]; then
+		cd $WORKSPACE/adoptopenjdkPBTests/$folderName-master/ansible
+		branchName="master"
+	else
+		cd $WORKSPACE/adoptopenjdkPBTests/$folderName-$branchName/ansible
+	fi
+	ln -sf Vagrantfile.$OS Vagrantfile
+	vagrant up
+	# Changes the value of "hosts" in main.yml
+	sed -i'' -e "s/.*hosts:.*/- hosts: all/g" playbooks/AdoptOpenJDK_Windows_Playbook/main.yml
+	# Uncomments and sets the ansible_password to 'vagrant', in adoptopenjdk_variables.yml
+	sed -i'' -e "s/.*ansible_password.*/ansible_password: vagrant/g" playbooks/AdoptOpenJDK_Windows_Playbook/group_vars/all/adoptopenjdk_variables.yml
+	# if "credssp" isn't found in adoptopenjdk_variables.yml
+	if ! grep -q "credssp" playbooks/AdoptOpenJDK_Windows_Playbook/group_vars/all/adoptopenjdk_variables.yml;
+	then
+		# Add the "ansible_winrm_transport" to adoptopenjdk_variables.yml
+		echo -e "\nansible_winrm_transport: credssp" >> playbooks/AdoptOpenJDK_Windows_Playbook/group_vars/all/adoptopenjdk_variables.yml
+	fi
+	# run the ansible playbook on the VM & logs the output.
+	sudo ansible-playbook -i playbooks/AdoptOpenJDK_Windows_Playbook/hosts.win -u vagrant --skip-tags jenkins playbooks/AdoptOpenJDK_Windows_Playbook/main.yml 2>&1 | tee ~/adoptopenjdkPBTests/logFiles/$folderName.$branchName.$OS.log
+}
+
 destroyVM()
 {
 	printf "Destroying Machine . . .\n"
@@ -165,8 +193,11 @@ searchLogFiles()
 	elif grep -q '\[ERROR\]' *$2.$1.log
 	then
 		printf "\n$1 playbook was stopped\n"
-	else
+	elif grep -q 'failed=0' *$2.$1.log
+	then
 		printf "\n$1 playbook succeeded\n"
+	else
+		printf "\n$1 playbook undetermined\n"
 	fi
 }
 
@@ -200,7 +231,11 @@ setupGit
 echo "Testing on the following OSs: $vagrantOS"
 for OS in $vagrantOS
 do
-	startVMPlaybook $OS
+	if [[ "$OS" == "Win2012" ]]; then
+		startVMPlaybookWin $OS
+	else
+		startVMPlaybook $OS
+	fi
 	if [[ "$retainVM" = false ]]
 	then
 		destroyVM

--- a/ansible/pbTestScripts/testScript.sh
+++ b/ansible/pbTestScripts/testScript.sh
@@ -174,7 +174,7 @@ startVMPlaybookWin()
 		echo -e "\nansible_winrm_transport: credssp" >> playbooks/AdoptOpenJDK_Windows_Playbook/group_vars/all/adoptopenjdk_variables.yml
 	fi
 	# run the ansible playbook on the VM & logs the output.
-	sudo ansible-playbook -i playbooks/AdoptOpenJDK_Windows_Playbook/hosts.win -u vagrant --skip-tags jenkins playbooks/AdoptOpenJDK_Windows_Playbook/main.yml 2>&1 | tee ~/adoptopenjdkPBTests/logFiles/$folderName.$branchName.$OS.log
+	ansible-playbook -i playbooks/AdoptOpenJDK_Windows_Playbook/hosts.win -u vagrant --skip-tags jenkins playbooks/AdoptOpenJDK_Windows_Playbook/main.yml 2>&1 | tee ~/adoptopenjdkPBTests/logFiles/$folderName.$branchName.$OS.log
 }
 
 destroyVM()


### PR DESCRIPTION
Edits have been done to allow for automating testing of the Windows playbook, using the Win2012 vagrantfile.
Edits include:
- Adding into the Vagrantfile's inline script, commands to find the IP address of the Vagrant VM, and save it to a file within the shared folder.
- Automatically changing various files to enable connection through ansible:
     - Changed ` - hosts: "{{ groups['Vendo ... ` to ` - hosts: all`;
     - Enabling the ansible_password var in `../AdoptOpenJDK_Windows_Playbook/group_vars/all/adoptopenjdk_variables.yml`
     - Adding `ansible_winrm_transport: credssp` to the same file.
- Changing `testScript.sh` to allow "Win2012", and variations as a viable OS.

Note: Unfortunately, if `./testScript.sh --build -v Win2012` is executed, it won't build a JDK on the Vagrant VM yet. The `--build` option currently doesn't do anything.