### PR TITLE
Added Java13 to Windows and Unix playbooks

### DIFF
--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/main.yml
@@ -43,6 +43,7 @@
     - adoptopenjdk10              # JDK11 build bootstrap
     - adoptopenjdk11              # JDK12 build bootstrap
     - adoptopenjdk12              # JDK13 build bootstrap
+    - adoptopenjdk13              # JDK14 build bootstrap
     - role: local_srcinstall
       src_tarball: https://github.com/protocolbuffers/protobuf/releases/download/v3.5.1/protobuf-cpp-3.5.1.tar.gz
       installed_target: /usr/local/bin/protoc

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/adoptopenjdk13/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/adoptopenjdk13/tasks/main.yml
@@ -1,0 +1,82 @@
+---
+########################################
+# AdoptOpenJDK 13 for bootstrapping 14 #
+########################################
+- name: Checking for /usr/lib/jvm
+  stat: path=/usr/lib/jvm
+  register: usr_lib_jvm_exists
+  tags: adoptopenjdk13
+
+- name: Creating /usr/lib/jvm if not found
+  file:
+    path: /usr/lib/jvm
+    state: directory
+    owner: root
+    group: root
+    mode: 0755
+  when: usr_lib_jvm_exists.stat.exists != True
+  tags: adoptopenjdk13
+
+- name: Check if jdk-13 is already installed in the target location
+  shell: ls -ld /usr/lib/jvm/jdk-13* >/dev/null 2>&1
+  ignore_errors: yes
+  register: adoptopenjdk13_installed
+  tags:
+    - adoptopenjdk13
+    - skip_ansible_lint
+
+- name: Install latest release if one not already installed (Linux/x64)
+  unarchive:
+    src: https://api.adoptopenjdk.net/v2/binary/releases/openjdk13?openjdk_impl={{ bootjdk }}&os=linux&arch=x64&heap_size=normal&release=latest&type=jdk
+    dest: /usr/lib/jvm
+    remote_src: yes
+  when:
+    - adoptopenjdk13_installed.rc != 0
+    - ansible_architecture == "x86_64"
+  tags: adoptopenjdk13
+
+- name: Install latest release if one not already installed (Linux/s390x)
+  unarchive:
+    src: https://api.adoptopenjdk.net/v2/binary/releases/openjdk13?openjdk_impl={{ bootjdk }}&os=linux&arch=s390x&release=latest&type=jdk
+    dest: /usr/lib/jvm
+    remote_src: yes
+  when:
+    - adoptopenjdk13_installed.rc != 0
+    - ansible_architecture == "s390x"
+  tags: adoptopenjdk13
+
+- name: Install latest release if one not already installed (Linux/ppc64le)
+  unarchive:
+    src: https://api.adoptopenjdk.net/v2/binary/releases/openjdk13?openjdk_impl={{ bootjdk }}&os=linux&arch=ppc64le&release=latest&type=jdk
+    dest: /usr/lib/jvm
+    remote_src: yes
+  when:
+    - adoptopenjdk13_installed.rc != 0
+    - ansible_architecture == "ppc64le"
+  tags: adoptopenjdk13
+
+- name: Install latest Hotspot release if one not already installed (Linux/aarch64)
+  unarchive:
+    src: https://api.adoptopenjdk.net/v2/binary/releases/openjdk13?openjdk_impl=hotspot&os=linux&arch=aarch64&release=latest&type=jdk
+    dest: /usr/lib/jvm
+    remote_src: yes
+  when:
+    - adoptopenjdk13_installed.rc != 0
+    - ansible_architecture == "aarch64"
+  tags: adoptopenjdk13
+
+- name: Get /usr/lib/jvm/jdk-13* full path name
+  shell: ls -ld /usr/lib/jvm/jdk-13* 2>/dev/null | awk '{print $9}'
+  register: adoptopenjdk13_dir
+  when: adoptopenjdk13_installed.rc != 0
+  tags: adoptopenjdk13
+
+- name: Chown /usr/lib/jvm/jdk-13*
+  file:
+    path: '{{ adoptopenjdk13_dir.stdout }}'
+    state: directory
+    owner: root
+    group: root
+    recurse: yes
+  when: adoptopenjdk13_installed.rc != 0
+  tags: adoptopenjdk13

--- a/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/main.yml
@@ -47,6 +47,7 @@
     - Java9                       # JDK10 build bootstrap
     - Java11                      # JDK11 build bootstrap
     - Java12                      # JDK12 build bootstrap
+    - Java13                      # JDK13 build bootstrap
     - ANT                         # Testing
     - MSVS_2013
     - MSVS_2017                   # OpenJ9

--- a/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/roles/Java13/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/roles/Java13/tasks/main.yml
@@ -1,0 +1,36 @@
+---
+###########
+# Java 13 #
+###########
+- name: Test if Java13 is already installed
+  win_stat:
+    path: 'C:\openjdk\jdk-13\bin'
+  register: java13_installed
+  tags: Java13
+
+- name: Check if Java13 is already downloaded
+  win_stat:
+    path: 'C:\temp\jdk-13.zip'
+  register: java13_download
+  tags: Java13
+
+- name: Download Java13
+  win_get_url:
+    url: https://api.adoptopenjdk.net/v2/binary/releases/openjdk13?openjdk_impl={{ bootjdk }}&os=windows&arch=x64&release=latest&type=jdk&heap_size={{ heapsize }}
+    dest: 'C:\temp\jdk-13.zip'
+  when: (java13_download.stat.exists == false) and (java13_installed.stat.exists == false)
+  tags: Java13
+
+- name: Install Java13
+  win_unzip:
+    src: C:\temp\jdk-13.zip
+    dest: C:\Program Files\Java
+  when: (java13_installed.stat.exists == false)
+  tags: Java13
+
+- name: Create symlink to directory without spaces if not already there
+  win_shell: for /D %a in ("C:\Program Files\Java\jdk-13*") do IF NOT EXIST "C:\openjdk\jdk-13" MKLINK /D "C:\openjdk\jdk-13" "%a"
+  args:
+    executable: cmd.exe
+    creates: 'C:\openjdk\jdk-13'
+  tags: Java13


### PR DESCRIPTION
fixes: #951 
Done by copying the respective java 12 files, and `sed`ing 12 to 13 (and then checked). 
Tested on Ubuntu1604 and Windows 2012, and they appear in the correct folders :-)