### PR TITLE
Disabled GUI for Windows Vagrantfile on VagrantUp

### DIFF
--- a/ansible/Vagrantfile.Win2012
+++ b/ansible/Vagrantfile.Win2012
@@ -22,4 +22,7 @@ Vagrant.configure("2") do |config|
     adoptopenjdkW2012.vm.network :private_network, type: "dhcp"
     adoptopenjdkW2012.vm.provision "shell", inline: $script, privileged: false
   end
+  config.v.provider "virtualbox" do |v|
+    v.gui = false
+  end
 end


### PR DESCRIPTION
Required for issue #924 
The vagrant box that the Vagrantfile uses automatically boots a Windows GUI when running `vagrant up`. This is causing issues as the Jenkins Job is unable to produce that GUI, causing an error. 
With #927 being merged and the Vagrantfile's inline shell configuring the Windows VM on `vagrant up`, the GUI isn't necessary anyway.
