### PR TITLE
UnixPB: Changed condition for yum autoremove in Clean_Up

### DIFF
--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Clean_Up/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Clean_Up/tasks/main.yml
@@ -23,7 +23,7 @@
   args:
     warn: no
   when:
-    - (ansible_distribution == "RedHat" and ansible_distribution_major_version == "7") or (ansible_distribution == "CentOS" and ansible_distribution_major_version = "7")
+    - (ansible_distribution == "RedHat" and ansible_distribution_major_version == "7") or (ansible_distribution == "CentOS" and ansible_distribution_major_version != "6")
   tags: clean_up
 
 - name: Remove pkg dependencies that are no longer required - FreeBSD

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Clean_Up/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Clean_Up/tasks/main.yml
@@ -23,7 +23,7 @@
   args:
     warn: no
   when:
-    - (ansible_distribution == "RedHat" and ansible_distribution_major_version == "7") or (ansible_distribution == "CentOS" and ansible_distribution_major_version != "6")
+    - (ansible_distribution == "RedHat" and ansible_distribution_major_version != "6") or (ansible_distribution == "CentOS" and ansible_distribution_major_version != "6")
   tags: clean_up
 
 - name: Remove pkg dependencies that are no longer required - FreeBSD


### PR DESCRIPTION
An update to a fix yesterday - I felt this was better as it just blacklists CentOS6, as opposed to whitelisting CentOS7, meaning it's more future proof if other versions of CentOS are added.