### PR TITLE
Ram increase for Vagrant VMs

### DIFF
--- a/ansible/Vagrantfile.CentOS6
+++ b/ansible/Vagrantfile.CentOS6
@@ -41,4 +41,9 @@ Vagrant.configure("2") do |config|
     adoptopenjdkC6.vm.network :private_network, type: "dhcp"
     adoptopenjdkC6.vm.provision "shell", inline: $script, privileged: false
   end
+  config.vm.provider "virtualbox" do |v|
+    v.gui = false
+    v.memory = 4096
+    v.customize ["modifyvm", :id, "--cpuexecutioncap", "50"]
+  end
 end

--- a/ansible/Vagrantfile.CentOS6
+++ b/ansible/Vagrantfile.CentOS6
@@ -43,7 +43,7 @@ Vagrant.configure("2") do |config|
   end
   config.vm.provider "virtualbox" do |v|
     v.gui = false
-    v.memory = 4096
+    v.memory = 2560
     v.customize ["modifyvm", :id, "--cpuexecutioncap", "50"]
   end
 end

--- a/ansible/Vagrantfile.CentOS7
+++ b/ansible/Vagrantfile.CentOS7
@@ -41,4 +41,9 @@ Vagrant.configure("2") do |config|
     adoptopenjdkC7.vm.network :private_network, type: "dhcp"
     adoptopenjdkC7.vm.provision "shell", inline: $script, privileged: false
   end
+  config.vm.provider "virtualbox" do |v|
+    v.gui = false
+    v.memory = 4096
+    v.customize ["modifyvm", :id, "--cpuexecutioncap", "50"]
+  end
 end

--- a/ansible/Vagrantfile.CentOS7
+++ b/ansible/Vagrantfile.CentOS7
@@ -43,7 +43,7 @@ Vagrant.configure("2") do |config|
   end
   config.vm.provider "virtualbox" do |v|
     v.gui = false
-    v.memory = 4096
+    v.memory = 2560
     v.customize ["modifyvm", :id, "--cpuexecutioncap", "50"]
   end
 end

--- a/ansible/Vagrantfile.Debian8
+++ b/ansible/Vagrantfile.Debian8
@@ -46,7 +46,7 @@ Vagrant.configure("2") do |config|
   end
   config.vm.provider "virtualbox" do |v|
     v.gui = false
-    v.memory = 4096
+    v.memory = 2560
     v.customize ["modifyvm", :id, "--cpuexecutioncap", "50"]
   end
 end

--- a/ansible/Vagrantfile.Debian8
+++ b/ansible/Vagrantfile.Debian8
@@ -44,4 +44,9 @@ Vagrant.configure("2") do |config|
     adoptopenjdkD8.vm.network :private_network, type: "dhcp"
     adoptopenjdkD8.vm.provision "shell", inline: $script, privileged: false
   end
+  config.vm.provider "virtualbox" do |v|
+    v.gui = false
+    v.memory = 4096
+    v.customize ["modifyvm", :id, "--cpuexecutioncap", "50"]
+  end
 end

--- a/ansible/Vagrantfile.FreeBSD12
+++ b/ansible/Vagrantfile.FreeBSD12
@@ -25,7 +25,7 @@ Vagrant.configure("2") do |config|
   end
   config.vm.provider "virtualbox" do |v|
     v.gui = false
-    v.memory = 4096
+    v.memory = 2560
     v.customize ["modifyvm", :id, "--cpuexecutioncap", "50"]
   end
 end

--- a/ansible/Vagrantfile.FreeBSD12
+++ b/ansible/Vagrantfile.FreeBSD12
@@ -23,4 +23,9 @@ Vagrant.configure("2") do |config|
     adoptopenjdkFBSD12.vm.network :private_network, type: "dhcp"
     adoptopenjdkFBSD12.vm.provision "shell", inline: $script, privileged: false
   end
+  config.vm.provider "virtualbox" do |v|
+    v.gui = false
+    v.memory = 4096
+    v.customize ["modifyvm", :id, "--cpuexecutioncap", "50"]
+  end
 end

--- a/ansible/Vagrantfile.SUSE12
+++ b/ansible/Vagrantfile.SUSE12
@@ -23,4 +23,9 @@ Vagrant.configure("2") do |config|
     adoptopenjdkS12.vm.network :private_network, type: "dhcp"
     adoptopenjdkS12.vm.provision "shell", inline: $script, privileged: false
   end
+  config.vm.provider "virtualbox" do |v|
+    v.gui = false
+    v.memory = 4096
+    v.customize ["modifyvm", :id, "--cpuexecutioncap", "50"]
+  end
 end

--- a/ansible/Vagrantfile.SUSE12
+++ b/ansible/Vagrantfile.SUSE12
@@ -25,7 +25,7 @@ Vagrant.configure("2") do |config|
   end
   config.vm.provider "virtualbox" do |v|
     v.gui = false
-    v.memory = 4096
+    v.memory = 2560
     v.customize ["modifyvm", :id, "--cpuexecutioncap", "50"]
   end
 end

--- a/ansible/Vagrantfile.Ubuntu1604
+++ b/ansible/Vagrantfile.Ubuntu1604
@@ -43,4 +43,9 @@ Vagrant.configure("2") do |config|
     adoptopenjdkU16.vm.network :private_network, type: "dhcp"
     adoptopenjdkU16.vm.provision "shell", inline: $script, privileged: false
   end
+  config.vm.provider "virtualbox" do |v|
+    v.gui = false
+    v.memory = 4096
+    v.customize ["modifyvm", :id, "--cpuexecutioncap", "50"]
+  end
 end

--- a/ansible/Vagrantfile.Ubuntu1604
+++ b/ansible/Vagrantfile.Ubuntu1604
@@ -45,7 +45,7 @@ Vagrant.configure("2") do |config|
   end
   config.vm.provider "virtualbox" do |v|
     v.gui = false
-    v.memory = 4096
+    v.memory = 2560
     v.customize ["modifyvm", :id, "--cpuexecutioncap", "50"]
   end
 end

--- a/ansible/Vagrantfile.Ubuntu1804
+++ b/ansible/Vagrantfile.Ubuntu1804
@@ -43,4 +43,9 @@ Vagrant.configure("2") do |config|
     adoptopenjdkU18.vm.network :private_network, type: "dhcp"
     adoptopenjdkU18.vm.provision "shell", inline: $script, privileged: false
   end
+  config.vm.provider "virtualbox" do |v|
+    v.gui = false
+    v.memory = 4096
+    v.customize ["modifyvm", :id, "--cpuexecutioncap", "50"]
+  end
 end

--- a/ansible/Vagrantfile.Ubuntu1804
+++ b/ansible/Vagrantfile.Ubuntu1804
@@ -45,7 +45,7 @@ Vagrant.configure("2") do |config|
   end
   config.vm.provider "virtualbox" do |v|
     v.gui = false
-    v.memory = 4096
+    v.memory = 2560
     v.customize ["modifyvm", :id, "--cpuexecutioncap", "50"]
   end
 end

--- a/ansible/Vagrantfile.Win2012
+++ b/ansible/Vagrantfile.Win2012
@@ -36,7 +36,7 @@ Vagrant.configure("2") do |config|
   end
   config.vm.provider "virtualbox" do |v|
     v.gui = false
-    v.memory = 4096
+    v.memory = 5120
     v.customize ["modifyvm", :id, "--cpuexecutioncap", "50"]
   end
 end

--- a/ansible/Vagrantfile.Win2012
+++ b/ansible/Vagrantfile.Win2012
@@ -36,5 +36,7 @@ Vagrant.configure("2") do |config|
   end
   config.vm.provider "virtualbox" do |v|
     v.gui = false
+    v.memory = 4096
+    v.customize ["modifyvm", :id, "--cpuexecutioncap", "50"]
   end
 end


### PR DESCRIPTION
Increase RAM available to Vagrant machines (especially Windows) and cap the CPU on the hypervisor for each individual one so that the build jobs don't overwhelm it