### PR TITLE
WinVF: Fixed finding IP

### DIFF
--- a/ansible/Vagrantfile.Win2012
+++ b/ansible/Vagrantfile.Win2012
@@ -6,9 +6,9 @@ $script = <<SCRIPT
 Start-Process powershell -Verb runAs
 wget https://raw.githubusercontent.com/ansible/ansible/devel/examples/scripts/ConfigureRemotingForAnsible.ps1 -OutFile .\\ConfigureRemotingForAnsible.ps1
 .\\ConfigureRemotingForAnsible.ps1 -EnableCredSSP
-$IPArray=Get-NetIPAddress | % {$_.IPAddress }
-$IPArray -split('\n')
-echo $IPArray[5] | Out-file -Encoding ASCII -FilePath C:/vagrant/playbooks/AdoptOpenJDK_Windows_Playbook/hosts.win
+$IPArray=(Get-NetIPAddress | select IPAddress)
+$IPArray=$IPArray | findstr /b 172
+echo $IPArray | Out-file -Encoding ASCII -FilePath C:/vagrant/playbooks/AdoptOpenJDK_Windows_Playbook/hosts.win
 # Retrieving disk's current size
 $currentDiskSize =(Get-Partition -DriveLetter c | select Size)
 $currentDiskSize =($currentDiskSize -replace "[^0-9]" , "")

--- a/ansible/Vagrantfile.Win2012
+++ b/ansible/Vagrantfile.Win2012
@@ -6,8 +6,7 @@ $script = <<SCRIPT
 Start-Process powershell -Verb runAs
 wget https://raw.githubusercontent.com/ansible/ansible/devel/examples/scripts/ConfigureRemotingForAnsible.ps1 -OutFile .\\ConfigureRemotingForAnsible.ps1
 .\\ConfigureRemotingForAnsible.ps1 -EnableCredSSP
-$IPArray=(Get-NetIPAddress | select IPAddress)
-$IPArray=$IPArray | findstr /b 172
+$IPArray=(Get-NetIPAddress -InterfaceAlias "Ethernet*" -AddressFamily ipv4 | select -First 1 -ExpandProperty IPAddress)
 echo $IPArray | Out-file -Encoding ASCII -FilePath C:/vagrant/playbooks/AdoptOpenJDK_Windows_Playbook/hosts.win
 # Retrieving disk's current size
 $currentDiskSize =(Get-Partition -DriveLetter c | select Size)


### PR DESCRIPTION
Currently the IP address is found through taking the 5th line from `Get-NetIPAddress | % {$_.IPAddress }`. This is usually fine, however occasionally, the IP Address on the machine is on the 4th line - resulting in Ansible attemping to connect to the wrong IP address 
e.g.: https://ci.adoptopenjdk.net/job/SXA-PlaybookCheckParallel/OS=Win2012,label=infra-vagrant-1/30/console

I've found that the IP Address will always start with `172` so I use that as a basis to find the correct IP from the output.