### PR TITLE
pbTests: Cleanup Windows files

### DIFF
--- a/ansible/pbTestScripts/testScript.sh
+++ b/ansible/pbTestScripts/testScript.sh
@@ -223,6 +223,7 @@ startVMPlaybookWin()
         if [[ "$vmHalt" = true ]]; then
                 vagrant halt
         fi
+	rm playbooks/AdoptOpenJDK_Windows_Playbook/hosts.win playbooks/AdoptOpenJDK_Windows_Playbook/hosts.tmp
 }
 
 destroyVM()


### PR DESCRIPTION
Cleans up the files that are required for ansible to connect to the Windows VM once the playbook, build and test has ran. This doesn't interfere with interacting with the VM, so the `--retainVM` option is still usable - it just can't run the playbook again without restoring the file.
Required to ensure the Jenkins job doesn't attempt to connect to an incorrect IP when re-running.