### PR TITLE
Set ansible_processor_vcpus for cmake role

### DIFF
--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/tasks/main.yml
@@ -20,6 +20,8 @@
     ansible_processor_vcpus: "{{ ansible_processor_cores | default(1) }}"
   when:
     - ansible_processor_vcpus is not defined
+  tags:
+    - cmake
 
 ##################
 # Set root group #


### PR DESCRIPTION
Set ansible_processor_vcpus to ansible_processor_cores when defined or
default it to 1.

Signed-off-by: Violeta Sebe <vsebe@ca.ibm.com>