### PR TITLE
pbTests: alter testScript to run ansible locally and point at VM

### DIFF
--- a/ansible/Vagrantfile.CentOS6
+++ b/ansible/Vagrantfile.CentOS6
@@ -23,6 +23,10 @@ echo "--------------------------------------------------------------------------
 echo "*** '$VAGRANT_MOUNT/playbooks/hosts' file for ansible-playbook contains ***"
 cat $VAGRANT_MOUNT/playbooks/hosts
 echo "---------------------------------------------------------------------------------------"
+# Get IPs of the VM, and output to shared folder
+ifconfig | grep "inet" | awk '{print $2}' | sed 's/addr://'  >> /vagrant/playbooks/AdoptOpenJDK_Unix_Playbook/hosts.tmp
+# Put the host machine's IP into the authorised_keys file on the VM
+[ -r /vagrant/id_rsa.pub ] && mkdir -p $HOME/.ssh && cat /vagrant/id_rsa.pub >> $HOME/.ssh/authorized_keys
 SCRIPT
 
 # 2 = version of configuration file for Vagrant 1.1+ leading up to 2.0.x

--- a/ansible/Vagrantfile.CentOS7
+++ b/ansible/Vagrantfile.CentOS7
@@ -23,6 +23,10 @@ echo "--------------------------------------------------------------------------
 echo "*** '$VAGRANT_MOUNT/playbooks/hosts' file for ansible-playbook contains ***"
 cat $VAGRANT_MOUNT/playbooks/hosts
 echo "---------------------------------------------------------------------------------------"
+# Get IPs of the VM, and output to shared folder
+ifconfig | grep "inet" | awk '{print $2}' | sed 's/addr://'  >> /vagrant/playbooks/AdoptOpenJDK_Unix_Playbook/hosts.tmp
+# Put the host machine's IP into the authorised_keys file on the VM
+[ -r /vagrant/id_rsa.pub ] && mkdir -p $HOME/.ssh && cat /vagrant/id_rsa.pub >> $HOME/.ssh/authorized_keys
 SCRIPT
 
 # 2 = version of configuration file for Vagrant 1.1+ leading up to 2.0.x

--- a/ansible/Vagrantfile.Ubuntu1604
+++ b/ansible/Vagrantfile.Ubuntu1604
@@ -25,6 +25,10 @@ echo "--------------------------------------------------------------------------
 echo "*** '$VAGRANT_MOUNT/playbooks/hosts' file for ansible-playbook contains ***"
 cat $VAGRANT_MOUNT/playbooks/hosts
 echo "---------------------------------------------------------------------------------------"
+# Get IPs of the VM, and output to shared folder
+ifconfig | grep "inet" | awk '{print $2}' | sed 's/addr://'  >> /vagrant/playbooks/AdoptOpenJDK_Unix_Playbook/hosts.tmp
+# Put the host machine's IP into the authorised_keys file on the VM
+[ -r /vagrant/id_rsa.pub ] && mkdir -p $HOME/.ssh && cat /vagrant/id_rsa.pub >> $HOME/.ssh/authorized_keys
 SCRIPT
 
 # 2 = version of configuration file for Vagrant 1.1+ leading up to 2.0.x

--- a/ansible/Vagrantfile.Ubuntu1804
+++ b/ansible/Vagrantfile.Ubuntu1804
@@ -25,6 +25,10 @@ echo "--------------------------------------------------------------------------
 echo "*** '$VAGRANT_MOUNT/playbooks/hosts' file for ansible-playbook contains ***"
 cat $VAGRANT_MOUNT/playbooks/hosts
 echo "---------------------------------------------------------------------------------------"
+# Get IPs of the VM, and output to shared folder
+ifconfig | grep "inet" | awk '{print $2}' | sed 's/addr://'  >> /vagrant/playbooks/AdoptOpenJDK_Unix_Playbook/hosts.tmp
+# Put the host machine's IP into the authorised_keys file on the VM
+[ -r /vagrant/id_rsa.pub ] && mkdir -p $HOME/.ssh && cat /vagrant/id_rsa.pub >> $HOME/.ssh/authorized_keys
 SCRIPT
 
 # 2 = version of configuration file for Vagrant 1.1+ leading up to 2.0.x

--- a/ansible/pbTestScripts/testScript.sh
+++ b/ansible/pbTestScripts/testScript.sh
@@ -78,10 +78,6 @@ checkVars()
                 echo "Can't find vagrant-disksize plugin, installing . . ."
                 vagrant plugin install vagrant-disksize
         fi
-	if [[ ! -f ~/.ssh/id_rsa ]]; then
-		echo "Creating SSH key to share to the VMs"
-		ssh-keygen -q -f ~/.ssh/id_rsa -t rsa -N ''
-	fi
 }
 
 checkVagrantOS()
@@ -164,8 +160,8 @@ startVMPlaybook()
 
 	ln -sf Vagrantfile.$OS Vagrantfile
 	# Copy the machine's ssh key for the VMs to use, after removing prior files
-	[[ -f id_rsa.pub ]] && rm id_rsa.pub
-	cp ~/.ssh/id_rsa.pub $WORKSPACE/adoptopenjdkPBTests/$folderName-$branchName/ansible
+	[[ -f id_rsa.pub ]] && rm id_rsa.pub id_rsa
+	ssh-keygen -q -f $PWD/id_rsa -t rsa -N ''
 	vagrant up
 	# Generate hosts.unx file for Ansible to use, remove prior hosts.unx if there
 	[[ -f playbooks/AdoptOpenJDK_Unix_Playbook/hosts.unx ]] && rm playbooks/AdoptOpenJDK_Unix_Playbook/hosts.unx


### PR DESCRIPTION
The change will make `testScript.sh` run the playbook on each Linux VM as it does with the Windows - runs ansible locally and points it at the VM.
This have been put in because currently, when running the jenkins job `SXA-PlaybookCheckParallel`, the use of `vagrant ssh -c` appears to be the cause of vagrant VMs being halted unintentionally. 
The `--build` and `--test` options have also been changed to not use `vagrant ssh -c`.

Has been tested on macOS and on the Jenkins job.