### PR TITLE
Update Marist zlinux inventory to the new z15 linux machines

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,7 @@ script:
   - cd ansible
 
     # Check that the inventory is valid
-  - ansible-inventory --host=build-marist-rhel74-s390x-1
+  - ansible-inventory --host=build-marist-rhel77-s390x-1
 
     # Check YAML validity
   - yamllint -c yamllint.yml .

--- a/ansible/inventory.yml
+++ b/ansible/inventory.yml
@@ -33,6 +33,9 @@ hosts:
           centos69-x64-1: {ip: 159.65.95.239}
           centos69-x64-2: {ip: 167.71.130.191}
 
+      - ibm:
+          aix71-ppc64-11: {ip: 129.33.196.209, user: b9s010a}
+
       - linaro:
           centos76-armv8-1: {ip: 213.146.141.99, user: centos}
           centos76-armv8-2: {ip: 213.146.141.123, user: centos}

--- a/ansible/inventory.yml
+++ b/ansible/inventory.yml
@@ -47,10 +47,9 @@ hosts:
           macos1012-x64-2: {ip: 207.254.71.42, user: Administrator}
 
       - marist:
-          rhel74-s390x-1: {ip: 148.100.110.129}
-          rhel74-s390x-2: {ip: 148.100.110.131}
-          ubuntu1604-s390x-2: {ip: 148.100.33.178}
-          ubuntu1604-s390x-3: {ip: 148.100.33.179}
+          rhel77-s390x-1: {ip: 148.100.86.102, user: linux1}
+          rhel77-s390x-2: {ip: 148.100.86.218, user: linux1}
+          ubuntu1604-s390x-1: {ip: 148.100.113.58, user: ubuntu}
           zos21-s390x-1: {ip: 148.100.36.136, user: OPEN1}
           zos21-s390x-2: {ip: 148.100.36.137, user: OPEN1}
 
@@ -144,9 +143,11 @@ hosts:
           macos1014-x64-3: {ip: 74.80.249.207, user: admin}
 
       - marist:
-          sles12-s390x-1: {ip: 148.100.110.56}
-          ubuntu1604-s390x-1: {ip: 148.100.33.147}
-          ubuntu1604-s390x-2: {ip: 148.100.33.184, user: linux1}
+          sles12-s390x-1: {ip: 148.100.86.128}
+          ubuntu1604-s390x-1: {ip: 148.100.113.20, user: ubuntu}
+          ubuntu1604-s390x-2: {ip: 148.100.113.25, user: ubuntu}
+          ubuntu1604-s390x-3: {ip: 148.100.113.30, user: ubuntu}
+          ubuntu1604-s390x-4: {ip: 148.100.113.46, user: ubuntu}
 
       - scaleway:
           ubuntu1604-x64-1: {ip: 51.15.76.107}


### PR DESCRIPTION
Part of https://github.com/AdoptOpenJDK/openjdk-infrastructure/issues/1031
NOTE: WIP until we are ready to decomission the old ones.
NOTE2: I'm not sure if the z/OS ones we had are worth keeping now since we cannot currently build on z/OS (even assuming those systems are really still there)