### PR TITLE
pbTests: Ensure ansible uses correct private key

### DIFF
--- a/ansible/pbTestScripts/buildJDK.sh
+++ b/ansible/pbTestScripts/buildJDK.sh
@@ -3,7 +3,8 @@ set -eu
 if [ -z "${WORKSPACE:-}" ]; then
 		echo "WORKSPACE not found, setting it as environment variable 'HOME'"
 		WORKSPACE=$HOME
-	fi
+fi
+[[ ! -d "$WORKSPACE/openjdk-build" ]] && git clone https://github.com/adoptopenjdk/openjdk-build $WORKSPACE/openjdk-build
 export TARGET_OS=linux
 export ARCHITECTURE=x64
 export JAVA_TO_BUILD=jdk8u

--- a/ansible/pbTestScripts/vmDestroy.sh
+++ b/ansible/pbTestScripts/vmDestroy.sh
@@ -70,7 +70,7 @@ listOS() {
 
 destroyVMs() {
 	local OS=$1
-	vagrant global-status | awk "/adoptopenjdk$OS/ { print \$1 }" | xargs vagrant destroy -f
+	vagrant global-status --prune | awk "/adoptopenjdk$OS/ { print \$1 }" | xargs vagrant destroy -f
 	echo "Destroyed all $OS Vagrant VMs"
 }
 


### PR DESCRIPTION
Among other changes, this will ensure that ansible uses the correct id_rsa to try and connect to the vagrant machines. This PR also : 
- Moves git clone to `buildJDK.sh` as this was taken out with #1016 
- Ensures `vmDestroy.sh` doesn't fail when `vagrant global-status` has invalid entries
- Removes the IP of the vagrant machine from the host's `known_hosts` file, as not to encounter ssh warnings about man-in-the-middle attacks

Unfortunately, this only works when the system running `testScript.sh` uses `GNU sed`.  