### PR TITLE
UnixPB: Fixes for FreeBSD12

### DIFF
--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/tasks/main.yml
@@ -6,11 +6,11 @@
 ###########################
 # Overide amd64 to x86_64 #
 ###########################
-- name: If ansible_distribution is amd64 set it to x86_64
+- name: If ansible_architecture is amd64 set it to x86_64
   set_fact:
-    ansible_distribution: "x86_64"
+    ansible_architecture: "x86_64"
   when:
-    - ansible_distribution == "amd64"
+    - ansible_architecture == "amd64"
 
 ##################
 # Set root group #

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/vars/FreeBSD.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/vars/FreeBSD.yml
@@ -14,6 +14,7 @@ Build_Tool_Packages:
   - giflib
   - git
   - gmake
+  - gtar
   - jpeg-turbo
   - lcms2
   - libXext
@@ -28,6 +29,7 @@ Build_Tool_Packages:
   - pkgconf
   - png
   - unzip
+  - wget
   - zip
 
 gcc_compiler:

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/ccache/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/ccache/tasks/main.yml
@@ -39,7 +39,7 @@
   tags: ccache
 
 - name: Running ./configure & make for CCACHE for FreeBSD
-  shell: cd /tmp/ccache-3.4.2 && ./configure && make -j {{ ansible_processor_cores }} && gmake install
+  shell: cd /tmp/ccache-3.4.2 && ./configure && make -j {{ ansible_processor_vcpus }} && gmake install
   when:
     - ccache_status.stat.isdir is not defined
     - ansible_distribution == "FreeBSD"


### PR DESCRIPTION
A couple of issues I found whilst running through the FreeBSD12 playbook locally.

- if `gtar` is not installed, then creating the symlink later on isn't possible.
- `wget` is required to be installed, otherwise the `ccache` role will fail
- the `ansible_processor_cores` variable is undefined at the point it runs the `ccache` role. The `ansible_processor_vcpus` is FreeBSD's equivalent.
- The override task to turn `amd64` to `x86_64` was testing and setting the wrong variable. FreeBSD is the first instance of it being an issue, as the `ansible_architecture` variable is set to `amd64`. If not corrected, the `adoptopenjdk_install` role doesn't download or install the JDK, and then fails at the `chown` task.