### PR TITLE
WinPB: Fix the Git installation for Windows

### DIFF
--- a/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/roles/GIT/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/roles/GIT/tasks/main.yml
@@ -16,11 +16,18 @@
   tags: git
 
 - name: Download GIT installer
-  win_shell: '[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; wget https://github.com/git-for-windows/git/releases/download/v2.24.1.windows.2/Git-2.24.1.2-64-bit.exe -Outfile C:/temp/git.exe'
+  win_get_url:
+    url: 'https://github.com/git-for-windows/git/releases/download/v2.14.3.windows.1/Git-2.14.3-64-bit.exe'
+    dest: 'C:\temp\git.exe'
   when: (git_download.stat.exists == false) and (git_installed.stat.exists == false)
   tags: git
 
+- name: Create GIT properties file
+  win_shell: 'New-Item -Path C:\temp -Name git_props.cfg -ItemType file -Value "[Setup]`nCRLFOption=CRLFCommitAsIs"'
+  when: (git_installed.stat.exists == false)
+  tags: git
+
 - name: Install GIT
-  win_command: 'C:\temp\git.exe /SILENT /COMPONENTS="icons,ext\reg\shellhere,assoc,assoc_sh"'
+  win_command: 'C:\temp\git.exe /SILENT /LOADINF="C:\temp\git_props.cfg" /COMPONENTS="icons,ext\reg\shellhere,assoc,assoc_sh"'
   when: (git_installed.stat.exists == false)
   tags: git

--- a/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/roles/cygwin/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/roles/cygwin/tasks/main.yml
@@ -52,6 +52,10 @@
     - perl-Text-CSV
   tags: cygwin
 
+- name: Change git config to not replace Line endings
+  win_shell: "C:/cygwin64/bin/git config --system core.autocrlf false"
+  tags: cygwin
+
 ###############################################################################
 # Cygwin by default installs latest versions of packages, which is 3.0-2 for
 # grep. This version of grep is unable to match EOL (with $) when the file use


### PR DESCRIPTION
Ref: #1023 

The issue is that the way Git is being installed means it will be changing the line endings as `git clone` is happening on a windows machine. This PR will change the git config so that it won't change the line endings.
As it's unclear whether the `git` being used is from Cygwin, or "git-for-windows", so this PR will contain changes to both roles, as there's no benefit to them converting the line endings for Windows in our situation anyway. 

git-for-windows: This involves creating a config file for the installation to use to determine settings. 
Cygwin: Once installation of Cygwin and its packages are done, a task will change the `.gitconfig` that's there once Cygwin is installed. Git falls under the `Devel` category of Cygwin Packages being installed, and in the playbooks current form, the installation properties can't be specified like it can in git-for-windows.

**Note:** The git download task in git-for-windows has changed as this was incorrectly changed prior (#1039). The issue that that PR was attempting to fix is an upstream issue with Ansible's `win_get_url` module and will supposedly be fixed on release of Ansible 2.9.3.