### PR TITLE
UnixPB: Set vars for s390x and remove unneeded tasks

### DIFF
--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/tasks/SLES.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/tasks/SLES.yml
@@ -91,15 +91,6 @@
   shell: cd /tmp/zlib-1.2.11 && ./configure && make -j {{ ansible_processor_vcpus }} && make install
   become: yes
   when:
-    - ansible_architecture != "s390x"
-    - zlib_status.stat.islnk is not defined
-  tags: zlib
-
-- name: Running ./configure & make for Zlib on Linux s390x
-  shell: cd /tmp/zlib-1.2.11 && ./configure && make -j {{ ansible_processor_cores }} && make install
-  become: yes
-  when:
-    - ansible_architecture == "s390x"
     - zlib_status.stat.islnk is not defined
   tags: zlib
 
@@ -197,16 +188,5 @@
   shell: cd /tmp/expat-2.2.5 && ./configure && make -j {{ ansible_processor_vcpus }} && sudo make install
   become: yes
   when:
-    - ansible_distribution_major_version == "11"
-    - ansible_architecture == "x86_64"
-    - expat_installed.stat.exists == false
-  tags: expat
-
-- name: Running ./configure & make for expat on Linux s390x
-  shell: cd /tmp/expat-2.2.5 && ./configure && make -j {{ ansible_processor_cores }} && sudo make install
-  become: yes
-  when:
-    - ansible_distribution_major_version == "12"
-    - ansible_architecture == "s390x"
     - expat_installed.stat.exists == false
   tags: expat

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/tasks/main.yml
@@ -12,6 +12,15 @@
   when:
     - ansible_architecture == "amd64"
 
+###############################
+# Set ansible_processor_vcpus #
+###############################
+- name: If ansible_processor_cpus is not defined, set to ansible_processor_cores or 1
+  set_fact:
+    ansible_processor_vcpus: "{{ ansible_processor_cores | default(1) }}"
+  when:
+    - ansible_processor_vcpus is not defined
+
 ##################
 # Set root group #
 ##################

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/ccache/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/ccache/tasks/main.yml
@@ -26,15 +26,6 @@
   shell: cd /tmp/ccache-3.4.2 && ./configure && make clean && make -j {{ ansible_processor_vcpus }} && make install
   when:
     - ccache_status.stat.isdir is not defined
-    - ansible_architecture != "s390x"
-    - ansible_distribution != "FreeBSD"
-  tags: ccache
-
-- name: Running ./configure & make for CCACHE for s390x
-  shell: cd /tmp/ccache-3.4.2 && ./configure && make -j {{ ansible_processor_cores }} && make install
-  when:
-    - ccache_status.stat.isdir is not defined
-    - ansible_architecture == "s390x"
     - ansible_distribution != "FreeBSD"
   tags: ccache
 

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/cmake/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/cmake/tasks/main.yml
@@ -3,13 +3,6 @@
 # cmake  - required by OpenJ9 and OpenJFX builds - requires C++11 compiler #
 ############################################################################
 
-- name: Set ansible_processor_vcpus
-  set_fact:
-    ansible_processor_vcpus: "{{ ansible_processor_cores }}"
-  when:
-    - ansible_architecture == "s390x"
-  tags: cmake
-
 - name: Test if cmake is installed on path
   shell: cmake >/dev/null 2>&1
   ignore_errors: yes


### PR DESCRIPTION
fixes: #1090 

The addition of the task in the `../Common` role will stop there being any point of having so many tasks that are specific to `s390x` that just replace the `ansible_processor_vcpus` variable with `ansible_processor_cores` variable. 

