### PR TITLE
PbTests: Updated READMEs relevant to the Test Scripts

### DIFF
--- a/ansible/README.md
+++ b/ansible/README.md
@@ -102,15 +102,18 @@ Yes, in order to access the package repositories (we will perform either `yum in
 As Ansible can't run on Windows, it has to be run on a seperate system and then pointed at a Windows machine (such as a VM). To test the playbook, a vagrant VM can be used.
 You can do this by following these steps:
 
-1) Run `vagrant plugin install vagrant-disksize`. This will install a plugin that allows the user to specify the disksize of the VM.
+1) Run `vagrant plugin install vagrant-disksize`. This will install a plugin that allows the user to specify the disksize of the VM and is required to use the Windows Vagrantfile.
 2) `git clone "https://github.com/AdoptOpenJdk/openjdk-infrastructure/"`
-3) `ln -sf Vagrantfile.WindowsS12 Vagrantfile && vagrant up` in the cloned `/openjdk-infrastructure/ansible` directory
-4) Note the IP address that is output from running `vagrant up` and place it into a text file. e.g. `hosts.win`. Place this text file in `../anisble/playbooks/AdoptopenJDK_Windows_Playbook`
-5) Edit `../AdoptOpenJDK_Windows_Playbook/main.yml` so the `- hosts :{{ groups['Vendor_groups'] ... etc` becomes `- hosts: all`
-6) Add into `../AdoptOpenJDK_Windows_Playbook/group_vars/all/adoptopenjdk_variables.yml` the line `ansible_winrm_transport: credssp`. You'll also need to uncomment and change `ansible_password: CHANGE_ME`.
-7) From the `../ansible` directory, running `sudo ansible-playbook -i playbooks/AdoptOpenJDK_Windows_Playbook/hosts.win -u vagrant playbooks/AdoptOpenJDK_Windows_Playbook/main.yml` will start the playbook.
+3) `ln -sf Vagrantfile.Win2012 Vagrantfile && vagrant up` in the cloned `openjdk-infrastructure/ansible` directory
+4) You can optionally edit `Vagantfile.Win2012` so the GUI is shown when running `vagrant up` by changing `v.gui = false` to `v.gui = true`, though this is not necessary to run the playbook.
+5) In `../ansible/playbooks/AdoptOpenJDK_Windows_Playbook/` a file called `hosts.tmp` will have been generated containing 2 IP addresses. Edit this file to remove the CRs and the lower IP address.
+6) Edit `../AdoptOpenJDK_Windows_Playbook/main.yml` so the `- hosts :{{ groups['Vendor_groups'] ... etc` becomes `- hosts: all`
+7) Add into `../AdoptOpenJDK_Windows_Playbook/group_vars/all/adoptopenjdk_variables.yml` the line `ansible_winrm_transport: credssp`. You'll also need to uncomment and change `ansible_password: CHANGE_ME` to `ansible_password: vagrant`.
+8) From the `../ansible` directory, running `ansible-playbook -i playbooks/AdoptOpenJDK_Windows_Playbook/hosts.tmp -u vagrant --skip-tags adoptopenjdk,jenkins playbooks/AdoptOpenJDK_Windows_Playbook/main.yml` will start the playbook.
 
-Note: if using macOS Mojave, `export OBJC_DISABLE_INITIALIZE_FORK_SAFETY=YES` will be required before starting the playbook.
+Alternatively, `openjdk-infrastructure/ansible/pbTestScripts/testScript.sh` will do this for you when executing `./testScript.sh -v Win2012 -u https://github.com/adoptopenjdk/openjdk-infrastructure --retainVM`
+
+Note: if using macOS Mojave, `export OBJC_DISABLE_INITIALIZE_FORK_SAFETY=YES` will be required before starting the playbook and executing `testScript.sh`
 
 ## Can I have multiple VMs on different OSs?
 

--- a/ansible/pbTestScripts/README.md
+++ b/ansible/pbTestScripts/README.md
@@ -8,18 +8,18 @@ This folder contains the scripts necessary to start separate vagrant machines wi
 * CentOS7
 * Windows Server 2012 R2
 
-And subsequently test those machine’s playbooks, and optionally build jdk8u and test the jdk built
+These machines will then have the playbooks ran on them, with additional options to build JDK8 and test it.
 
 The script takes a number of options:
 
-| Option               | Description                                           | Example                                                                           |
-|----------------------|-------------------------------------------------------|-----------------------------------------------------------------------------------|
-| --all / -a           | Runs for all OSs                                      | `./testScript.sh -a`                                                              |
-| --retainVM / -r      | Retains the VM after running the Playbook             | `./testScript.sh -a --retainVM`                                                   |
-| --build / -b         | Build JDK8 on the VM after the playbook               | `./testScript.sh -a --build`                                                      |
-| --URL / -u <Git URL> | Specify the URL of the infrastructure repo to clone * | `./testScript.sh -a --URL https://github.com/adoptopenjdk/openjdk-infrastructure` |
-| --test / -t          | Run a small test on the built JDK within the VM **    | `./testScript.sh -a --build --test`                                               |
-| --help               | Displays usage                                        | `./testScript.sh --help`                                                          |
+| Option               | Description                                           | Example                                                                                 |
+|----------------------|-------------------------------------------------------|-----------------------------------------------------------------------------------------|
+| --all / -a           | Runs for all OSs                                      | `./vagrantPlaybookCheck -a`                                                             |
+| --retainVM / -r      | Retains the VM after running the Playbook             | `./vagrantPlaybookCheck-a --retainVM`                                                   |
+| --build / -b         | Build JDK8 on the VM after the playbook               | `./vagrantPlaybookCheck-a --build`                                                      |
+| --URL / -u Git URL   | Specify the URL of the infrastructure repo to clone * | `./vagrantPlaybookCheck-a --URL https://github.com/adoptopenjdk/openjdk-infrastructure` |
+| --test / -t          | Run a small test on the built JDK within the VM **    | `./vagrantPlaybookCheck-a --build --test`                                               |
+| --help               | Displays usage                                        | `./vagrantPlaybookCheck--help`                                                          |
 
 Notes:
  - If not specified, the URL will default to `https://github.com/adoptopenjdk/openjdk-infrastructure`
@@ -32,9 +32,12 @@ The script is able to test specific branches of repositories, as well as the mas
 This can also be done on other people's forks of the repository, for example:
 * "https://github.com/username/openjdk-infrastructure/tree/branch_name" will git clone the "branch_name" branch of "username"s fork of the repository 
 
-The script will then make a directory in the User’s home called _adoptopenjdkPBTests_, in which another directory containing the log files, and the Git repository is stored. Following that, the script will run each ansible playbook on their respective VMs, writing the output to the aforementioned log files.
+The script will then make a directory in the `$WORKSPACE` location called _adoptopenjdkPBTests_, in which another directory containing the log files, and the Git repository is stored. Following that, the script will run each ansible playbook on their respective VMs, writing the output to the aforementioned log files. If not defined prior to running, `$WORKSPACE` will default to `$HOME`. 
+
 After each playbook is ran through, a summary is given, containing which OS playbooks succeeded, failed, or were cancelled. The logs can also be perused to get more in-depth error messages.
 
-If specified, the VMs will then be tested by building JDK8 - if all dependencies are filled by the playbook as they should be, the JDK will be successfully built. If the `--test` option is then specified, the JDK will then have a simple test ran against it that will ensure it was built properly. 
+If specified, the VMs will then be tested by building JDK8 - if all dependencies are filled by the playbook as they should be, the JDK will be successfully built. If the `--test` option is then specified, the JDK will then have a simple test ran against it that will ensure it was built properly.
 
-If the VMs were chosen *not* to be destroyed, they can be later by running the _vmDestroy.sh_ script, which takes the `project folder` as an argument. If that folder is found, it will run through and destroy the VMs.
+If the VMs were chosen *not* to be destroyed, they can be later by running the _vmDestroy.sh_ script, which takes the `Vagrant OS` as an argument. If found, every Vagrant VM with this OS will be destroyed, therefore the user will be asked to confirm they want this. The `--force` option will skip this prompt.
+
+The additional scripts in the _pbTestScripts_ folder are called from `testScript.sh`


### PR DESCRIPTION
Updating the `README`s to more accurately describe how to manually setup a Windows VM and run the playbook and how to automatically build them using `testScript.sh`