### PR TITLE
WinPB: Changed Firefox download link

### DIFF
--- a/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/roles/Firefox/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/roles/Firefox/tasks/main.yml
@@ -17,7 +17,7 @@
 
 - name: Download Firefox
   win_get_url:
-    url: https://download.mozilla.org/?product=firefox-54.0-SSL&os=win64&lang=en-US
+    url: https://ftp.mozilla.org/pub/firefox/releases/54.0/win64/en-GB/Firefox%20Setup%2054.0.exe
     dest: 'C:\temp\firefox.exe'
   when: (firefox_download.stat.exists == false) and (firefox_installed.stat.exists == false)
   tags: Firefox


### PR DESCRIPTION
To solve the issue found here : https://ci.adoptopenjdk.net/job/SXA-PlaybookCheckParallel/163/OS=Win2012,label=vagrant/console

This PR will just use a different URL to download the same version of Firefox, as I think the download link of it was causing the installation issue. Tested on macOS and Linux.