### PR TITLE
Add Jenkins user to Performance Log Users group

### DIFF
--- a/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/roles/Jenkins/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/roles/Jenkins/tasks/main.yml
@@ -2,6 +2,11 @@
 ################
 # Jenkins user #
 ################
+
+# Add Jenkins user to Performance Log Users in order to view counter data.
+# see https://docs.microsoft.com/en-us/windows/win32/perfctrs/limited-user-access-support
+# Required by OpenJ9 tests: testOSMXBean*
+
 - name: Create Jenkins user
   win_user:
     name: "{{ Jenkins_Username }}"
@@ -10,7 +15,7 @@
     state: present
     password_never_expires: true
     groups:
-      - Users, Remote Desktop Users
+      - Users, Remote Desktop Users, Performance Log Users
   tags: jenkins
 
 


### PR DESCRIPTION
Add user to Performance Log Users to view counter data.

Related Issue: https://github.com/eclipse/openj9/issues/7716

Signed-off-by: Violeta Sebe <vsebe@ca.ibm.com>