### PR TITLE
PbTest: Add JAVA_HOME var for buildJDK script

### DIFF
--- a/ansible/pbTestScripts/buildJDK.sh
+++ b/ansible/pbTestScripts/buildJDK.sh
@@ -9,7 +9,8 @@ export ARCHITECTURE=x64
 export JAVA_TO_BUILD=jdk8u
 export VARIANT=openj9
 export JDK7_BOOT_DIR=/usr/lib/jvm/java-1.7.0
-export JDK_BOOT_DIR=/usr/lib/jvm/java-8-openjdk-amd64
+export JDK_BOOT_DIR=/usr/lib/jvm/java-1.8.0-openjdk-amd64
+export JAVA_HOME=/usr/lib/jvm/java-1.8.0-openjdk-amd64
 cd $WORKSPACE/openjdk-build
 build-farm/make-adopt-build-farm.sh
 


### PR DESCRIPTION
Required to run Gradle - I remember the old iteration of this script working, so I'm puzzled as to why it doesn't suddenly. Either way, this fixes the issue.
Error message below from before the fix:
```
BUILD SUCCESSFUL in 29s
3 actionable tasks: 2 executed, 1 up-to-date
/home/vagrant/openjdk-build/sbin/build.sh: line 420: /bin/java: No such file or directory
Connection to 127.0.0.1 closed.
```