### PR TITLE
pbTests: Altered Windows Scripts to build and test

### DIFF
--- a/ansible/pbTestScripts/buildJDKWin.sh
+++ b/ansible/pbTestScripts/buildJDKWin.sh
@@ -6,8 +6,6 @@ export JAVA_TO_BUILD=jdk8
 export VARIANT=hotspot
 export JDK7_BOOT_DIR=/cygdrive/c/openjdk/jdk7
 export PATH=/usr/bin/:$PATH
-# Ensures Git won't replace line endings (CRLF)
-C:/cygwin64/bin/sed -i -e 's/autocrlf.*/autocrlf = false/g' C:\\ProgramData/Git/config
 # Git clone openjdk-build if it's not currently there.
 cd C:/
 if [ ! -d "openjdk-build" ]; then

--- a/ansible/pbTestScripts/testJDKWin.sh
+++ b/ansible/pbTestScripts/testJDKWin.sh
@@ -29,7 +29,7 @@ fi
 cd openjdk-tests
 
 ./get.sh -t $HOME/testLocation/openjdk-tests -p x64_windows
-cd TestConfig
+cd TKG
 make -f run_configure.mk AUTO_DETECT=true
 export BUILD_LIST=MachineInfo
 make compile

--- a/ansible/pbTestScripts/testScript.sh
+++ b/ansible/pbTestScripts/testScript.sh
@@ -214,12 +214,14 @@ startVMPlaybookWin()
 	searchLogFiles $OS
 	local pbFailed=$?
         if [[ "$testNativeBuild" = true && "$pbFailed" == 0 ]]; then
+		vagrant reload
 		# Runs the build script via ansible, as vagrant powershell gives error messages that ansible doesn't. 
         	# See: https://github.com/AdoptOpenJDK/openjdk-infrastructure/pull/942#issuecomment-539946564
         	cd $WORKSPACE/adoptopenjdkPBTests/$folderName-$branchName/ansible
 		ansible all -i playbooks/AdoptOpenJDK_Windows_Playbook/hosts.win -u vagrant -m raw -a "Start-Process powershell.exe -Verb runAs; cd C:/; sh C:/vagrant/pbTestScripts/buildJDKWin.sh"
 		echo The build finished at : `date +%T`
 		if [[ "$runTest" = true ]]; then
+			vagrant reload
 			# Runs a script on the VM to test the built JDK
 			ansible all -i playbooks/AdoptOpenJDK_Windows_Playbook/hosts.win -u vagrant -m raw -a "sh C:/vagrant/pbTestScripts/testJDKWin.sh"
 			echo The test finished at : `date +%T`


### PR DESCRIPTION
Fixes: #865 (I hope) - https://ci.adoptopenjdk.net/job/SXA-PlaybookCheckParallel/208/

Last commit that should get the SXA-PlaybookCheckParallel job finished and working. Fixes the `buildJDK.sh` to remove the git config line as that should be set in #1047 . Changed `testJDKWin.sh` to find `TKG` not `TestConfig`. Added `vagrant reload` to `testScript.sh` as the Windows VM seems to have its shared folder disappear after the playbook runs. `vagrant reload` will just restart the vagrant box and remount the shared folders.