### PR TITLE
correct centos misspelling

### DIFF
--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Clean_Up/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Clean_Up/tasks/main.yml
@@ -23,7 +23,7 @@
   args:
     warn: no
   when:
-    - (ansible_distribution == "RedHat" and ansible_distribution_major_version == "7") or (ansible_distribution == "centos")
+    - (ansible_distribution == "RedHat" and ansible_distribution_major_version == "7") or (ansible_distribution == "CentOS")
   tags: clean_up
 
 - name: Remove pkg dependencies that are no longer required - FreeBSD


### PR DESCRIPTION
Changed the spelling of CentOS, from centos to CentOS in AdoptOpenJDK_Unix_Playbook/roles/Clean_Up/tasks/main.yml playbook. 

The misspelling prevented a clean up task from being executed on CentOS machines.