### PR TITLE
Added disksize parameter to Win2012 Vagrantfile

### DIFF
--- a/ansible/README.md
+++ b/ansible/README.md
@@ -102,12 +102,13 @@ Yes, in order to access the package repositories (we will perform either `yum in
 As Ansible can't run on Windows, it has to be run on a seperate system and then pointed at a Windows machine (such as a VM). To test the playbook, a vagrant VM can be used.
 You can do this by following these steps:
 
-1) `git clone "https://github.com/AdoptOpenJdk/openjdk-infrastructure/"`
-2) `ln -sf Vagrantfile.WindowsS12 Vagrantfile && vagrant up` in the cloned `/openjdk-infrastructure/ansible` directory
-3) Note the IP address that is output from running `vagrant up` and place it into a text file. e.g. `hosts.win`. Place this text file in `../anisble/playbooks/AdoptopenJDK_Windows_Playbook`
-4) Edit `../AdoptOpenJDK_Windows_Playbook/main.yml` so the `- hosts :{{ groups['Vendor_groups'] ... etc` becomes `- hosts: all`
-5) Add into `../AdoptOpenJDK_Windows_Playbook/group_vars/all/adoptopenjdk_variables.yml` the line `ansible_winrm_transport: credssp`. You'll also need to uncomment and change `ansible_password: CHANGE_ME`.
-6) From the `../ansible` directory, running `sudo ansible-playbook -i playbooks/AdoptOpenJDK_Windows_Playbook/hosts.win -u vagrant playbooks/AdoptOpenJDK_Windows_Playbook/main.yml` will start the playbook.
+1) Run `vagrant plugin install vagrant-disksize`. This will install a plugin that allows the user to specify the disksize of the VM.
+2) `git clone "https://github.com/AdoptOpenJdk/openjdk-infrastructure/"`
+3) `ln -sf Vagrantfile.WindowsS12 Vagrantfile && vagrant up` in the cloned `/openjdk-infrastructure/ansible` directory
+4) Note the IP address that is output from running `vagrant up` and place it into a text file. e.g. `hosts.win`. Place this text file in `../anisble/playbooks/AdoptopenJDK_Windows_Playbook`
+5) Edit `../AdoptOpenJDK_Windows_Playbook/main.yml` so the `- hosts :{{ groups['Vendor_groups'] ... etc` becomes `- hosts: all`
+6) Add into `../AdoptOpenJDK_Windows_Playbook/group_vars/all/adoptopenjdk_variables.yml` the line `ansible_winrm_transport: credssp`. You'll also need to uncomment and change `ansible_password: CHANGE_ME`.
+7) From the `../ansible` directory, running `sudo ansible-playbook -i playbooks/AdoptOpenJDK_Windows_Playbook/hosts.win -u vagrant playbooks/AdoptOpenJDK_Windows_Playbook/main.yml` will start the playbook.
 
 Note: if using a macOS Mojave, `export OBJC_DISABLE_INITIALIZE_FORK_SAFETY=yes` will be required before starting the playbook.
  

--- a/ansible/Vagrantfile.Win2012
+++ b/ansible/Vagrantfile.Win2012
@@ -21,6 +21,7 @@ Vagrant.configure("2") do |config|
     adoptopenjdkW2012.vm.synced_folder ".", "/vagrant"
     adoptopenjdkW2012.vm.network :private_network, type: "dhcp"
     adoptopenjdkW2012.vm.provision "shell", inline: $script, privileged: false
+    adoptopenjdkW2012.disksize.size = '100GB'
   end
   config.vm.provider "virtualbox" do |v|
     v.gui = false

--- a/ansible/pbTestScripts/testScript.sh
+++ b/ansible/pbTestScripts/testScript.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#/bin/bash
 set -eu
 
 branchName=''
@@ -66,6 +66,10 @@ checkVars()
 		echo "No Vagrant OS specified; Defaulting to testing all of them"
 		vagrantOS="all"
 	fi
+        if [[ ! $(vagrant plugin list | grep 'disksize') ]]; then
+                echo "Can't find vagrant-disksize plugin, installing . . ."
+                vagrant plugin install vagrant-disksize
+        fi
 }
 
 checkVagrantOS()
@@ -166,6 +170,8 @@ startVMPlaybook()
 startVMPlaybookWin()
 {
 	local OS=$1
+	# The number of bytes the disk should be (this is 95GB in bytes)
+	local diskSizeBoundary=102005473280;
 	if [ "$branchName" == "" ]; then
 		cd $WORKSPACE/adoptopenjdkPBTests/$folderName-master/ansible
 		branchName="master"
@@ -183,6 +189,12 @@ startVMPlaybookWin()
 	then
 		# Add the "ansible_winrm_transport" to adoptopenjdk_variables.yml
 		echo -e "\nansible_winrm_transport: credssp" >> playbooks/AdoptOpenJDK_Windows_Playbook/group_vars/all/adoptopenjdk_variables.yml
+	fi
+	# getting the current c drive information and cutting it down to the number of GB it is.
+	export currentDiskSize=$(vagrant powershell -c "Start-Process powershell -Verb runAs; Get-Partition -Driveletter c | select Size" | grep '[0-9]{5,}'
+	if [[ $currentDiskSize -lt $diskSizeBoundary ]]; then
+		echo "Resizing C Drive"
+		vagrant powershell -c "Start-Process powershell -Verb runAs; \$size = (Get-PartitionSupportedSize -DriveLetter c); Resize-Partition -DriveLetter c -Size \$size.SizeMax"
 	fi
 	# run the ansible playbook on the VM & logs the output.
 	ansible-playbook -i playbooks/AdoptOpenJDK_Windows_Playbook/hosts.win -u vagrant --skip-tags jenkins,adoptopenjdk playbooks/AdoptOpenJDK_Windows_Playbook/main.yml 2>&1 | tee ~/adoptopenjdkPBTests/logFiles/$folderName.$branchName.$OS.log


### PR DESCRIPTION
Required to allow for the Ansible Playbook to fully run through - otherwise it ends up running out of diskspace around the `Clang` roles. Also added info into `README.md` as it requires the host machine install a vagrant plugin.