### PR TITLE
UnixPB: Changed Ccache URL

### DIFF
--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/ccache/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/ccache/tasks/main.yml
@@ -9,7 +9,7 @@
   tags: ccache
 
 - name: Download ccache.tar.gz
-  command: wget -O /tmp/ccache.tar.gz https://www.samba.org/ftp/ccache/ccache-3.4.2.tar.gz
+  command: wget -O /tmp/ccache.tar.gz https://github.com/ccache/ccache/releases/download/v3.4.2/ccache-3.4.2.tar.gz
     warn=False
   when: ccache_status.stat.isdir is not defined
   tags: ccache


### PR DESCRIPTION
Fixes the consistent error when running the playbook on CentOS6, as seen here: https://ci.adoptopenjdk.net/job/SXA-PlaybookCheckParallel/OS=CentOS6,label=infra-vagrant-1/lastBuild/consoleText

Changed the URL from the Samba website to the git-hub releases as whenever `wget` (or the `get_url` module) was used inside of Ansible, a 403 error would be given. However, it would work when executing `wget` manually. This was also working for a fair amount of time before, so it seems most likely to be a problem with the Samba website.