### PR TITLE
WinPB: Remove adoptopenjdk tag from Freemarker

### DIFF
--- a/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/roles/Freemarker/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/roles/Freemarker/tasks/main.yml
@@ -7,15 +7,11 @@
   win_stat:
     path: 'C:\openjdk\freemarker.jar'
   register: freemarker_installed
-  tags:
-    - Freemarker
-    - adoptopenjdk
+  tags: Freemarker
 
 - name: Download freemarker
   win_get_url:
     url: http://central.maven.org/maven2/freemarker/freemarker/2.3.8/freemarker-2.3.8.jar
     dest: 'C:\openjdk\freemarker.jar'
   when: (freemarker_installed.stat.exists == false)
-  tags:
-    - Freemarker
-    - adoptopenjdk
+  tags: Freemarker


### PR DESCRIPTION
Initially this was put in to keep consistency with the Unix playbook, however, a Windows machine can't build a j9-JDK without this being run as part of the playbook.