### PR TITLE
pbTests: Added /usr/local/bin to path when building JDK on unix

### DIFF
--- a/ansible/pbTestScripts/buildJDK.sh
+++ b/ansible/pbTestScripts/buildJDK.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 set -eu
+export PATH=/usr/local/bin/:$PATH
 if [ -z "${WORKSPACE:-}" ]; then
 		echo "WORKSPACE not found, setting it as environment variable 'HOME'"
 		WORKSPACE=$HOME


### PR DESCRIPTION
To fix the issue here where CentOS6 (and 7) are finishing the playbooks and compiling `GIT_SOURCE`, however still can't find `git` in the path.

