### PR TITLE
Remove nested variables from adoptopenjdk_install role

### DIFF
--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/adoptopenjdk_install/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/adoptopenjdk_install/tasks/main.yml
@@ -72,13 +72,13 @@
 
 - name: Get /usr/lib/jvm/jdk-{{ jdk_version }}* full path name
   shell: ls -ld /usr/lib/jvm/jdk-{{ jdk_version }}* 2>/dev/null | awk '{print $9}'
-  register: adoptopenjdk{{ jdk_version }}_dir
+  register: adoptopenjdk_dir
   when: adoptopenjdk_installed.rc != 0
   tags: adoptopenjdk
 
 - name: Chown /usr/lib/jvm/jdk-{{ jdk_version }}*
   file:
-    path: '{{ adoptopenjdk{{ jdk_version }}_dir.stdout }}'
+    path: '{{ adoptopenjdk_dir.stdout }}'
     state: directory
     owner: root
     group: root


### PR DESCRIPTION
This was working ok with latest ansible but not with my laptop's 2.6.1 ... Since we have a trap to ensure we have >=2.4 and this works fine without a nested variable, I'm changing this to work ok with the earlier version.
Signed-off-by: Stewart Addison <sxa@uk.ibm.com>