### PR TITLE
pbTests: Find correct JDK versions for different OSs

### DIFF
--- a/ansible/pbTestScripts/buildJDK.sh
+++ b/ansible/pbTestScripts/buildJDK.sh
@@ -6,13 +6,18 @@ if [ -z "${WORKSPACE:-}" ]; then
 		WORKSPACE=$HOME
 fi
 [[ ! -d "$WORKSPACE/openjdk-build" ]] && git clone https://github.com/adoptopenjdk/openjdk-build $WORKSPACE/openjdk-build
+
+# If detected GCC version is <7, set it to 7 
+export gccVer=$(gcc --version | grep "gcc" | awk '{ print $4 }' | cut -d. -f1)
+[[ ${gccVer} -lt 7 ]] && ln -sf /usr/bin/gcc-7 /usr/bin/gcc && ln -sf /usr/bin/g++-7 /usr/bin/g++
+
 export TARGET_OS=linux
 export ARCHITECTURE=x64
 export JAVA_TO_BUILD=jdk8u
 export VARIANT=openj9
 export JDK7_BOOT_DIR=/usr/lib/jvm/java-1.7.0
-export JDK_BOOT_DIR=/usr/lib/jvm/java-1.8.0-openjdk-amd64
-export JAVA_HOME=/usr/lib/jvm/java-1.8.0-openjdk-amd64
+# Differences in openJDK8 name between Ubuntu and CentOS
+export JAVA_HOME=$(find /usr/lib/jvm/ -name java-1.8.0-openjdk-\*)
 cd $WORKSPACE/openjdk-build
 build-farm/make-adopt-build-farm.sh
 

--- a/ansible/pbTestScripts/buildJDK.sh
+++ b/ansible/pbTestScripts/buildJDK.sh
@@ -7,15 +7,16 @@ if [ -z "${WORKSPACE:-}" ]; then
 fi
 [[ ! -d "$WORKSPACE/openjdk-build" ]] && git clone https://github.com/adoptopenjdk/openjdk-build $WORKSPACE/openjdk-build
 
-# If detected GCC version is <7, set it to 7 
-export gccVer=$(gcc --version | grep "gcc" | awk '{ print $4 }' | cut -d. -f1)
-[[ ${gccVer} -lt 7 ]] && ln -sf /usr/bin/gcc-7 /usr/bin/gcc && ln -sf /usr/bin/g++-7 /usr/bin/g++
-
 export TARGET_OS=linux
 export ARCHITECTURE=x64
 export JAVA_TO_BUILD=jdk8u
 export VARIANT=openj9
-export JDK7_BOOT_DIR=/usr/lib/jvm/java-1.7.0
+
+# Differences in openJDK7 name between OSs. Search for CentOS one
+export JDK7_BOOT_DIR=$(find /usr/lib/jvm/ -name java-1.7.0-openjdk.x86_64)
+# If the CentOS JDK7 can't be found, search for the Ubuntu one
+[[ -z "$JDK7_BOOT_DIR" ]] && export JDK7_BOOT_DIR=$(find /usr/lib/jvm/ -name java-1.7.0-openjdk-\*)
+
 # Differences in openJDK8 name between Ubuntu and CentOS
 export JAVA_HOME=$(find /usr/lib/jvm/ -name java-1.8.0-openjdk-\*)
 cd $WORKSPACE/openjdk-build


### PR DESCRIPTION
As the build in `SXA-PlaybookCheckParallel` are JDK8-J9 builds, they need a higher GCC version to be set, so this PR ensures that.

Different OSs have different names for the OpenJDK-8 that's installed via the playbook. The change made should allow both Ubuntu and CentOS OSs in the job to find the correct JDK.
i.e, CentOS6 has `java-1.8.0-openjdk-1.8.0.232.b09-1.el6_10.x86_64`
and Ubuntu1604 has `java-1.8.0-openjdk-amd64`