### PR TITLE
WinPB: Change Ansible version check to reflect Unix's

### DIFF
--- a/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/roles/Version/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/roles/Version/tasks/main.yml
@@ -5,5 +5,5 @@
 - name: Verify if Ansible version is 2.4 or above
   assert:
     that:
-      - "{{ ansible_version.string | version_compare('2.4', '>=') }}"
+      - "{{ ansible_version.string is version_compare('2.4', '>=') }}"
     msg: "Ansible 2.4 or above is required"


### PR DESCRIPTION
Recently updated the Ansible version on jenkins slave `infra-vagrant-1` and the Windows playbook would fail with the following error message:
```
TASK [Version : Verify if Ansible version is 2.4 or above] *********************
fatal: [172.28.128.33]: FAILED! => {"msg": "template error while templating string: no filter named 'version_compare'. String: {{ ansible_version.string | version_compare('2.4', '>=') }}"}
```

This PR fixes that and reflects what the unix playbook does.