### PR TITLE
winPB: Change Git version to latest; use win_shell module

### DIFF
--- a/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/roles/GIT/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/roles/GIT/tasks/main.yml
@@ -16,9 +16,7 @@
   tags: git
 
 - name: Download GIT installer
-  win_get_url:
-    url: 'https://github.com/git-for-windows/git/releases/download/v2.14.3.windows.1/Git-2.14.3-64-bit.exe'
-    dest: 'C:\temp\git.exe'
+  win_shell: '[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; wget https://github.com/git-for-windows/git/releases/download/v2.24.1.windows.2/Git-2.24.1.2-64-bit.exe -Outfile C:/temp/git.exe'
   when: (git_download.stat.exists == false) and (git_installed.stat.exists == false)
   tags: git
 


### PR DESCRIPTION
There was an error with downloading GIt on the windows playbook : 
```
TASK [GIT : Install GIT] *******************************************************
fatal: [172.28.128.4]: FAILED! => {"changed": false, "cmd": "C:\\temp\\git.exe /SILENT /COMPONENTS=\"icons,ext\\reg\\shellhere,assoc,assoc_sh\"", "msg": "Exception calling \"CreateProcess\" with \"5\" argument(s): \"CreateProcessW() failed (The file or directory is corrupted and unreadable, Win32ErrorCode 1392)\"", "rc": 2}
```
The downloading task before it seemed to incorrectly downloading the git executable, as the size was much smaller than what it should've been. Narrowed it down to the `win_get_url` module being the issue. 
The addition of the line `[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12` is to set the tls protocol to version 1.2, as thats what the webpage requires when using `wget`.