### PR TITLE
Fixed Clean_up role for Centos6

### DIFF
--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Clean_Up/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Clean_Up/tasks/main.yml
@@ -23,7 +23,7 @@
   args:
     warn: no
   when:
-    - (ansible_distribution == "RedHat" and ansible_distribution_major_version == "7") or (ansible_distribution == "CentOS")
+    - (ansible_distribution == "RedHat" and ansible_distribution_major_version == "7") or (ansible_distribution == "CentOS" and ansible_distribution_major_version = "7")
   tags: clean_up
 
 - name: Remove pkg dependencies that are no longer required - FreeBSD


### PR DESCRIPTION
The unix playbook would fail on CentOS6, as `yum -y autoremove` isn't a command apparently: 
https://ci.adoptopenjdk.net/job/SXA-PlaybookCheckParallel/OS=CentOS6,label=infra-vagrant-1/29/console

Made it specific to CentOS7