### PR TITLE
UnixPB: Remove 'group' tag from adoptopenjdk_install role

### DIFF
--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/adoptopenjdk_install/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/adoptopenjdk_install/tasks/main.yml
@@ -17,7 +17,6 @@
     path: /usr/lib/jvm
     state: directory
     owner: root
-    group: root
     mode: 0755
   when: usr_lib_jvm_exists.stat.exists != True
   tags: adoptopenjdk_install
@@ -90,14 +89,13 @@
   shell: ls -ld /usr/lib/jvm/jdk-{{ jdk_version }}* 2>/dev/null | awk '{print $9}'
   register: adoptopenjdk_dir
   when: adoptopenjdk_installed.rc != 0
-  tags: adoptopenjdk
+  tags: adoptopenjdk_install
 
 - name: Chown /usr/lib/jvm/jdk-{{ jdk_version }}*
   file:
     path: '{{ adoptopenjdk_dir.stdout }}'
     state: directory
     owner: root
-    group: root
     recurse: yes
   when: adoptopenjdk_installed.rc != 0
-  tags: adoptopenjdk
+  tags: adoptopenjdk_install


### PR DESCRIPTION
This is due to FreeBSD12 having the group called `wheels` instead. However, the group should default to `root` in the case of the other OSs anyway.

I also changed the tags on the final 2 tasks as these are incorrect.