### PR TITLE
UnixPB: Retry Ant-Contrib role properly

### DIFF
--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Ant-Contrib/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Ant-Contrib/tasks/main.yml
@@ -28,6 +28,9 @@
     timeout: 25
     validate_certs: no
   retries: 3
+  delay: 5
+  register: antContrib_download
+  until: antContrib_download is not failed
   when: antcontrib_status.stat.exists == False
   tags: ant-contrib
 


### PR DESCRIPTION
Extension to #995 

The `until` tag is required for the retries to happen.