### PR TITLE
Added install component to Windows PB CUDA role

### DIFF
--- a/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/roles/NVidia_Cuda_Toolkit/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/roles/NVidia_Cuda_Toolkit/tasks/main.yml
@@ -16,7 +16,7 @@
   tags: NVidia_Cuda_Toolkit
 
 - name: Install NVidia CUDA toolkit - Windows 7,8 and Server 2008,2012
-  win_shell: C:\temp\cuda_9.0.176_windows_network-exe.exe -s compiler_9.0
+  win_shell: C:\temp\cuda_9.0.176_windows_network-exe.exe -s compiler_9.0 nvml_dev_9.0
   when: (cuda_installed.stat.exists == false) and (ansible_distribution_major_version == "5" or ansible_distribution_major_version == "6")
   tags: NVidia_Cuda_Toolkit
 
@@ -35,7 +35,7 @@
   tags: NVidia_Cuda_Toolkit
 
 - name: Install NVidia CUDA toolkit - Windows 10 and Server 2016
-  win_shell: C:\temp\cuda_9.0.176_win10_network-exe.exe -s compiler_9.0
+  win_shell: C:\temp\cuda_9.0.176_win10_network-exe.exe -s compiler_9.0 nvml_dev_9.0
   when: (cuda_installed.stat.exists == false and ansible_distribution_major_version == "10")
   tags: NVidia_Cuda_Toolkit
 


### PR DESCRIPTION
Whilst going through the PR to test builds on Windows, I've found an issue that the Windows PB doesn't install the NVidia Management Library as part of the Cuda toolkit, (an error stated that it couldn't find `nvml.h`). With the addition of this component put into the CUDA installation, the correct file is there.