### PR TITLE
pbTests: Update buildJDK.sh to support FreeBSD & openSUSE

### DIFF
--- a/ansible/pbTestScripts/buildJDK.sh
+++ b/ansible/pbTestScripts/buildJDK.sh
@@ -32,8 +32,13 @@ export JDK7_BOOT_DIR=$(find /usr/lib/jvm/ -name java-1.7.0-openjdk.x86_64)
 # Differences in openJDK8 name between Ubuntu and CentOS
 export JAVA_HOME=$(find /usr/lib/jvm/ -name java-1.8.0-openjdk-\*)
 if [ -z "$JAVA_HOME" ]; then
-  export JAVA_HOME=$(ls -1d /usr/lib/jvm/adoptopenjdk-8-* | head -1)
+	export JAVA_HOME=$(ls -1d /usr/lib/jvm/adoptopenjdk-8-* | head -1)
 fi
+
+if grep 'openSUSE' /etc/os-release >/dev/null 2>&1; then
+	echo "Running on openSUSE"
+	JAVA_HOME=$(find /usr/lib/jvm/ -name jdk8u*)
+fi	
 
 # Only build Hotspot on FreeBSD
 if [[ $(uname) == "FreeBSD" ]]; then

--- a/ansible/pbTestScripts/buildJDK.sh
+++ b/ansible/pbTestScripts/buildJDK.sh
@@ -3,7 +3,7 @@ set -eu
 
 # Argument parsing
 if [[ $# == 0 ]]; then
-        echo "No arguments added, defaulting to JDK8"
+        echo "No arguments input, defaulting to JDK8"
         export JAVA_TO_BUILD=jdk8u
 elif [[ $# == 1 ]]; then
         export JAVA_TO_BUILD=$1
@@ -41,9 +41,10 @@ if [[ $(uname) == "FreeBSD" ]]; then
         export TARGET_OS=FreeBSD
         export VARIANT=hotspot
         export JDK7_BOOT_DIR=/usr/local/openjdk7
+	export JAVA_HOME=/usr/local/openjdk8
 fi
 
-echo " DEBUG:
+echo "DEBUG:
         TARGET_OS=$TARGET_OS
         ARCHITECTURE=$ARCHITECTURE
         JAVA_TO_BUILD=$JAVA_TO_BUILD

--- a/ansible/pbTestScripts/buildJDK.sh
+++ b/ansible/pbTestScripts/buildJDK.sh
@@ -1,16 +1,28 @@
 #!/bin/bash
 set -eu
+
+# Argument parsing
+if [[ $# == 0 ]]; then
+        echo "No arguments added, defaulting to JDK8"
+        export JAVA_TO_BUILD=jdk8u
+elif [[ $# == 1 ]]; then
+        export JAVA_TO_BUILD=$1
+else
+        echo "Too many arguments"
+        exit 1;
+fi
+
 export PATH=/usr/local/bin/:$PATH
 if [ -z "${WORKSPACE:-}" ]; then
-		echo "WORKSPACE not found, setting it as environment variable 'HOME'"
-		WORKSPACE=$HOME
+	echo "WORKSPACE not found, setting it as environment variable 'HOME'"
+	WORKSPACE=$HOME
 fi
+
 [[ ! -d "$WORKSPACE/openjdk-build" ]] && git clone https://github.com/adoptopenjdk/openjdk-build $WORKSPACE/openjdk-build
 
 export TARGET_OS=linux
-export ARCHITECTURE=x64
-export JAVA_TO_BUILD=jdk8u
 export VARIANT=openj9
+export ARCHITECTURE=x64
 
 # Differences in openJDK7 name between OSs. Search for CentOS one
 export JDK7_BOOT_DIR=$(find /usr/lib/jvm/ -name java-1.7.0-openjdk.x86_64)
@@ -22,6 +34,23 @@ export JAVA_HOME=$(find /usr/lib/jvm/ -name java-1.8.0-openjdk-\*)
 if [ -z "$JAVA_HOME" ]; then
   export JAVA_HOME=$(ls -1d /usr/lib/jvm/adoptopenjdk-8-* | head -1)
 fi
+
+# Only build Hotspot on FreeBSD
+if [[ $(uname) == "FreeBSD" ]]; then
+        echo "Running on FreeBSD"
+        export TARGET_OS=FreeBSD
+        export VARIANT=hotspot
+        export JDK7_BOOT_DIR=/usr/local/openjdk7
+fi
+
+echo " DEBUG:
+        TARGET_OS=$TARGET_OS
+        ARCHITECTURE=$ARCHITECTURE
+        JAVA_TO_BUILD=$JAVA_TO_BUILD
+        VARIANT=$VARIANT
+        JDK7_BOOT_DIR=$JDK7_BOOT_DIR
+        JAVA_HOME=$JAVA_HOME
+        WORKSPACE=$WORKSPACE"
+
 cd $WORKSPACE/openjdk-build
 build-farm/make-adopt-build-farm.sh
-

--- a/ansible/pbTestScripts/testJDK.sh
+++ b/ansible/pbTestScripts/testJDK.sh
@@ -1,12 +1,18 @@
 #!/bin/bash
 
-mv $HOME/openjdk-build/workspace/build/src/build/linux-x86_64-normal-server-release/images/jdk8* $HOME
+export MAKE_COMMAND="make"
+if [[ $(uname) == "FreeBSD" ]]; then
+	mv $HOME/openjdk-build/workspace/build/src/build/bsd-x86_64-normal-server-release/images/jdk8* $HOME
+	export MAKE_COMMAND="gmake"
+else
+	mv $HOME/openjdk-build/workspace/build/src/build/linux-x86_64-normal-server-release/images/jdk8* $HOME
+fi
 export TEST_JDK_HOME=$(find $HOME -maxdepth 1 -type d -name "*jdk8u*"|grep -v ".*jre.*")
 mkdir -p $HOME/testLocation
 [ ! -d $HOME/testLocation/openjdk-tests ] && git clone https://github.com/adoptopenjdk/openjdk-tests $HOME/testLocation/openjdk-tests
 $HOME/testLocation/openjdk-tests/get.sh -t $HOME/testLocation/openjdk-tests
 cd $HOME/testLocation/openjdk-tests/TKG || exit 1
-make -f run_configure.mk
+$MAKE_COMMAND -f run_configure.mk
 export BUILD_LIST=MachineInfo
-make compile
-make _MachineInfo
+$MAKE_COMMAND compile
+$MAKE_COMMAND _MachineInfo


### PR DESCRIPTION
Now that FreeBSD12 passes the playbook, `buildJDK.sh` needs to be altered to be able to set the correct environment variables for it to build the correct JDK.

I've also added in the ability to pass in JDKs, so we have the option to build more than JDK8 on these playbooks. 
As we don't build openJ9 on FreeBSD, that defaults to Hotspot, however linux distributions are built in `openJ9` as they require more dependencies be installed.