### PR TITLE
pbTests: Update testJDK.sh

### DIFF
--- a/ansible/pbTestScripts/testJDK.sh
+++ b/ansible/pbTestScripts/testJDK.sh
@@ -1,14 +1,12 @@
 #!/bin/bash
 
-mv /vagrant/pbTestScripts/workspace/build/src/build/linux-x86_64-normal-server-release/images/jdk8* ~
-export TEST_JDK_HOME=$(find ~ -maxdepth 1 -type d -name "*jdk8u*"|grep -v ".*jre.*")
-cd $HOME && mkdir -p testLocation
-cd testLocation && git clone https://github.com/adoptopenjdk/openjdk-tests
-cd openjdk-tests
-./get.sh -t $HOME/testLocation/openjdk-tests
-cd TestConfig
+mv $HOME/openjdk-build/workspace/build/src/build/linux-x86_64-normal-server-release/images/jdk8* $HOME
+export TEST_JDK_HOME=$(find $HOME -maxdepth 1 -type d -name "*jdk8u*"|grep -v ".*jre.*")
+mkdir -p $HOME/testLocation
+[ ! -d $HOME/testLocation/openjdk-tests ] && git clone https://github.com/adoptopenjdk/openjdk-tests $HOME/testLocation/openjdk-tests
+$HOME/testLocation/openjdk-tests/get.sh -t $HOME/testLocation/openjdk-tests
+cd $HOME/testLocation/openjdk-tests/TKG || exit 1
 make -f run_configure.mk
 export BUILD_LIST=MachineInfo
 make compile
 make _MachineInfo
-


### PR DESCRIPTION
Updated `testJDK.sh` to work now that builds are semi reliable (once #1034 is merged).

Tested on built JDKs in Ubuntu1604. Ubuntu1804 and CentOS6. 