### PR TITLE
pbTest: Run extended.system tests on Windows instead of _MachineInfo

### DIFF
--- a/ansible/pbTestScripts/testJDKWin.sh
+++ b/ansible/pbTestScripts/testJDKWin.sh
@@ -31,6 +31,6 @@ cd openjdk-tests
 ./get.sh -t $HOME/testLocation/openjdk-tests -p x64_windows
 cd TKG
 make -f run_configure.mk AUTO_DETECT=true
-export BUILD_LIST=MachineInfo
+export BUILD_LIST=system
 make compile
-make _MachineInfo
+make _extended.system 


### PR DESCRIPTION
Fixes: #1072 

A suite of tests that are still quite fast to run, but will also validate the installation of `Strawberry Perl` on the VM that had the Playbook ran on it.

Tested on a VM that skipped the `Strawberry Perl` role, to ensure that it does fail when it isn't installed, and it does:
https://ci.adoptopenjdk.net/job/VagrantPlaybookCheck/275/OS=Win2012,label=vagrant/console
