### PR TITLE
VFs: Add FreeBSD12 and SLES12 Vagrantfiles

### DIFF
--- a/ansible/Vagrantfile.FreeBSD12
+++ b/ansible/Vagrantfile.FreeBSD12
@@ -4,6 +4,7 @@
 $script = <<SCRIPT
 # Doesn't come pre-installed in the vagrant box
 sudo pkg install -y python
+sudo ln -sf /usr/local/bin/python /usr/bin/python
 # Get IPs of the VM, and output to shared folder
 ifconfig | grep "inet" | awk '{print $2}' | sed 's/addr://'  >> /vagrant/playbooks/AdoptOpenJDK_Unix_Playbook/hosts.tmp
 # Put the host machine's IP into the authorised_keys file on the VM

--- a/ansible/Vagrantfile.FreeBSD12
+++ b/ansible/Vagrantfile.FreeBSD12
@@ -1,0 +1,23 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+$script = <<SCRIPT
+# Doesn't come pre-installed in the vagrant box
+sudo pkg install -y python
+# Get IPs of the VM, and output to shared folder
+ifconfig | grep "inet" | awk '{print $2}' | sed 's/addr://'  >> /vagrant/playbooks/AdoptOpenJDK_Unix_Playbook/hosts.tmp
+# Put the host machine's IP into the authorised_keys file on the VM
+[ -r /vagrant/id_rsa.pub ] && mkdir -p $HOME/.ssh && cat /vagrant/id_rsa.pub >> $HOME/.ssh/authorized_keys
+SCRIPT
+
+# 2 = version of configuration file for Vagrant 1.1+ leading up to 2.0.x
+Vagrant.configure("2") do |config|
+
+  config.vm.define :adoptopenjdkFBSD12 do |adoptopenjdkFBSD12|
+    adoptopenjdkFBSD12.vm.box = "generic/freebsd12"
+    adoptopenjdkFBSD12.vm.synced_folder ".", "/vagrant", type: 'rsync'
+    adoptopenjdkFBSD12.vm.hostname = "adoptopenjdkFBSD12"
+    adoptopenjdkFBSD12.vm.network :private_network, type: "dhcp"
+    adoptopenjdkFBSD12.vm.provision "shell", inline: $script, privileged: false
+  end
+end

--- a/ansible/Vagrantfile.SLES12
+++ b/ansible/Vagrantfile.SLES12
@@ -1,0 +1,21 @@
+#-*- mode: ruby -*-
+# vi: set ft=ruby :
+
+$script = <<SCRIPT
+# Get IPs of the VM, and output to shared folder
+ip address show | grep -e "\\binet\\b" | cut -d' ' -f6 | cut -d/ -f1  >> /vagrant/playbooks/AdoptOpenJDK_Unix_Playbook/hosts.tmp
+# Put the host machine's IP into the authorised_keys file on the VM
+[ -r /vagrant/id_rsa.pub ] && mkdir -p $HOME/.ssh && cat /vagrant/id_rsa.pub >> $HOME/.ssh/authorized_keys
+SCRIPT
+
+# 2 = version of configuration file for Vagrant 1.1+ leading up to 2.0.x
+Vagrant.configure("2") do |config|
+
+  config.vm.define :adoptopenjdkS12 do |adoptopenjdkS12|
+    adoptopenjdkS12.vm.box = "suse/sles12sp1"
+    adoptopenjdkS12.vm.synced_folder ".", "/vagrant", type: "rsync"
+    adoptopenjdkS12.vm.hostname = "adoptopenjdkS12"
+    adoptopenjdkS12.vm.network :private_network, type: "dhcp"
+    adoptopenjdkS12.vm.provision "shell", inline: $script, privileged: false
+  end
+end

--- a/ansible/pbTestScripts/vagrantPlaybookCheck.sh
+++ b/ansible/pbTestScripts/vagrantPlaybookCheck.sh
@@ -165,8 +165,8 @@ startVMPlaybook()
 	rm -f id_rsa.pub id_rsa
 	ssh-keygen -q -f $PWD/id_rsa -t rsa -N ''
 	vagrant up
-	# FreeBSD12 uses a different shared folder type- required to get hosts.tmp from VM
-	if [[ "$OS" == "FreeBSD12" ]]; then
+	# FreeBSD12 & SLES12 uses a different shared folder type- required to get hosts.tmp from VM
+	if [[ "$OS" == "FreeBSD12" || "$OS" == "SLES12" ]]; then
                vagrant rsync-back
 	fi
 	# Generate hosts.unx file for Ansible to use, remove prior hosts.unx if there

--- a/ansible/pbTestScripts/vagrantPlaybookCheck.sh
+++ b/ansible/pbTestScripts/vagrantPlaybookCheck.sh
@@ -81,6 +81,10 @@ checkVars()
                 echo "Can't find vagrant-disksize plugin, installing . . ."
                 vagrant plugin install vagrant-disksize
         fi
+        if [[ ! $(vagrant plugin list | grep 'rsync-back') ]]; then
+                echo "Can't find vagrant-rsync-back plugin, installing . . ."
+                vagrant plugin install vagrant-rsync-back
+        fi
 }
 
 checkVagrantOS()
@@ -161,6 +165,10 @@ startVMPlaybook()
 	rm -f id_rsa.pub id_rsa
 	ssh-keygen -q -f $PWD/id_rsa -t rsa -N ''
 	vagrant up
+	# FreeBSD12 uses a different shared folder type- required to get hosts.tmp from VM
+	if [[ "$OS" == "FreeBSD12" ]]; then
+               vagrant rsync-back
+	fi
 	# Generate hosts.unx file for Ansible to use, remove prior hosts.unx if there
 	[[ -f playbooks/AdoptOpenJDK_Unix_Playbook/hosts.unx ]] && rm playbooks/AdoptOpenJDK_Unix_Playbook/hosts.unx
 	cat playbooks/AdoptOpenJDK_Unix_Playbook/hosts.tmp | tr -d \\r | sort -nr | head -1 > playbooks/AdoptOpenJDK_Unix_Playbook/hosts.unx && rm playbooks/AdoptOpenJDK_Unix_Playbook/hosts.tmp

--- a/ansible/pbTestScripts/vmDestroy.sh
+++ b/ansible/pbTestScripts/vmDestroy.sh
@@ -51,10 +51,12 @@ checkOS() {
                         osToDestroy="D8" ;;
 		"FreeBSD12" | "freebsd12" | "F12" | "f12" )
 			osToDestroy="FBSD12" ;;
+		"SLES12" | "sles12" | "S12" | "s12" )
+			osToDestroy="S12" ;;
 		"Windows2012" | "Win2012" | "W12" | "w12" )
                         osToDestroy="W2012";;
                 "all" )
-                        osToDestroy="U16 U18 C6 C7 D8 FBSD12 W2012" ;;
+                        osToDestroy="U16 U18 C6 C7 D8 FBSD12 S12 W2012" ;;
 		"")
 			echo "No OS detected. Did you miss the '-o' option?" ; usage; exit 1;;
 		*) echo "$OS is not a currently supported OS" ; listOS; exit 1;
@@ -70,6 +72,7 @@ listOS() {
 		- CentOS7
 		- Debian8
 		- FreeBSD12
+		- SLES12
 		- Win2012"
 	echo
 }

--- a/ansible/pbTestScripts/vmDestroy.sh
+++ b/ansible/pbTestScripts/vmDestroy.sh
@@ -49,10 +49,12 @@ checkOS() {
                         osToDestroy="C7" ;;
                 "Debian8" | "debian8" | "D7" | "d7" )
                         osToDestroy="D8" ;;
-                "Windows2012" | "Win2012" | "W12" | "w12" )
+		"FreeBSD12" | "freebsd12" | "F12" | "f12" )
+			osToDestroy="FBSD12" ;;
+		"Windows2012" | "Win2012" | "W12" | "w12" )
                         osToDestroy="W2012";;
                 "all" )
-                        osToDestroy="U16 U18 C6 C7 D8 W2012" ;;
+                        osToDestroy="U16 U18 C6 C7 D8 FBSD12 W2012" ;;
 		"")
 			echo "No OS detected. Did you miss the '-o' option?" ; usage; exit 1;;
 		*) echo "$OS is not a currently supported OS" ; listOS; exit 1;
@@ -67,6 +69,7 @@ listOS() {
 		- CentOS6
 		- CentOS7
 		- Debian8
+		- FreeBSD12
 		- Win2012"
 	echo
 }


### PR DESCRIPTION
fixes: #1061 

This PR will allow us to test the unix playbooks for the above OSs, so we don't run into a series of unexpected errors such as #1033 . 

FreeBSD12: I have managed to get the `generic` box working, which is the FreeBSD12 box with the most downloads and looks the most trustworthy. https://app.vagrantup.com/generic/boxes/freebsd12. FreeBSD12 doesn't support the `vboxsf` file type, so between the 2 alternatives of `smb` and `rsync`, `rsync` has been used as `smb` is not supported on linux hosts. Due to `rsync`s inability to share files from the guest VM to the host machine, the plugin `vagrant-rsync-back` has had to be used to do this.

SLES12: I've got this working using a Vagrantfile provided by SUSE. Unfortunately, this is only SLES12SP1, however there were no SLES12SP3 or SP4 vagrant boxes to speak of. https://app.vagrantup.com/suse/boxes/sles12sp1 . This vagrantfile also has to use the `rsync` file type as this box doesn't have the `Virtualbox Guest Additions` installed to them that are required for the `vboxsf` type. See the above issue for more detail. Therefore this will also make use of the `vagrant-rsync-back` plugin.