### PR TITLE
Unix PB: Removed unnecessary check in Git_source

### DIFF
--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/GIT_Source/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/GIT_Source/tasks/main.yml
@@ -89,7 +89,7 @@
       - perl-Git
     state: absent
   when:
-    - (git_installed.rc != 0 ) or (git_installed.rc == 0 and git_version.stdout is version_compare('2.15', operator='lt') )
+    - (git_installed.rc == 0 and git_version.stdout is version_compare('2.15', operator='lt') )
     - ansible_distribution == "CentOS" or ansible_distribution == "RedHat"
   tags:
     - git_source
@@ -100,7 +100,7 @@
     name: git
     state: absent
   when:
-    - (git_installed.rc != 0 ) or (git_installed.rc == 0 and git_version.stdout is version_compare('2.15', operator='lt') )
+    - (git_installed.rc == 0 and git_version.stdout is version_compare('2.15', operator='lt') )
     - ansible_distribution == "SLES"
   tags:
     - git_source


### PR DESCRIPTION
`git_installed.rc` has to be 0, to carry out the action, because you can't remove what isn't there.