### PR TITLE
unixPB: Remove duplicate protobuf install

### DIFF
--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/main.yml
@@ -49,12 +49,6 @@
       jdk_version: 12
     - role: adoptopenjdk_install  # JDK14 Build Bootstrap
       jdk_version: 13
-    - role: local_srcinstall
-      src_tarball: https://github.com/protocolbuffers/protobuf/releases/download/v3.5.1/protobuf-cpp-3.5.1.tar.gz
-      installed_target: /usr/local/bin/protoc
-      when:
-        - (ansible_distribution == "RedHat" or ansible_distribution == "CentOS" or ansible_distribution == "Ubuntu" or ansible_distribution == "SLES" or ansible_distribution == "Debian" )
-        - ansible_architecture == "x86_64"
     - OpenSSL102                  # OpenJ9
     - Nagios_Plugins              # AdoptOpenJDK Infrastructure
     - Nagios_Master_Config        # AdoptOpenJDK Infrastructure


### PR DESCRIPTION
We wish to use the separate role in order to force the use of GCC7 for the OpenJ9 builds as the code is statically linked in during build time.

Signed-off-by: Stewart Addison <sxa@uk.ibm.com>