### PR TITLE
Added VS2010_SP1 role to Windows playbook

### DIFF
--- a/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/main.yml
@@ -35,6 +35,7 @@
     - Windows_Updates
     - Jenkins                     # AdoptOpenJDK infrastructure
     - MSVS_2010
+    - VS2010_SP1
     - cygwin
     - Firefox
     - Strawberry_Perl             # Testing

--- a/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/roles/VS2010_SP1/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/roles/VS2010_SP1/tasks/main.yml
@@ -1,0 +1,20 @@
+---
+########################################
+# Visual Studio 2010 Service Package 1 #
+########################################
+
+- name: Check if VS2010SP1 has been downloaded
+  win_stat:
+    path: 'C:\temp\vs2010sp1.exe'
+  register: vs2010sp1_installed
+  tags: VS2010_SP1
+
+- name: Download VS2010SP1
+  win_shell: Invoke-WebRequest 'http://download.microsoft.com/download/2/3/0/230C4F4A-2D3C-4D3B-B991-2A9133904E35/VS10sp1-KB983509.exe' -OutFile C:\temp\vs2010sp1.exe;
+  when: (vs2010sp1_installed.stat.exists == false)
+  tags: VS2010_SP1
+
+- name: Install VS2010SP1
+  raw: 'C:\temp\vs2010sp1.exe /q /norestart'
+  when: (vs2010sp1_installed.stat.exists == false)
+  tags: VS2010_SP1


### PR DESCRIPTION
Fixes: #383 
Ref: #553 , #942 

Found a way that should download and install VS2010_SP1 from the Windows Playbook. Must have MSVS2010 installed first. I've tested this on a Windows VM that did have MSVS2010 installed prior, but having ran MSVS_2010 and the new VS2010_SP1 tags on the playbook, it showed `Microsoft Visual Studio 2010 Version 10.0.40219.1 SP1Rel` under `help --> about microsoft visual studio`, which I believe means SP1 installed correctly.