### PR TITLE
UnixPB: Debian Fixes + trailing space fix

### DIFF
--- a/ansible/Vagrantfile.Debian8
+++ b/ansible/Vagrantfile.Debian8
@@ -26,6 +26,10 @@ echo "--------------------------------------------------------------------------
 echo "*** '$VAGRANT_MOUNT/playbooks/hosts' file for ansible-playbook contains ***"
 cat $VAGRANT_MOUNT/playbooks/hosts
 echo "---------------------------------------------------------------------------------------"
+# Get IPs of the VM, and output to shared folder
+ifconfig | grep "inet" | awk '{print $2}' | sed 's/addr://'  >> /vagrant/playbooks/AdoptOpenJDK_Unix_Playbook/hosts.tmp
+# Put the host machine's IP into the authorised_keys file on the VM
+[ -r /vagrant/id_rsa.pub ] && mkdir -p $HOME/.ssh && cat /vagrant/id_rsa.pub >> $HOME/.ssh/authorized_keys
 SCRIPT
 
 # 2 = version of configuration file for Vagrant 1.1+ leading up to 2.0.x

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/main.yml
@@ -2,7 +2,7 @@
 ###################################
 # AdoptOpenJDK - Ansible Playbook #
 ###################################
-# Groups can be passed in as a command-line variable in Ansible playbook. 
+# Groups can be passed in as a command-line variable in Ansible playbook.
 # It can be defined as 'all' or a specific group which the host belongs to.
 # For example, it can be 'all' or 'x86' for when a host is in the group 'x86'.
 - hosts: "{{ Groups | default('localhost:build:test:!*zos*:!*win*:!*aix*') }}"

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Ant-Contrib/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Ant-Contrib/tasks/main.yml
@@ -27,6 +27,7 @@
     mode: 0440
     timeout: 25
     validate_certs: no
+    checksum: sha256:c9b8b1ca18b13e293688cafbd8990c940ca49104dbeefc242e5c3f8de271abdf
   retries: 3
   delay: 5
   register: antContrib_download

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/tasks/Debian.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/tasks/Debian.yml
@@ -40,7 +40,7 @@
 
 # Both repositories needed for gcc/g++-4.8
 - name: Add additional repositories for Raspbian Buster
-  apt-repository: repo={{ item }}
+  apt_repository: repo={{ item }}
   with_items:
     - deb-src http://raspbian.raspberrypi.org/raspbian/ buster main contrib non-free rpi
     - deb http://mirrordirector.raspbian.org/raspbian/ jessie main contrib non-free rpi
@@ -89,7 +89,7 @@
   tags: build_tools
 
 - name: Install GCC G++ on Raspian Buster
-  packages: "name={{ item }} state=latest"
+  package: "name={{ item }} state=latest"
   with_items:
     - gcc-4.8
     - g++-4.8


### PR DESCRIPTION
Fixing incorrect names of Ansible modules in the `../Common/tasks/Debian.yml` file.
Also added the commands necessary for ansible to connect to a Debian8 Vagrant VM, tp `Vagrantfile.Debian8`, and fixed a trailing space.