### PR TITLE
Refactor of Playbook Scripts

### DIFF
--- a/ansible/pbTestScripts/README.md
+++ b/ansible/pbTestScripts/README.md
@@ -6,20 +6,35 @@ This folder contains the scripts necessary to start separate vagrant machines wi
 * Ubuntu 18.04
 * CentOS6
 * CentOS7
+* Windows Server 2012 R2
 
-And subsequently test those machine’s playbooks, and build jdk8 on them.
+And subsequently test those machine’s playbooks, and optionally build jdk8u and test the jdk built
 
-Start by executing _testScript.sh_ with 2 arguments; the `GitHub URL` to be tested, and a `y/n` to specify keeping the VMs alive or not. The Github URL can be in two forms:
+The script takes a number of options:
 
+| Option               | Description                                           | Example                                                                           |
+|----------------------|-------------------------------------------------------|-----------------------------------------------------------------------------------|
+| --all / -a           | Runs for all OSs                                      | `./testScript.sh -a`                                                              |
+| --retainVM / -r      | Retains the VM after running the Playbook             | `./testScript.sh -a --retainVM`                                                   |
+| --build / -b         | Build JDK8 on the VM after the playbook               | `./testScript.sh -a --build`                                                      |
+| --URL / -u <Git URL> | Specify the URL of the infrastructure repo to clone * | `./testScript.sh -a --URL https://github.com/adoptopenjdk/openjdk-infrastructure` |
+| --test / -t          | Run a small test on the built JDK within the VM **    | `./testScript.sh -a --build --test`                                               |
+| --help               | Displays usage                                        | `./testScript.sh --help`                                                          |
+
+Notes:
+ - If not specified, the URL will default to `https://github.com/adoptopenjdk/openjdk-infrastructure`
+ - `--test` requires `--build` be enabled, otherwise the script will error.
+
+The script is able to test specific branches of repositories, as well as the master branch, for example:
 * "https://github.com/adoptopenjdk/openjdk-infrastructure" will git clone and test the master branch of adoptopenjdk/openjdk-infrastructure.
 * "https://github.com/adoptopenjdk/openjdk-infrastructure/tree/branch_name" will git clone and test the "branch_name" branch of adoptopenjdk/openjdk-infrastructure
 
 This can also be done on other people's forks of the repository, for example:
-
 * "https://github.com/username/openjdk-infrastructure/tree/branch_name" will git clone the "branch_name" branch of "username"s fork of the repository 
 
 The script will then make a directory in the User’s home called _adoptopenjdkPBTests_, in which another directory containing the log files, and the Git repository is stored. Following that, the script will run each ansible playbook on their respective VMs, writing the output to the aforementioned log files.
-
 After each playbook is ran through, a summary is given, containing which OS playbooks succeeded, failed, or were cancelled. The logs can also be perused to get more in-depth error messages.
+
+If specified, the VMs will then be tested by building JDK8 - if all dependencies are filled by the playbook as they should be, the JDK will be successfully built. If the `--test` option is then specified, the JDK will then have a simple test ran against it that will ensure it was built properly. 
 
 If the VMs were chosen *not* to be destroyed, they can be later by running the _vmDestroy.sh_ script, which takes the `project folder` as an argument. If that folder is found, it will run through and destroy the VMs.

--- a/ansible/pbTestScripts/buildJDK.sh
+++ b/ansible/pbTestScripts/buildJDK.sh
@@ -1,11 +1,15 @@
 #!/bin/bash
 set -eu
+if [ -z "${WORKSPACE:-}" ]; then
+		echo "WORKSPACE not found, setting it as environment variable 'HOME'"
+		WORKSPACE=$HOME
+	fi
 export TARGET_OS=linux
 export ARCHITECTURE=x64
 export JAVA_TO_BUILD=jdk8u
 export VARIANT=openj9
 export JDK7_BOOT_DIR=/usr/lib/jvm/java-1.7.0
 export JDK_BOOT_DIR=/usr/lib/jvm/java-8-openjdk-amd64
-cd ~/openjdk-build
+cd $WORKSPACE/openjdk-build
 build-farm/make-adopt-build-farm.sh
 

--- a/ansible/pbTestScripts/vmDestroy.sh
+++ b/ansible/pbTestScripts/vmDestroy.sh
@@ -4,32 +4,38 @@ set -eu
 # Takes in all arguments
 processArgs()
 {
+	if [ ! -n "${WORKSPACE:-}" ]; then
+		echo "WORKSPACE not found, setting it as environment variable 'HOME'"
+		WORKSPACE=$HOME
+	fi
 	if [ $# -lt 1 ]; then
-		printf "\nScript takes 1 input argument\n"
-		printf "The project whose VMs are to be destroyed\n\n"
+		echo "Script takes 1 input argument: "
+		echo "The project whose VMs are to be destroyed"
 		exit 1
 	fi
+	
 }
 
 # Takes project name as arg 1, and OS as arg 2
 destroyVM()
 {
-	cd $HOME/adoptopenjdkPBTests/$1/ansible
+	cd $WORKSPACE/adoptopenjdkPBTests/$1/ansible
 	ln -sf Vagrantfile.$2 Vagrantfile	# Correct Vagrantfile alias
 	vagrant destroy -f			# Force destroy without question
-	printf "\nDestroyed $2 Machine\n"	
+	echo
+	echo "Destroyed $2 Machine"	
 }
 
 # Takes the project name as arg1
 checkFolder()
 {
-	cd $HOME/adoptopenjdkPBTests
+	cd $WORKSPACE/adoptopenjdkPBTests
 	if [ -d "$1" ]; then
-		printf "\n$1 found!\n"
+		echo "$1 found!"
 		return 0
 	else
-		printf "\n$1 not found\n"
-		return 1
+		echo "$1 not found"
+		exit 1
 	fi
 }
 
@@ -37,7 +43,7 @@ checkFolder()
 processArgs $*
 if checkFolder $1; then	
  	# For all currently supported OSs
-	for OS in Ubuntu1804 Ubuntu1604 CentOS6 CentOS7
+	for OS in Ubuntu1804 Ubuntu1604 CentOS6 CentOS7 Win2012
 	do
 		destroyVM $1 $OS
 	done


### PR DESCRIPTION
Small updates to the scripts I've written over the last couple months that have been annoying me:
- Updating `README.md` to reflect how to use the scripts, and adding an options table.
- Changing in `buildJDK.sh` tilde to `$WORKSPACE` and a subsequent check incase `WORKSPACE` isn't detected.
-  Changing `testScript.sh` so it uses  just `echo` and not a mix of `echo` and `printf`. Also to be more specific with the log file searches.
- in `vmDestroy.sh`, add `Win2012` to the list of OSs, change `$HOME` to `$WORKSPACE` (with the aforementioned check), and standardised the use of `echo`, not `echo` and `printf`