### PR TITLE
Use retries on ant_contrib URL to resolve sourceforge URL connection issues

### DIFF
--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Ant-Contrib/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Ant-Contrib/tasks/main.yml
@@ -27,6 +27,7 @@
     mode: 0440
     timeout: 25
     validate_certs: no
+  retries: 3
   when: antcontrib_status.stat.exists == False
   tags: ant-contrib
 


### PR DESCRIPTION
At least one of the sourceforget mirrors when downloading the `ant-contrib` tarball is vorboss.dl.sourceforge.net and that one seems to be rather intermittent. I suspect that's why we're seeing problems with that work item. Even the second attempt here took a while to get going
```
sxa@x220t:/dev/shm$ wget https://vorboss.dl.sourceforge.net/project/ant-contrib/ant-contrib/ant-contrib-1.0b2/ant-contrib-1.0b2-bin.tar.gz 
--2019-11-16 18:53:11--  https://vorboss.dl.sourceforge.net/project/ant-contrib/ant-contrib/ant-contrib-1.0b2/ant-contrib-1.0b2-bin.tar.gz
Resolving vorboss.dl.sourceforge.net (vorboss.dl.sourceforge.net)... 5.10.152.194
Connecting to vorboss.dl.sourceforge.net (vorboss.dl.sourceforge.net)|5.10.152.194|:443... failed: Connection timed out.
Retrying.

--2019-11-16 18:55:22--  (try: 2)  https://vorboss.dl.sourceforge.net/project/ant-contrib/ant-contrib/ant-contrib-1.0b2/ant-contrib-1.0b2-bin.tar.gz
Connecting to vorboss.dl.sourceforge.net (vorboss.dl.sourceforge.net)|5.10.152.194|:443... connected.
HTTP request sent, awaiting response... 200 OK
Length: 357665 (349K) [application/x-gzip]
Saving to: ‘ant-contrib-1.0b2-bin.tar.gz.21’

ant-contrib-1.0b2-bin.tar.gz.21            100%[=====================================================================================>] 349.28K  1.85MB/s    in 0.2s    

2019-11-16 18:55:55 (1.85 MB/s) - ‘ant-contrib-1.0b2-bin.tar.gz.21’ saved [357665/357665]

sxa@x220t:/dev/shm$ 
```
This is causing regular problems on the new Vagrant jobs so will provide a partial fix to https://github.com/AdoptOpenJDK/openjdk-infrastructure/issues/994 - Since it's the weekend I'm going to push this through without secondary approval in order to be able to test it before Monday.