### PR TITLE
UnixPB: Add checksums to all `get_url` modules

### DIFF
--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Ant-Contrib/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Ant-Contrib/tasks/main.yml
@@ -27,6 +27,7 @@
     mode: 0440
     timeout: 25
     validate_certs: no
+    checksum: sha256:c9b8b1ca18b13e293688cafbd8990c940ca49104dbeefc242e5c3f8de271abdf
   retries: 3
   delay: 5
   register: antContrib_download

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/tasks/CentOS.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/tasks/CentOS.yml
@@ -36,6 +36,7 @@
     url: http://repos.azulsystems.com/rhel/zulu.repo
     dest: /etc/yum.repos.d/zulu.repo
     timeout: 25
+    checksum: sha256:a7403b21c3eaad3104195746bfb0784fe2747a2722cf7ffb787f9ea4fc0cd39b
   when:
     - ansible_architecture == "x86_64"
   tags: build_tools
@@ -46,9 +47,6 @@
 - name: Call Build Packages and Tools Task
   include_tasks: build_packages_and_tools.yml
 
-##########################
-# Additional build tools #
-##########################
 ##########################
 # Additional build tools #
 ##########################
@@ -63,6 +61,7 @@
     url: https://people.centos.org/tru/devtools-2/devtools-2.repo
     dest: /etc/yum.repos.d/devtools-2.repo
     timeout: 25
+    checksum: sha256:a8ebeb4bed624700f727179e6ef771dafe47651131a00a78b342251415646acc
   when:
     - ansible_distribution == "CentOS"
     - ansible_distribution_major_version == "6"
@@ -148,6 +147,7 @@
     mode: 0440
     timeout: 25
     validate_certs: no
+    checksum: sha256:d9dc32efba7e74f788fcc4f212a43216fc37cf5f23f4c2339664d473353aedf6
   when:
     - ansible_architecture == "x86_64"
   tags: expat

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/tasks/SLES.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/tasks/SLES.yml
@@ -73,6 +73,7 @@
     url: http://www.zlib.net/zlib-1.2.11.tar.gz
     dest: /tmp/zlib-1.2.11.tar.gz
     mode: 0440
+    checksum: sha256:c3e5e9fdd5004dcb542feda5ee4f0ff0744628baf8ed2dd5d66f8ca1197cb1a1
   when:
     - zlib_status.stat.islnk is not defined
   tags: zlib
@@ -176,6 +177,7 @@
     mode: 0440
     timeout: 25
     validate_certs: no
+    checksum: sha256:d9dc32efba7e74f788fcc4f212a43216fc37cf5f23f4c2339664d473353aedf6
   when:
     - ((ansible_distribution_major_version == "11" and ansible_architecture == "x86_64") or (ansible_distribution_major_version == "12" and ansible_architecture == "s390x"))
     - expat_installed.stat.exists == false

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Docker/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Docker/tasks/main.yml
@@ -121,6 +121,7 @@
     owner: root
     group: root
     mode: 0644
+    checksum: sha256:6650718e0fe5202ae7618521f695d43a8bc051c539d7570f0edbfa5b4916f218
   when:
     - docker_installed.rc != 0
     - ansible_distribution == "RedHat"
@@ -189,6 +190,7 @@
     owner: root
     group: root
     mode: 0644
+    checksum: sha256:6650718e0fe5202ae7618521f695d43a8bc051c539d7570f0edbfa5b4916f218
   when:
     - docker_installed.rc != 0
     - ansible_distribution == "CentOS"

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/GIT_Source/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/GIT_Source/tasks/main.yml
@@ -31,6 +31,7 @@
     url: https://www.kernel.org/pub/software/scm/git/git-2.15.0.tar.xz
     dest: /tmp/git-2.15.0.tar.xz
     mode: 0440
+    checksum: sha256:107116489f10b758b51af1c5dbdb9a274917b0fb67dc8eaefcdabc7bc3eb3e6a
   retries: 3
   delay: 5
   register: git_download

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/NVidia_Cuda_Toolkit/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/NVidia_Cuda_Toolkit/tasks/main.yml
@@ -12,6 +12,7 @@
   get_url:
     url: "https://developer.nvidia.com/compute/cuda/9.0/Prod/local_installers/cuda_9.0.176_384.81_linux-run"
     dest: "/tmp/cuda9_linux-run"
+    checksum: sha256:96863423feaa50b5c1c5e1b9ec537ef7ba77576a3986652351ae43e66bcd080c
   retries: 3
   delay: 5
   register: nvidia_cuda_toolkit_download

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Nagios_Plugins/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Nagios_Plugins/tasks/main.yml
@@ -47,6 +47,7 @@
     url: https://raw.githubusercontent.com/justintime/nagios-plugins/master/check_mem/check_mem.pl
     dest: /usr/local/nagios/libexec/check_mem
     mode: 0755
+    checksum: sha256:47666dce9d11d5908c3e775d229dcbdcd11ce13fd5ea576859987eccbdfc3efa
   when:
     - Nagios_Plugins == "Enabled"
   tags: [nagios_plugins, adoptopenjdk]

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Nagios_Plugins/tasks/nagios_FreeBSD.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Nagios_Plugins/tasks/nagios_FreeBSD.yml
@@ -31,6 +31,7 @@
     dest: /tmp/
     mode: 0440
     timeout: 25
+    checksum: sha256:647c0ba4583d891c965fc29b77c4ccfeccc21f409fdf259cb8af52cb39c21e18
   tags: [nagios_plugins, adoptopenjdk]
 
 - name: Extract nagios-plugins
@@ -53,4 +54,5 @@
     url: https://raw.githubusercontent.com/AdoptOpenJDK/openjdk-infrastructure/master/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Nagios_Plugins/tasks/additional_plugins/check_pkg
     dest: /usr/local/nagios/libexec/check_pkg
     mode: 0755
+    checksum: sha256:1ccbd48c22dfc42f712f31d09b2509cc93f2b5ef7bb804ba1d0d7db0a4803874
   tags: [nagios_plugins, adoptopenjdk]

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Nagios_Plugins/tasks/nagios_RedHat.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Nagios_Plugins/tasks/nagios_RedHat.yml
@@ -56,6 +56,7 @@
     dest: /tmp/
     mode: 0440
     timeout: 25
+    checksum: sha256:647c0ba4583d891c965fc29b77c4ccfeccc21f409fdf259cb8af52cb39c21e18
   when:
 #      - ansible_distribution_major_version == "6"
     - not folder_nagios.stat.exists
@@ -87,4 +88,5 @@
     url: https://raw.githubusercontent.com/AdoptOpenJDK/openjdk-infrastructure/master/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Nagios_Plugins/tasks/additional_plugins/check_yum
     dest: /usr/local/nagios/libexec/check_yum
     mode: 0755
+    checksum: sha256:f93372dee2b1aa4ea45f1a2ee30ffa9d5ebc5fe2a44f8d5e69b7f9f38420be7e
   tags: [nagios_plugins, adoptopenjdk]

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Nagios_Plugins/tasks/nagios_SLES.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Nagios_Plugins/tasks/nagios_SLES.yml
@@ -39,6 +39,7 @@
     dest: /tmp/
     mode: 0440
     timeout: 25
+    checksum: sha256:647c0ba4583d891c965fc29b77c4ccfeccc21f409fdf259cb8af52cb39c21e18
   tags: [nagios_plugins, adoptopenjdk]
 
 - name: Extract nagios-plugins
@@ -61,4 +62,5 @@
     url: https://raw.githubusercontent.com/AdoptOpenJDK/openjdk-infrastructure/master/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Nagios_Plugins/tasks/additional_plugins/check_zypper
     dest: /usr/local/nagios/libexec/check_zypper
     mode: 0755
+    checksum: sha256:005f7008c7d817e6de9bd1650fe198ad9fd0ebaade74ce45f1c6a9ae3fd278af
   tags: [nagios_plugins, adoptopenjdk]

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Nagios_Tunnel/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Nagios_Tunnel/tasks/main.yml
@@ -28,6 +28,7 @@
     url: https://raw.githubusercontent.com/AdoptOpenJDK/openjdk-infrastructure/master/ansible/playbooks/Supporting_Scripts/Nagios_Ansible_Config_tool/Nagios_RemoteTunnel.sh
     dest: /home/nagios/Nagios_RemoteTunnel.sh
     mode: 0755
+    checksum: sha256:f2bfb91818fe04ba4f4498c27b5d622f3111e5823d14df0b30a7b8ef9d4dc56f
   when:
     - ansible_port != "22"
     - Nagios_Monitoring == "Enabled"

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/OpenSSL102/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/OpenSSL102/tasks/main.yml
@@ -17,6 +17,7 @@
     force: no
     mode: 0755
     validate_certs: no
+    checksum: sha256:ae51d08bba8a83958e894946f15303ff894d75c2b8bbd44a852b64e3fe11d0d6
   when:
     - (ansible_distribution_major_version == "6" and (ansible_distribution == "RedHat" or ansible_distribution == "CentOS") or ansible_distribution == "Debian")
     - ((openssl_version.stdout == '') or ((openssl_version.stdout != '') and (openssl_version.stdout is version_compare('1.0.2', operator='lt', strict=True))))

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Protobuf/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Protobuf/tasks/main.yml
@@ -78,6 +78,7 @@
     force: no
     mode: 0755
     validate_certs: no
+    checksum: sha256:c28dba8782da2cfea1e11c61d335958c31a9c1bc553063546af9cbe98f204092
   when:
     - (ansible_distribution == "RedHat" or ansible_distribution == "CentOS" or ansible_distribution == "Ubuntu" or ansible_distribution == "SLES")
     - protobuf_status.stat.exists == False

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Python3_Source/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Python3_Source/tasks/main.yml
@@ -51,6 +51,7 @@
     url: https://www.python.org/ftp/python/3.7.3/Python-3.7.3.tar.xz
     dest: /tmp/Python-3.7.3.tar.xz
     mode: 0440
+    checksum: sha256:da60b54064d4cfcd9c26576f6df2690e62085123826cff2e667e72a91952d318
   when:
     - (python3_installed.rc != 0 )
   tags: python3_source

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/ant/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/ant/tasks/main.yml
@@ -20,6 +20,7 @@
     mode: 0440
     timeout: 25
     validate_certs: no
+    checksum: sha512:2e48f9e429d67708f5690bc307232f08440d01ebe414059292b6543971da9c7cd259c21533b9163b4dd753321c17bd917adf8407d03245a0945fc30a4e633163
   when:
     - ant_installed.rc != 0
   tags: ant

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/autoconf/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/autoconf/tasks/main.yml
@@ -18,6 +18,7 @@
     dest: /tmp/autoconf-2.69.tar.gz
     force: no
     mode: 0755
+    checksum: sha256:954bd69b391edc12d6a4a51a2dd1476543da5c6bbf05a95b59dc0dd6fd4c2969
   when:
     - (ansible_distribution == "RedHat" or ansible_distribution == "CentOS")
     - ansible_distribution_major_version == "6"

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/cmake/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/cmake/tasks/main.yml
@@ -31,6 +31,7 @@
     mode: 0440
     force: no
     validate_certs: no
+    checksum: sha256:8f864e9f78917de3e1483e256270daabc4a321741592c5b36af028e72bff87f5
   when:
     - (cmake_installed.rc != 0 ) or (cmake_installed.rc == 0 and cmake_version.stdout is version_compare('3.11.4', operator='lt') )
     - (ansible_architecture == "x86_64") or (ansible_architecture == "ppc64le") or (ansible_architecture == "s390x")

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/curl/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/curl/tasks/main.yml
@@ -27,6 +27,7 @@
     mode: 0440
     timeout: 25
     validate_certs: no
+    checksum: sha256:eaa812e9a871ea10dbe8e1d3f8f12a64a8e3e62aeab18cb23742e2f1727458ae
   retries: 3
   delay: 5
   register: curl_download

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/gcc_48/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/gcc_48/tasks/main.yml
@@ -18,6 +18,7 @@
     dest: '/tmp/gcc-4.8.5.tar.gz'
     force: no
     mode: 0755
+    checksum: sha256:1dbc5cd94c9947fe5dffd298e569de7f44c3cedbd428fceea59490d336d8295a
   when:
     - gcc_installed.rc != 0
     - ansible_distribution == "RedHat"

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/gcc_7/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/gcc_7/tasks/main.yml
@@ -19,6 +19,7 @@
     dest: '/tmp/ansible-adoptopenjdk-gcc-7.tar.xz'
     force: no
     mode: 0644
+    checksum: db3dcf4867acbf0cdcd9cb3a97f2e47d72d1a2a59e9e60359f267742f5fa650a
   when:
     - ansible_distribution == "RedHat" or ansible_distribution == "CentOS"
     - ansible_architecture != "CentOS" and ansible_architecture != "x86-64"

--- a/ansible/playbooks/vagrant.yml
+++ b/ansible/playbooks/vagrant.yml
@@ -121,6 +121,7 @@
             url: https://www.kernel.org/pub/software/scm/git/git-2.15.0.tar.xz
             dest: /tmp/git-2.15.0.tar.xz
             mode: 0440
+            checksum: sha256:107116489f10b758b51af1c5dbdb9a274917b0fb67dc8eaefcdabc7bc3eb3e6a
           when:
             - (git_installed.rc != 0 ) or (git_installed.rc == 0 and git_version.stdout is version_compare('2.15', operator='lt') )
 
@@ -168,6 +169,7 @@
           get_url:
             url: https://releases.hashicorp.com/vagrant/2.2.5/vagrant_2.2.5_x86_64.deb
             dest: /tmp/vagrant_2.2.5_x86_64.deb
+            checksum: sha256:415f50b93235e761db284c761f6a8240a6ef6762ee3ec7ff869d2bccb1a1cdf7
           when:
             - (vagrant_installed.rc != 0) or (vagrant_installed.rc == 0 and vagrant_version.stdout is version_compare('2.2.5', operator='lt') )
 


### PR DESCRIPTION
Fixes: #998 
This will be broken up into a few groups:
 - The 1st group of checksums commit entail all the roles with `get_url` tasks that have provided a checksum with the download. I.e. `cmake`s one is from https://cmake.org/files/v3.11/cmake-3.11.4-SHA-256.txt

- The 2nd group will entail all roles that don't provide a checksum. These will be found by executing `wget` on each URL and installing them onto a VM. If the installation works correctly, I'll assume the downloaded item was correct and use that checksum.