### PR TITLE
pbTests: Updated VMDestroy

### DIFF
--- a/ansible/pbTestScripts/vmDestroy.sh
+++ b/ansible/pbTestScripts/vmDestroy.sh
@@ -1,50 +1,58 @@
 #!/bin/bash
 set -eu
 
+osToDestroy=''
+
 # Takes in all arguments
 processArgs()
 {
-	if [ ! -n "${WORKSPACE:-}" ]; then
-		echo "WORKSPACE not found, setting it as environment variable 'HOME'"
-		WORKSPACE=$HOME
-	fi
 	if [ $# -lt 1 ]; then
 		echo "Script takes 1 input argument: "
-		echo "The project whose VMs are to be destroyed"
+		echo "The OS of the VMs you want to destroy."
 		exit 1
 	fi
-	
 }
 
-# Takes project name as arg 1, and OS as arg 2
-destroyVM()
-{
-	cd $WORKSPACE/adoptopenjdkPBTests/$1/ansible
-	ln -sf Vagrantfile.$2 Vagrantfile	# Correct Vagrantfile alias
-	vagrant destroy -f			# Force destroy without question
+checkOS() {
+	local OS=$1
+        case "$OS" in
+                "Ubuntu1604" | "U16" | "u16" )
+			osToDestroy="U16";;
+                "Ubuntu1804" | "U18" | "u18" )
+                        osToDestroy="U18";;
+                "CentOS6" | "centos6" | "C6" | "c6" )
+                        osToDestroy="C6" ;;
+                "CentOS7" | "centos7" | "C7" | "c7" )
+                        osToDestroy="C7" ;;
+                "Windows2012" | "Win2012" | "W12" | "w12" )
+                        osToDestroy="W2012";;
+                "all" )
+                        osToDestroy="U16 U18 C6 C7 W2012" ;;
+                *) echo "Not a currently supported OS" ; listOS; exit 1;
+        esac
+}
+
+listOS() {
 	echo
-	echo "Destroyed $2 Machine"	
+	echo "Currently supported OSs:
+		- Ubuntu1604
+		- Ubuntu1804
+		- CentOS6
+		- CentOS7
+		- Win2012"
+	echo
 }
 
-# Takes the project name as arg1
-checkFolder()
-{
-	cd $WORKSPACE/adoptopenjdkPBTests
-	if [ -d "$1" ]; then
-		echo "$1 found!"
-		return 0
-	else
-		echo "$1 not found"
-		exit 1
-	fi
+destroyVMs() {
+	local OS=$1
+	vagrant global-status | grep "adoptopenjdk$OS" | awk '{ print $1 }' | xargs -I {} vagrant destroy -f {}
+	echo "Destroyed all $OS Vagrant VMs"
 }
 
-# Script takes project name as arg 1
 processArgs $*
-if checkFolder $1; then	
- 	# For all currently supported OSs
-	for OS in Ubuntu1804 Ubuntu1604 CentOS6 CentOS7 Win2012
-	do
-		destroyVM $1 $OS
-	done
-fi
+checkOS $1
+for OS in $osToDestroy
+do
+	destroyVMs $OS
+done
+

--- a/ansible/pbTestScripts/vmDestroy.sh
+++ b/ansible/pbTestScripts/vmDestroy.sh
@@ -11,7 +11,14 @@ processArgs()
 		shift;
 		case "$opt" in
 			"--OS" | "-o" )
-				osToDestroy=$1; shift;;
+				if [[ -z "${1:-}" ]]; then
+					echo "Please specifiy an OS with the '-o' option"
+					usage
+					exit 1
+				else
+					osToDestroy=$1;
+				fi
+				shift;;
 			"--force" | "-f" )
 				force=True;;
 			"--help" | "-h" )
@@ -22,10 +29,11 @@ processArgs()
 }
 
 usage() {
-
-		echo "Usage: ./vmDestroy <option>
+	   echo "Usage: ./vmDestroy.sh (<options>) -o <os_list>
+		--OS | -o		Specifies the OS of the vagrant VMs you want to destroy
 		--force | -f		Force destroy the VMs without asking confirmation
 		--help | -h		Displays this help message"
+		listOS
 }
 
 checkOS() {
@@ -43,7 +51,9 @@ checkOS() {
                         osToDestroy="W2012";;
                 "all" )
                         osToDestroy="U16 U18 C6 C7 W2012" ;;
-                *) echo "$OS is not a currently supported OS" ; listOS; exit 1;
+		"")
+			echo "No OS detected. Did you miss the '-o' option?" ; usage; exit 1;;
+		*) echo "$OS is not a currently supported OS" ; listOS; exit 1;
         esac
 }
 
@@ -60,7 +70,7 @@ listOS() {
 
 destroyVMs() {
 	local OS=$1
-	vagrant global-status | grep "adoptopenjdk$OS" | awk '{ print $1 }' | xargs vagrant destroy -f
+	vagrant global-status | awk "/adoptopenjdk$OS/ { print \$1 }" | xargs vagrant destroy -f
 	echo "Destroyed all $OS Vagrant VMs"
 }
 

--- a/ansible/pbTestScripts/vmDestroy.sh
+++ b/ansible/pbTestScripts/vmDestroy.sh
@@ -60,7 +60,7 @@ listOS() {
 
 destroyVMs() {
 	local OS=$1
-	vagrant global-status | grep "adoptopenjdk$OS" | awk '{ print $1 }' | xargs -I {} vagrant destroy -f {}
+	vagrant global-status | grep "adoptopenjdk$OS" | awk '{ print $1 }' | xargs vagrant destroy -f
 	echo "Destroyed all $OS Vagrant VMs"
 }
 
@@ -71,7 +71,7 @@ if [[ "$force" == False ]]; then
 	echo "Are you sure you want to destroy ALL Vms with the following OS(s)? (Y/n)"
 	echo "$osToDestroy"
 	read userInput
-	if [[ "$userInput" != "Y" ]]; then
+	if [ "$userInput" != "Y" ] && [ "$userInput" != "y" ]; then
 		echo "Cancelling ..."
 		exit 1;
 	fi


### PR DESCRIPTION
Updates to make the script a bit more useful - this will destroy all of the VMs that have the OS that is passed to the script. This is more work towards #865 as a way of halting and destroying all VMs before all the `testScript.sh` s are ran, but not interfering with the playbook being executed.

This will still be useful if using `testScript.sh` locally, however would need to be used with more caution if there's VMs that are required to be retained.