### PR TITLE
Passed the value of hosts from command line

### DIFF
--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/main.yml
@@ -2,7 +2,10 @@
 ###################################
 # AdoptOpenJDK - Ansible Playbook #
 ###################################
-- hosts: "{{ groups['Vendor_groups'] | default('localhost:build:test:!*zos*:!*win*:!*aix*') }}"
+# Groups can be passed in as a command-line variable in Ansible playbook. 
+# It can be defined as 'all' or a specific group which the host belongs to.
+# For example, it can be 'all' or 'x86' for when a host is in the group 'x86'.
+- hosts: "{{ Groups | default('localhost:build:test:!*zos*:!*win*:!*aix*') }}"
   gather_facts: yes
   tasks:
     - block:


### PR DESCRIPTION
- The variable groups['Vendor_groups']
is skipped due to lack of definition when we
run AdoptOpenJDK Unix Playbook internally

- Replaced it with a command line variable
and set the value to all or a specific group

Signed-off-by: Jenny Chen <Jenny.Chen@ibm.com>