### PR TITLE
ansible: Switch adoptopenjdk downloads to APIv3 from APIv2

### DIFF
--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/adoptopenjdk_install/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/adoptopenjdk_install/tasks/main.yml
@@ -32,7 +32,7 @@
 
 - name: Install latest release if one not already installed (Linux/x64)
   unarchive:
-    src: https://api.adoptopenjdk.net/v2/binary/releases/openjdk{{ jdk_version }}?openjdk_impl={{ bootjdk }}&os=linux&arch=x64&heap_size=normal&release=latest&type=jdk
+    src: https://api.adoptopenjdk.net/v3/binary/latest/{{ jdk_version }}/ga/linux/x64/jdk/{{ bootjdk }}/normal/adoptopenjdk?project=jdk
     dest: /usr/lib/jvm
     remote_src: yes
   when:
@@ -42,7 +42,7 @@
 
 - name: Install latest release if one not already installed (Linux/s390x)
   unarchive:
-    src: https://api.adoptopenjdk.net/v2/binary/releases/openjdk{{ jdk_version }}?openjdk_impl={{ bootjdk }}&os=linux&arch=s390x&release=latest&type=jdk
+    src: https://api.adoptopenjdk.net/v3/binary/latest/{{ jdk_version }}/ga/linux/s390x/jdk/{{ bootjdk }}/normal/adoptopenjdk?project=jdk
     dest: /usr/lib/jvm
     remote_src: yes
   when:
@@ -52,7 +52,7 @@
 
 - name: Install latest release if one not already installed (Linux/ppc64le)
   unarchive:
-    src: https://api.adoptopenjdk.net/v2/binary/releases/openjdk{{ jdk_version }}?openjdk_impl={{ bootjdk }}&os=linux&arch=ppc64le&release=latest&type=jdk
+    src: https://api.adoptopenjdk.net/v3/binary/latest/{{ jdk_version }}/ga/linux/ppc64le/jdk/{{ bootjdk }}/normal/adoptopenjdk?project=jdk
     dest: /usr/lib/jvm
     remote_src: yes
   when:
@@ -62,7 +62,7 @@
 
 - name: Install latest Hotspot release if one not already installed (Linux/aarch64)
   unarchive:
-    src: https://api.adoptopenjdk.net/v2/binary/releases/openjdk{{ jdk_version }}?openjdk_impl=hotspot&os=linux&arch=aarch64&release=latest&type=jdk
+    src: https://api.adoptopenjdk.net/v3/binary/latest/{{ jdk_version }}/ga/linux/aarch64/jdk/{{ bootjdk }}/normal/adoptopenjdk?project=jdk
     dest: /usr/lib/jvm
     remote_src: yes
   when:

--- a/ansible/playbooks/aix.yml
+++ b/ansible/playbooks/aix.yml
@@ -257,7 +257,7 @@
 
         - name: Transfer and Extract AdoptOpenJDK 8
           unarchive:
-            src: https://api.adoptopenjdk.net/v2/binary/releases/openjdk8?openjdk_impl={{ bootjdk }}&os=aix&arch=ppc64&release=latest&type=jdk
+            src: https://api.adoptopenjdk.net/v3/binary/latest/8/ga/aix/ppc64/jdk/{{ bootjdk }}/normal/adoptopenjdk?project=jdk
             dest: /usr
             remote_src: yes
           when: java8.stat.isdir is not defined
@@ -300,7 +300,7 @@
 
         - name: Transfer and Extract AdoptOpenJDK 9
           unarchive:
-            src: https://api.adoptopenjdk.net/v2/binary/releases/openjdk9?openjdk_impl={{ bootjdk }}&os=aix&arch=ppc64&release=latest&type=jdk
+            src: https://api.adoptopenjdk.net/v3/binary/latest/9/ga/aix/ppc64/jdk/{{ bootjdk }}/normal/adoptopenjdk?project=jdk
             dest: /usr
             remote_src: yes
           when: java9.stat.isdir is not defined
@@ -337,7 +337,7 @@
 
         - name: Transfer and Extract AdoptOpenJDK 10
           unarchive:
-            src: https://api.adoptopenjdk.net/v2/binary/releases/openjdk10?openjdk_impl=openj9&os=aix&arch=ppc64&release=latest&type=jdk
+            src: https://api.adoptopenjdk.net/v3/binary/latest/10/ga/aix/ppc64/jdk/{{ bootjdk }}/normal/adoptopenjdk?project=jdk
             dest: /usr
             remote_src: yes
           when: java10.stat.isdir is not defined
@@ -374,7 +374,7 @@
 
         - name: Transfer and Extract AdoptOpenJDK 11
           unarchive:
-            src: https://api.adoptopenjdk.net/v2/binary/releases/openjdk11?openjdk_impl=openj9&os=aix&arch=ppc64&release=latest&type=jdk
+            src: https://api.adoptopenjdk.net/v3/binary/latest/11/ga/aix/ppc64/jdk/{{ bootjdk }}/normal/adoptopenjdk?project=jdk
             dest: /usr
             remote_src: yes
           when: java11.stat.isdir is not defined
@@ -410,7 +410,7 @@
 
         - name: Transfer and Extract AdoptOpenJDK 12
           unarchive:
-            src: https://api.adoptopenjdk.net/v2/binary/releases/openjdk12?openjdk_impl=openj9&os=aix&arch=ppc64&release=latest&type=jdk
+            src: https://api.adoptopenjdk.net/v3/binary/latest/12/ga/aix/ppc64/jdk/{{ bootjdk }}/normal/adoptopenjdk?project=jdk
             dest: /usr
             remote_src: yes
           when: java12.stat.isdir is not defined


### PR DESCRIPTION
May resolve issues with API instability as per https://github.com/AdoptOpenJDK/openjdk-api/issues/190