### PR TITLE
unixPB: Enable protobuf for OpenJ9 JITserver

### DIFF
--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/main.yml
@@ -40,6 +40,7 @@
     - gcc_48
     - gcc_7                       # OpenJ9
     - cmake                       # OpenJ9 / OpenJFX
+    - Protobuf                    # OpenJ9 (JITserver)
     - ccache
     - {role: nasm, when: ansible_architecture == 'x86_64'} # OpenJ9
     - role: adoptopenjdk_install  # JDK11 Build Bootstrap


### PR DESCRIPTION
Jan 2020 OpenJ9 releases on Linux/x64 will be built with JITserver support enabled, which requires protobuf.

Discussed in https://ci.adoptopenjdk.net/view/work%20in%20progress/job/VagrantPlaybookCheck/

Testing at https://ci.adoptopenjdk.net/view/work%20in%20progress/job/VagrantPlaybookCheck/323/

Signed-off-by: Stewart Addison <sxa@uk.ibm.com>