### PR TITLE
UnixPB: Changes so PB runs on Raspbian Buster

### DIFF
--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/tasks/Debian.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/tasks/Debian.yml
@@ -38,6 +38,16 @@
     - ansible_architecture == "x86_64"
   tags: patch_update
 
+# Both repositories needed for gcc/g++-4.8
+- name: Add additional repositories for Raspbian Buster
+  apt-repository: repo={{ item }}
+  with_items:
+    - deb-src http://raspbian.raspberrypi.org/raspbian/ buster main contrib non-free rpi
+    - deb http://mirrordirector.raspbian.org/raspbian/ jessie main contrib non-free rpi
+  when:
+    - (ansible_distribution_major_version == "10" and ansible_architecture == "armv7l")
+  tags: patch_update
+
 - name: Add additional repositories for BeagleBone
   apt_repository: repo={{ item }}
   with_items:
@@ -76,6 +86,15 @@
   with_items: "{{ gcc_compiler }}"
   when:
     - (ansible_distribution_major_version != "9" and ansible_architecture != "armv7l")
+  tags: build_tools
+
+- name: Install GCC G++ on Raspian Buster
+  packages: "name={{ item }} state=latest"
+  with_items:
+    - gcc-4.8
+    - g++-4.8
+  when:
+    - (ansible_distribution_major_version == "10" and ansible_architecture == "armv7l")
   tags: build_tools
 
 - name: Install additional build tools for x86_64

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/tasks/main.yml
@@ -19,16 +19,6 @@
   set_fact:
     root_group: "root"
 
-#########################
-# Override for Raspbian #
-#########################
-- name: If Raspbian on armv7l override ansible_distribution
-  set_fact:
-    ansible_distribution: "Ubuntu"
-  when:
-    - ansible_distribution == "Debian"
-    - ansible_architecture == "armv7l"
-
 ################
 # Set Hostname #
 ################

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Docker/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Docker/tasks/main.yml
@@ -207,6 +207,15 @@
     - ansible_distribution == "Debian"
   tags: docker
 
+- name: Add Docker GPG apt key for Raspbian
+  apt_key:
+    url: htps://yum.dockerproject.org/gpg
+    state: present
+  when:
+    - docker_installed.rc != 0
+    - ansible_distribution == "Debian" and ansible_architecture == "armv7l"
+  tags: docker
+
 - name: Install Docker prerequisites for Debian
   apt: pkg={{ item }} state=latest
   with_items:
@@ -222,7 +231,7 @@
     # TODO: Package installs should not use latest
     - skip_ansible_lint
 
-- name: Add Docker Repo for Debian x86_64
+- name: Add Docker repo for Debian x86_64
   apt_repository:
     repo: "deb [arch=amd64] https://download.docker.com/linux/debian {{ ansible_distribution_release }} stable"
     state: present
@@ -230,6 +239,16 @@
     - docker_installed.rc != 0
     - ansible_distribution == "Debian"
     - ansible_architecture == "x86_64"
+  tags: docker
+
+- name: Add Docker repo for Raspbian arm7vl
+  apt_repository:
+    repo: "deb https://download.docker.com/linux/raspbian {{ ansible_distribution_release }} stable"
+    state: present
+  when:
+    - docker_installed.rc != 0
+    - ansible_distribution == "Debian"
+    - ansible_architecture == "armv7l"
   tags: docker
 
 # All OS' - Common


### PR DESCRIPTION
Extension of #1021 

Changes to allow the playbook to run through on Raspbian Buster. I noticed there was an override to cause Raspbian to run the Ubuntu version of the playbook. I deleted this as there is now a Debian 
specific playbook. 

The only additions were adding a couple of repositories to allow for the playbook to install gcc-4.8 on the RPI - This is not available to Raspbian Buster by default. I also had to add the Raspbian specific repository and gpg key for Docker, as the Debian repository relies on the `auf-dkms` package that is not available on Raspbian (ref: https://github.com/raspberrypi/linux/issues/3021). 