### PR TITLE
UnixPB: Update playbook to allow SLES12 to work

### DIFF
--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/CPAN/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/CPAN/tasks/main.yml
@@ -47,6 +47,7 @@
 
 - name: Install XML::Parser
   command: cpanm --with-recommends --sudo XML::Parser
+  when: ansible_distribution != "SLES" and ansible_distribution_major_version != "12"
   tags:
     - cpan
     - xml_parser

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/tasks/SLES.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/tasks/SLES.yml
@@ -8,7 +8,7 @@
 #########################################
 - zypper_repository:
     name: devel-tools
-    repo: 'https://download.opensuse.org/repositories/devel:/tools:/scm/SLE_12_SP3/'
+    repo: 'https://download.opensuse.org/repositories/devel:/tools/SLE_12_SP4/'
     auto_import_keys: yes
     state: present
   when:

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/vars/SLES.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/vars/SLES.yml
@@ -27,7 +27,7 @@ Build_Tool_Packages:
 
 Additional_Build_Tools_SLES12:
   - java-1_8_0-openjdk
-  - git
+  - git-core
   - libfreetype6
   - libXext6
   - libXi6                        # JDK12+ compilation

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/NVidia_Cuda_Toolkit/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/NVidia_Cuda_Toolkit/tasks/main.yml
@@ -91,9 +91,7 @@
   tags: nvidia_cuda_toolkit
 
 - name: Enable NVidia CUDA toolkit Repo for SLES12 on x86_64
-  command: |
-    rpm -i /tmp/sles12_cuda9_repo.rpm
-    sed 's/gpgcheck=1/gpgcheck=0/' -i /etc/zypp/repos.d/cuda.repo
+  command: rpm -i /tmp/sles12_cuda9_repo.rpm
   when:
     - cuda_installed.stat.islnk is not defined
     - ansible_architecture == "x86_64"
@@ -103,6 +101,19 @@
     - nvidia_cuda_toolkit
     #TODO: rpm used in place of yum or rpm_key module
     - skip_ansible_lint
+
+- name: Sed change gpgcheck for SLES12 on x86_64
+  command: sed 's/gpgcheck=1/gpgcheck=0/' -i /etc/zypp/repos.d/cuda.repo
+  when:
+    - cuda_installed.stat.islnk is not defined
+    - ansible_architecture == "x86_64"
+    - ansible_distribution == "SLES"
+    - ansible_distribution_major_version == "12"
+  tags:
+    - nvidia_cuda_toolkit
+    #TODO: rpm used in place of yum or rpm_key module
+    - skip_ansible_lint
+
 
 - name: Install NVidia CUDA toolkit for SLES12 on x86_64
   zypper: pkg=cuda state=latest update_cache=yes

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Swap_File/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Swap_File/tasks/main.yml
@@ -9,22 +9,12 @@
 # Not installed: When swap_root.rc or swap_tmp.rc does NOT equal 0
 # Assume swap path of /swapfile override where applicable
 
-- name: Test swapfile path - /swapfile
-  command: ls /swapfile
+- name: Test if swapfile exists
+  command: grep swap /etc/fstab
   ignore_errors: yes
-  register: swap_root
+  register: swap_exists
   tags:
     - swap_file
-    # TODO: use stat to check file existence
-    - skip_ansible_lint
-
-- name: Test swapfile path - /tmp/swapfile
-  command: ls /tmp/swapfile
-  ignore_errors: yes
-  register: swap_tmp
-  tags:
-    - swap_file
-    # TODO: use stat to check file existence
     - skip_ansible_lint
 
 - name: Set Swapfile path - /swapfile
@@ -43,8 +33,7 @@
   debug:
     msg:
       - "swap_path: {{ swap_path | default('***Undefined***') }} "
-      - "swap_tmp: {{ swap_tmp.rc | default('***Undefined***') }} "
-      - "swap_root: {{ swap_root.rc | default('***Undefined***') }} "
+      - "swap_exists: {{ swap_exists.rc | default('***Undefined***') }} "
   tags: swap_file
 
 - name: Disable dphys-swapfile where applicable
@@ -57,7 +46,7 @@
 - name: Create swap file - via DD
   command: "dd if=/dev/zero of=/{{ swap_path }} bs=250M count=8"
   when:
-    - (swap_root.rc != 0 and swap_tmp.rc != 0)
+    - (swap_exists.rc != 0)
   tags: swap_file
 
 - name: Set swap file permissions
@@ -66,19 +55,19 @@
         group="{{ root_group }}"
         mode=0600
   when:
-    - (swap_root.rc != 0 and swap_tmp.rc != 0)
+    - (swap_exists.rc != 0)
   tags: swap_file
 
 - name: Create swap area device
   command: "mkswap {{ swap_path }}"
   when:
-    - (swap_root.rc != 0 and swap_tmp.rc != 0)
+    - (swap_exists.rc != 0)
   tags: swap_file
 
 - name: Mount swap file
   command: "swapon {{ swap_path }}"
   when:
-    - (swap_root.rc != 0 and swap_tmp.rc != 0)
+    - (swap_exists.rc != 0)
   tags: swap_file
 
 - name: Add swap to fstab
@@ -90,5 +79,5 @@
     dump=0
     state=present
   when:
-    - (swap_root.rc != 0 and swap_tmp.rc != 0)
+    - (swap_exists.rc != 0)
   tags: swap_file


### PR DESCRIPTION
fixes: #1033 

Fixes all of the issues listed in 1033. 

The only concern I have is the changes implemented to not install CPAN's XML::Parser, and instead install `perl-xml-parser` under the `test-tool-packages` section. Supposedly that's meant to be equivalent, according to this : https://github.com/chorny/XML-Parser/blob/master/README

However, I don't know how to verify this. It does install however.
I've done this as CPAN XML::Parser has a dependency for `libexpat1-dev` (or `libexpat-dev`) or `expat-dev` depending on the OS, that appears to not be available to SLES12-SP4 (The machine both @Haroon-Khel and I were testing on).

Note: Currently testing using the `vagrantPlaybookCheck.sh` script. https://ci.adoptopenjdk.net/view/Tooling/job/VagrantPlaybookCheck/220/