### PR TITLE
Resolve the dependency error for RedHat s390x

### DIFF
--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/tasks/RedHat.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/tasks/RedHat.yml
@@ -73,7 +73,7 @@
   tags: build_tools
 
 - name: Install additional build tools for RHEL on s390x
-  package: "name={{ item }} state=latest"
+  package: "name={{ item }} state=present"
   with_items: "{{ Additional_Build_Tools_RHEL_s390x }}"
   when:
     - ansible_architecture == "s390x"


### PR DESCRIPTION
- If the 32 bit C lib is installed on machines,
 it will be skipped.

Signed-off-by: Jenny Chen <Jenny.Chen@ibm.com>