### PR TITLE
pbTests: Removed vagrant powershell. Put in workarounds

### DIFF
--- a/ansible/Vagrantfile.Win2012
+++ b/ansible/Vagrantfile.Win2012
@@ -9,6 +9,18 @@ wget https://raw.githubusercontent.com/ansible/ansible/devel/examples/scripts/Co
 $IPArray=Get-NetIPAddress | % {$_.IPAddress }
 $IPArray -split('\n')
 echo $IPArray[5] | Out-file -Encoding ASCII -FilePath C:/vagrant/playbooks/AdoptOpenJDK_Windows_Playbook/hosts.win
+# Retrieving disk's current size
+$currentDiskSize =(Get-Partition -DriveLetter c | select Size)
+$currentDiskSize =($currentDiskSize -replace "[^0-9]" , "")
+# The size the disk should be, in bytes (95GB)
+$diskSizeBoundary = 102005473280
+# Changing the disksize to max supported size (~100GB)
+if ([long]$currentDiskSize -lt $diskSizeBoundary) {
+        echo "Resizing disk to max size"
+        $size = (Get-PartitionSupportedSize -DriveLetter c); Resize-Partition -DriveLetter c -Size $size.SizeMax
+}else {
+        echo "Disk is already at max size"
+}
 SCRIPT
 
 # 2 = version of configuration file for Vagrant 1.1+ leading up to 2.0.x

--- a/ansible/pbTestScripts/buildJDKWin.sh
+++ b/ansible/pbTestScripts/buildJDKWin.sh
@@ -6,4 +6,12 @@ export JAVA_TO_BUILD=jdk8
 export VARIANT=hotspot
 export JDK7_BOOT_DIR=/cygdrive/c/openjdk/jdk7
 export PATH=/usr/bin/:$PATH
+# Ensures Git won't replace line endings (CRLF)
+C:/cygwin64/bin/sed -i -e 's/autocrlf.*/autocrlf = false/g' C:\\ProgramData/Git/config
+# Git clone openjdk-build if it's not currently there.
+cd C:/
+if [ ! -d "openjdk-build" ]; then
+        echo 'Cloning openJDK-build repo'
+        git clone https://github.com/adoptopenjdk/openjdk-build
+fi
 /cygdrive/c/openjdk-build/makejdk-any-platform.sh -J /cygdrive/c/openjdk/jdk-8 --configure-args "--disable-ccache --with-toolchain-version=2013" --freetype-version 2.5.3 -v jdk8u


### PR DESCRIPTION
Fixes: #977 

Changes made as follows:
- Removed all instances of `vagrant powershell` 
- Made the vagrant machine change to 100GB disksize in the Vagrantfile instead.
- Moved the cloning of openjdk-build and the changing of Git's CRLF settings into the `buildJDKWin.sh` file

Tested on a Lenovo ThinkPad running Linux Mint, as well as a Mac.