### PR TITLE
Added functionality for testScript.sh to run a test on a built JDK

### DIFF
--- a/ansible/pbTestScripts/testJDK.sh
+++ b/ansible/pbTestScripts/testJDK.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+mv /vagrant/pbTestScripts/workspace/build/src/build/linux-x86_64-normal-server-release/images/jdk8* ~
+export TEST_JDK_HOME=$(find ~ -maxdepth 1 -type d -name "*jdk8u*"|grep -v ".*jre.*")
+cd $HOME && mkdir -p testLocation
+cd testLocation && git clone https://github.com/adoptopenjdk/openjdk-tests
+cd openjdk-tests
+./get.sh -t $HOME/testLocation/openjdk-tests
+cd TestConfig
+make -f run_configure.mk
+export BUILD_LIST=MachineInfo
+make compile
+make _MachineInfo
+


### PR DESCRIPTION
Ref: #939 

Currently only implemented for the unix playbooks. If the option is specified, the script will run the `MachineInfo` test against a version of JDK8 that is built on the VM, having been setup by the playbook. It won't allow a test to be ran unless a JDK is built.