### PR TITLE
Added build tags to appropriate roles

### DIFF
--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/main.yml
@@ -5,7 +5,7 @@
 # Groups can be passed in as a command-line variable in Ansible playbook.
 # It can be defined as 'all' or a specific group which the host belongs to.
 # For example, it can be 'all' or 'x86' for when a host is in the group 'x86'.
-- hosts: all
+- hosts: "{{ Groups | default('localhost:build:test:!*zos*:!*win*:!*aix*') }}"
   gather_facts: yes
   tasks:
     - block:

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/main.yml
@@ -5,7 +5,7 @@
 # Groups can be passed in as a command-line variable in Ansible playbook.
 # It can be defined as 'all' or a specific group which the host belongs to.
 # For example, it can be 'all' or 'x86' for when a host is in the group 'x86'.
-- hosts: "{{ Groups | default('localhost:build:test:!*zos*:!*win*:!*aix*') }}"
+- hosts: all
   gather_facts: yes
   tasks:
     - block:
@@ -25,29 +25,40 @@
     - autoconf
     - curl
     - Jenkins_User                # AdoptOpenJDK Infrastructure
-    - freemarker                  # OpenJ9
+    - role: freemarker            # OpenJ9
+      tags: [build_tools, build_tools_openj9]
     - ant                         # Testing
     - Ant-Contrib                 # Testing
     - GIT_Source
     - CPAN
     - gmake
     - Docker                      # Testing
-    - NVidia_Cuda_Toolkit         # OpenJ9
+    - role: NVidia_Cuda_Toolkit   # OpenJ9
+      tags: [build_tools, build_tools_openj9]
     - Superuser                   # AdoptOpenJDK Infrastructure
     - Swap_File
     - Crontab
     - NTP_TIME
     - gcc_48
-    - gcc_7                       # OpenJ9
-    - cmake                       # OpenJ9 / OpenJFX
+    - role: gcc_7                 # OpenJ9
+      tags: [build_tools, build_tools_openj9]
+    - role: cmake                 # OpenJ9 / OpenJFX
+      tags: [build_tools, build_tools_openj9, build_tools_openjfx]
+    - role: Protobuf              # OpenJ9 (JITserver)
+      tags: [build_tools, build_tools_openj9]
     - ccache
-    - {role: nasm, when: ansible_architecture == 'x86_64'} # OpenJ9
+    - role: nasm                  # OpenJ9
+      when: ansible_architecture == 'x86_64'
+      tags: [build_tools, build_tools_openj9]
     - role: adoptopenjdk_install  # JDK11 Build Bootstrap
       jdk_version: 10
+      tags: build_tools
     - role: adoptopenjdk_install  # JDK13 Build Bootstrap
       jdk_version: 12
+      tags: build_tools
     - role: adoptopenjdk_install  # JDK14 Build Bootstrap
       jdk_version: 13
+      tags: build_tools
     - role: local_srcinstall
       src_tarball: https://github.com/protocolbuffers/protobuf/releases/download/v3.5.1/protobuf-cpp-3.5.1.tar.gz
       installed_target: /usr/local/bin/protoc

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/vars/CentOS.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/vars/CentOS.yml
@@ -80,6 +80,8 @@ Test_Tool_Packages:
   - lbzip2
   - zlib-devel
   - perl-devel
+  - libcurl-devel
+  - openssl-devel
   - mercurial
   - perl
   - xorg-x11-xauth

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/vars/CentOS.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/vars/CentOS.yml
@@ -74,6 +74,12 @@ Additional_Build_Tools_CentOS_x86:
   - libstdc++.i686                # a dependency required for executing a 32-bit C binary
 
 Test_Tool_Packages:
+  - gcc
+  - gcc-c++
+  - unzip
+  - lbzip2
+  - zlib-devel
+  - perl-devel
   - mercurial
   - perl
   - xorg-x11-xauth

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/vars/RedHat.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/vars/RedHat.yml
@@ -83,5 +83,8 @@ Test_Tool_Packages:
   - perl
   - xorg-x11-xauth
   - xorg-x11-server-Xvfb
+  - zlib-devel
+  - perl-devel
+  - expat-devel
 
 crontab_Patching: "/usr/bin/yum -y update && yum clean packages"

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/vars/RedHat.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/vars/RedHat.yml
@@ -86,5 +86,6 @@ Test_Tool_Packages:
   - zlib-devel
   - perl-devel
   - expat-devel
+  - libcurl-devel
 
 crontab_Patching: "/usr/bin/yum -y update && yum clean packages"

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/vars/SLES.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/vars/SLES.yml
@@ -49,7 +49,7 @@ Additional_Build_Tools_SLES_x86:
 
 Test_Tool_Packages:
   - gcc
-  - gcc-c++  
+  - gcc-c++
   - perl
   - pulseaudio
   - xorg-x11

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/vars/SLES.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/vars/SLES.yml
@@ -48,6 +48,8 @@ Additional_Build_Tools_SLES_x86:
   - libstdc++6-32bit              # a dependency required for executing a 32-bit C binary
 
 Test_Tool_Packages:
+  - gcc
+  - gcc-c++  
   - perl
   - pulseaudio
   - xorg-x11

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/vars/Ubuntu.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/vars/Ubuntu.yml
@@ -70,6 +70,7 @@ Additional_Packages_Ubuntu16:
   - libgstreamer0.10-dev                # OpenJFX prereq
   - libgstreamer-plugins-base0.10-dev   # OpenJFX prereq
   - openjdk-7-jdk
+  - openjdk-8-jdk
   - libmpfr4
   - libmpfr4-dbg
 
@@ -109,6 +110,9 @@ Test_Tool_Packages:
   - xvfb
   - binfmt-support
   - qemu-user-static
+  - unzip
+  - cpanminus
+  - libexpat1-dev
 
 Test_Tool_Packages_x86_64:
   - pulseaudio

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/vars/Ubuntu.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/vars/Ubuntu.yml
@@ -113,6 +113,7 @@ Test_Tool_Packages:
   - unzip
   - cpanminus
   - libexpat1-dev
+  - libcurl4-openssl-dev
 
 Test_Tool_Packages_x86_64:
   - pulseaudio


### PR DESCRIPTION
Related to https://github.com/AdoptOpenJDK/openjdk-infrastructure/issues/683

The tags `build_tools`, `build_tools_openj9` and `build_tools_openjfx` have been added to certain roles/tasks so that these can be skipped if creating only a test machine.

~~This is a work in progress, please do not merge yet~~