### PR TITLE
UnixPB: Changes to allow for Debian8 playbook run through

### DIFF
--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/main.yml
@@ -49,7 +49,7 @@
       src_tarball: https://github.com/protocolbuffers/protobuf/releases/download/v3.5.1/protobuf-cpp-3.5.1.tar.gz
       installed_target: /usr/local/bin/protoc
       when:
-        - (ansible_distribution == "RedHat" or ansible_distribution == "CentOS" or ansible_distribution == "Ubuntu" or ansible_distribution == "SLES")
+        - (ansible_distribution == "RedHat" or ansible_distribution == "CentOS" or ansible_distribution == "Ubuntu" or ansible_distribution == "SLES" or ansible_distribution == "Debian" )
         - ansible_architecture == "x86_64"
     - OpenSSL102                  # OpenJ9
     - Nagios_Plugins              # AdoptOpenJDK Infrastructure

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/tasks/Debian.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/tasks/Debian.yml
@@ -1,0 +1,151 @@
+---
+##########
+# Debian #
+##########
+
+#########################################
+# Configure Repos and Update the system #
+#########################################
+- name: Add the openjdk repository to apt
+  apt_repository: repo='ppa:openjdk-r/ppa' update_cache=no
+  when:
+    - ansible_architecture != "armv7l"
+  tags: patch_update
+
+- name: Add the ubuntu toolchain repository to apt
+  apt_repository: repo='ppa:ubuntu-toolchain-r/test' update_cache=no
+  when:
+    - ansible_architecture != "armv7l"
+  tags: patch_update
+
+- name: Change Jessie to Trusty in the sources files
+  command: sed -i "s/jessie/trusty/g" /etc/apt/sources.list.d/ppa_openjdk_r_ppa_jessie.list  /etc/apt/sources.list.d/ppa_ubuntu_toolchain_r_test_jessie.list
+  when:
+    - ansible_architecture != "armv7l"
+  tags: patch_update
+
+- name: Add Azul Zulu GPG Package Signing Key for x86_64
+  apt_key:
+    url: http://repos.azulsystems.com/RPM-GPG-KEY-azulsystems
+    state: present
+  when:
+    - ansible_architecture == "x86_64"
+  tags: [patch_update, azul-key]
+
+- name: Add Azul Zulu repository for x86_64
+  apt_repository: repo='deb http://repos.azulsystems.com/ubuntu stable main'
+  when:
+    - ansible_architecture == "x86_64"
+  tags: patch_update
+
+- name: Add additional repositories for BeagleBone
+  apt_repository: repo={{ item }}
+  with_items:
+    - deb https://deb.debian.org/debian/ stable main contrib non-free
+    - deb-src https://deb.debian.org/debian/ stable main contrib non-free
+    - deb https://deb.debian.org/debian/ stable-updates main contrib non-free
+    - deb-src https://deb.debian.org/debian/ stable-updates main contrib non-free
+    - deb https://deb.debian.org/debian-security stable/updates main
+    - deb-src https://deb.debian.org/debian-security stable/updates main
+    - deb http://ftp.debian.org/debian stretch-backports main
+    - deb-src http://ftp.debian.org/debian stretch-backports main
+  when:
+    - (ansible_distribution_major_version == "9" and ansible_architecture == "armv7l")
+  tags: patch_update
+
+- name: Run apt-get upgrade
+  apt: upgrade=safe update_cache=yes
+  tags: patch_update
+
+############################
+# Build Packages and tools #
+############################
+- name: Call Build Packages and Tools Task
+  include_tasks: build_packages_and_tools.yml
+
+##########################
+# Additional build tools #
+##########################
+- name: Call Build Packages and Tools Task for OpenJFX
+  package: "name={{ item }} state=latest"
+  with_items: "{{ OpenJFX_Build_Tool_Packages }}"
+  tags: [build_tools, build_tools_jfx]
+
+- name: Install GCC G++ on supported platforms
+  package: "name={{ item }} state=latest"
+  with_items: "{{ gcc_compiler }}"
+  when:
+    - (ansible_distribution_major_version != "9" and ansible_architecture != "armv7l")
+  tags: build_tools
+
+- name: Install additional build tools for x86_64
+  package: "name={{ item }} state=latest"
+  with_items: "{{ Additional_Build_Tools_x86_64 }}"
+  when:
+    - ansible_architecture == "x86_64"
+  tags: build_tools
+
+- name: Install additional build tools for PPC64LE
+  package: "name={{ item }} state=latest"
+  with_items: "{{ Additional_Build_Tools_ppc64le }}"
+  when:
+    - ansible_architecture == "ppc64le"
+  tags: build_tools
+
+- name: Install additional build tools for S390x
+  package: "name={{ item }} state=latest"
+  with_items: "{{ Additional_Build_Tools_s390x }}"
+  when:
+    - ansible_architecture == "s390x"
+  tags: build_tools
+
+- name: Install additional build tools for aarch64
+  package: "name={{ item }} state=latest"
+  with_items: "{{ Additional_Build_Tools_aarch64 }}"
+  when:
+    - ansible_architecture == "aarch64"
+  tags: build_tools
+
+#########################
+# Additional Test Tools #
+#########################
+- name: Install additional Test Tool Packages for x86_64
+  package: "name={{ item }} state=latest"
+  with_items: "{{ Test_Tool_Packages_x86_64 }}"
+  when:
+    - ansible_architecture == "x86_64"
+  tags: test_tools
+
+- name: Install additional Packages specific to Debian 8
+  package: "name={{ item }} state=latest"
+  with_items: "{{ Additional_Packages_Debian8 }}"
+  when:
+    - ansible_distribution_major_version == "8"
+  tags: test_tools
+
+##################
+# Enable Locales #
+##################
+- name: Enable ja_JP locale
+  locale_gen:
+    name: ja_JP.UTF-8
+    state: present
+  tags: locales
+
+- name: Enable ko_KR locale
+  locale_gen:
+    name: ko_KR.UTF-8
+    state: present
+  tags: locales
+
+- name: Enable zh_CN locale
+  locale_gen:
+    name: zh_CN.UTF-8
+    state: present
+  tags: locales
+
+- name: Enable zh_TW locale
+  locale_gen:
+    name: zh_TW.UTF-8
+    state: present
+  tags: locales

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/vars/Debian.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/vars/Debian.yml
@@ -1,0 +1,109 @@
+---
+##########
+# Debian #
+##########
+
+# Command Build Tool Packages
+Build_Tool_Packages:
+  - apt-transport-https
+  - autoconf
+  - bison                         # OpenJ9
+  - build-essential
+  - cpanminus
+  - cpio
+  - curl
+  - flex                          # Openj9
+  - g++
+  - gcc
+  - gettext
+  - libasound2-dev
+  - libcups2-dev
+  - libcurl4-openssl-dev
+  - libdwarf-dev                  # OpenJ9
+  - libelf-dev
+  - libexpat1-dev
+  - libffi-dev
+  - libfreetype6-dev
+  - libfontconfig1-dev
+  - libgmp3-dev
+  - libmpfr-dev
+  - libmpfr-doc
+  - libssl-dev
+  - libwww-perl
+  - libx11-dev
+  - libxext-dev
+  - libxi-dev                     # JDK12+ compilation
+  - libxrandr-dev                 # JDK12+ compilation
+  - libxrender-dev
+  - libxt-dev
+  - libxtst-dev
+  - make
+  - ntp
+  - pigz
+  - pkg-config
+  - systemtap-sdt-dev
+  - wget
+  - zip
+
+OpenJFX_Build_Tool_Packages:
+  - gperf
+  - libavcodec-dev
+  - libavformat-dev
+  - libgl1-mesa-dev
+  - libgtk2.0-dev
+  - libgtk-3-dev
+  - libjpeg-dev
+  - libpng-dev
+  - libudev-dev
+  - libxml2-dev
+  - libxslt1-dev
+  - libxxf86vm-dev
+  - ruby
+
+gcc_compiler:
+  - g++-4.8
+  - gcc-4.8
+
+Additional_Packages_Debian8:
+  - libgstreamer0.10-dev                # OpenJFX prereq
+  - libgstreamer-plugins-base0.10-dev   # OpenJFX prereq
+  - openjdk-7-jdk
+  - libmpfr4
+  - libmpfr4-dbg
+
+Additional_Build_Tools_x86_64:
+  - zulu-9
+  - libnuma-dev
+  - numactl
+  - gcc-7
+  - g++-7
+
+Additional_Build_Tools_ppc64le:
+  - libnuma-dev
+  - numactl
+  - gcc-7                         # OpenJ9
+  - g++-7                         # OpenJ9
+
+Additional_Build_Tools_s390x:
+  - gcc-7                         # OpenJ9
+  - g++-7                         # OpenJ9
+  - numactl
+  - libfreetype6-dev              # Needed by test state=installed
+
+Additional_Build_Tools_aarch64:
+  - libpng-dev
+
+Test_Tool_Packages:
+  - acl
+  - mercurial
+  - perl
+  - xauth
+  - xorg
+  - xvfb
+  - binfmt-support
+  - qemu-user-static
+
+Test_Tool_Packages_x86_64:
+  - pulseaudio
+
+crontab_Patching: "/usr/bin/apt-get update && /usr/bin/apt-get -y upgrade"

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/OpenSSL102/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/OpenSSL102/tasks/main.yml
@@ -6,8 +6,7 @@
 - name: Test if OpenSSL v1.0.2r is installed
   shell: export LD_LIBRARY_PATH=/usr/local/openssl-1.0.2/lib &&  /usr/local/openssl-1.0.2/bin/openssl version | awk '{print $2}' | cut -c 1-5
   when:
-    - (ansible_distribution == "RedHat" or ansible_distribution == "CentOS")
-    - ansible_distribution_major_version == "6"
+    - (ansible_distribution_major_version == "6" and (ansible_distribution == "RedHat" or ansible_distribution == "CentOS") or ansible_distribution == "Debian")
   register: openssl_version
   tags: openssl
 
@@ -19,8 +18,7 @@
     mode: 0755
     validate_certs: no
   when:
-    - (ansible_distribution == "RedHat" or ansible_distribution == "CentOS")
-    - ansible_distribution_major_version == "6"
+    - (ansible_distribution_major_version == "6" and (ansible_distribution == "RedHat" or ansible_distribution == "CentOS") or ansible_distribution == "Debian")
     - ((openssl_version.stdout == '') or ((openssl_version.stdout != '') and (openssl_version.stdout is version_compare('1.0.2', operator='lt', strict=True))))
   tags: openssl
 
@@ -30,16 +28,14 @@
     dest: /tmp
     copy: False
   when:
-    - (ansible_distribution == "RedHat" or ansible_distribution == "CentOS")
-    - ansible_distribution_major_version == "6"
+    - (ansible_distribution_major_version == "6" and (ansible_distribution == "RedHat" or ansible_distribution == "CentOS") or ansible_distribution == "Debian")
     - ((openssl_version.stdout == '') or ((openssl_version.stdout != '') and (openssl_version.stdout is version_compare('1.0.2', operator='lt', strict=True))))
   tags: openssl
 
 - name: Build and install OpenSSL v1.0.2r
   shell: cd /tmp/openssl-1.0.2r && ./config --prefix=/usr/local/openssl-1.0.2 shared && make && make install
   when:
-    - (ansible_distribution == "RedHat" or ansible_distribution == "CentOS")
-    - ansible_distribution_major_version == "6"
+    - (ansible_distribution_major_version == "6" and (ansible_distribution == "RedHat" or ansible_distribution == "CentOS") or ansible_distribution == "Debian")
     - ((openssl_version.stdout == '') or ((openssl_version.stdout != '') and (openssl_version.stdout is version_compare('1.0.2', operator='lt', strict=True))))
   tags: openssl
 
@@ -52,7 +48,6 @@
     - /tmp/openssl-1.0.2r
   ignore_errors: yes
   when:
-    - (ansible_distribution == "RedHat" or ansible_distribution == "CentOS")
-    - ansible_distribution_major_version == "6"
+    - (ansible_distribution_major_version == "6" and (ansible_distribution == "RedHat" or ansible_distribution == "CentOS") or ansible_distribution == "Debian")
     - ((openssl_version.stdout == '') or ((openssl_version.stdout != '') and (openssl_version.stdout is version_compare('1.0.2', operator='lt', strict=True))))
   tags: openssl


### PR DESCRIPTION
fixes: #1015 
@sxa555 @gdams 
These are all the changes I've had to implement to allow for a complete run through of the playbook. I was also able to build JDK8-openJ9, JDK11-openj9 and JDK13-HS when it ran through.
I've based the `Common/tasks/Debian.yml` and `Common/vars/Debian.yml` files on the `Ubuntu.yml` files of the respective repositories and changed them to suit:
  - Made sure `update_cache=no` is put in for the first 2 repositories, as the source files are required to be changed from `Jessie` to `Trusty`
  - Added the above task to change `Jessie` to `Trusty`
  - Removed all the assigning Java tasks
  - Removed openjdk-8-jdk from the "Build_Tool_Packages" *

In addition to this I have:
  - Changed the conditionals to include Debian in the OpenSSL102 roles, as system OpenSSL from the Vagrant Box is 1.0.1 which is slightly too old for OpenJ9.
  - Added Debian to the ProtoBuf localsrc_install conditionals.

* This is due to openjdk8 not being in the Jessie package repository ( https://packages.debian.org/jessie/java/ ).

The only thing in addition to this PR to make Debian work is the addition of someway of install JDK8, as it currently can't (see #1015 ). This could be remedied by adding an OpenJDK8 role to the Unix PB, but that's up for discussion. 