### PR TITLE
winPB: Update checksums for win_get_url module

### DIFF
--- a/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/roles/7-Zip/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/roles/7-Zip/tasks/main.yml
@@ -9,7 +9,8 @@
     url: https://www.7-zip.org/a/7z1805-x64.exe
     dest: 'C:\temp\7z.exe'
     force: no
-    checksum: sha256:c1e42d8b76a86ea1890ad080e69a04c75a5f2c0484bdcd838dc8fa908dd4a84c
+    checksum: c1e42d8b76a86ea1890ad080e69a04c75a5f2c0484bdcd838dc8fa908dd4a84c
+    checksum_algorithm: sha256
   tags: 7zip
 
 - name: Install 7-Zip

--- a/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/roles/ANT/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/roles/ANT/tasks/main.yml
@@ -20,7 +20,8 @@
     url: https://archive.apache.org/dist/ant/binaries/apache-ant-1.10.5-bin.zip
     dest: c:\temp\ant.zip
     force: no
-    checksum: sha256:9028e2fc64491cca0f991acc09b06ee7fe644afe41d1d6caf72702ca25c4613c
+    checksum: 9028e2fc64491cca0f991acc09b06ee7fe644afe41d1d6caf72702ca25c4613c
+    checksum_algorithm: sha256
   when: (ant_installed.stat.exists == false) and (ant_download.stat.exists == false)
   register: ant_download
   tags: ANT
@@ -57,7 +58,8 @@
     url: https://sourceforge.net/projects/ant-contrib/files/ant-contrib/ant-contrib-1.0b2/ant-contrib-1.0b2-bin.zip
     dest: c:\temp\ant-contrib.zip
     force: no
-    checksum: sha256:22bae6c3ddf1a464b285784599eef8698f64dde24378c77e42522a536b88cbbc
+    checksum: 22bae6c3ddf1a464b285784599eef8698f64dde24378c77e42522a536b88cbbc
+    checksum_algorithm: sha256
   when: (ant_contrib_installed.stat.exists == false)
   tags: ANT
 

--- a/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/roles/Clang_32bit/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/roles/Clang_32bit/tasks/main.yml
@@ -17,7 +17,8 @@
     url: https://ci.adoptopenjdk.net/userContent/llvm700/llvm-7.0.0-win32.zip
     dest: 'C:\temp\'
     force: no
-    checksum: sha256:89dcd42d240b3e7ef3a5487855e224f2f90a23a2a194dbadd8c427c2dd59df79
+    checksum: 89dcd42d240b3e7ef3a5487855e224f2f90a23a2a194dbadd8c427c2dd59df79
+    checksum_algorithm: sha256
   when: clang_32bit_installed.stat.exists == false
   tags: clang_32bit
 

--- a/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/roles/Clang_64bit/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/roles/Clang_64bit/tasks/main.yml
@@ -15,7 +15,8 @@
     url: https://releases.llvm.org/7.0.0/LLVM-7.0.0-win64.exe
     dest: 'C:\temp\'
     force: no
-    checksum: sha256:74b197a3959b0408adf0824be01db8dddfa2f9a967f4085af3fad900ed5fdbf6
+    checksum: 74b197a3959b0408adf0824be01db8dddfa2f9a967f4085af3fad900ed5fdbf6
+    checksum_algorithm: sha256
   when: clang_64bit_installed.stat.exists == false
   tags: clang_64bit
 

--- a/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/roles/Firefox/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/roles/Firefox/tasks/main.yml
@@ -19,7 +19,8 @@
   win_get_url:
     url: https://ftp.mozilla.org/pub/firefox/releases/54.0/win64/en-GB/Firefox%20Setup%2054.0.exe
     dest: 'C:\temp\firefox.exe'
-    checksum: sha256:9a1fbbb7eb68347decafbf048fc9728777fc213fefc5224119625b1f58a626fc
+    checksum: 9a1fbbb7eb68347decafbf048fc9728777fc213fefc5224119625b1f58a626fc
+    checksum_algorithm: sha256
   when: (firefox_download.stat.exists == false) and (firefox_installed.stat.exists == false)
   tags: Firefox
 

--- a/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/roles/Freemarker/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/roles/Freemarker/tasks/main.yml
@@ -13,6 +13,7 @@
   win_get_url:
     url: http://central.maven.org/maven2/freemarker/freemarker/2.3.8/freemarker-2.3.8.jar
     dest: 'C:\openjdk\freemarker.jar'
-    checksum: sha256:cf0507fbe4901946e1842c1b63ac95e4b8ed59c0ea27b4398e207428f07633bf
+    checksum: cf0507fbe4901946e1842c1b63ac95e4b8ed59c0ea27b4398e207428f07633bf
+    checksum_algorithm: sha256
   when: (freemarker_installed.stat.exists == false)
   tags: Freemarker

--- a/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/roles/Freemarker/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/roles/Freemarker/tasks/main.yml
@@ -11,7 +11,7 @@
 
 - name: Download freemarker
   win_get_url:
-    url: http://central.maven.org/maven2/freemarker/freemarker/2.3.8/freemarker-2.3.8.jar
+    url: https://repo.maven.apache.org/maven2/freemarker/freemarker/2.3.8/freemarker-2.3.8.jar
     dest: 'C:\openjdk\freemarker.jar'
     checksum: 357472da121499a66175af0a4cd5e8be84b8b4d2fdc6bcc974937937ba3003bc
     checksum_algorithm: sha256

--- a/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/roles/Freemarker/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/roles/Freemarker/tasks/main.yml
@@ -13,7 +13,7 @@
   win_get_url:
     url: http://central.maven.org/maven2/freemarker/freemarker/2.3.8/freemarker-2.3.8.jar
     dest: 'C:\openjdk\freemarker.jar'
-    checksum: cf0507fbe4901946e1842c1b63ac95e4b8ed59c0ea27b4398e207428f07633bf
+    checksum: 357472da121499a66175af0a4cd5e8be84b8b4d2fdc6bcc974937937ba3003bc
     checksum_algorithm: sha256
   when: (freemarker_installed.stat.exists == false)
   tags: Freemarker

--- a/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/roles/Freetype/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/roles/Freetype/tasks/main.yml
@@ -19,7 +19,8 @@
   win_get_url:
     url: https://sourceforge.net/projects/freetype/files/freetype2/2.5.3/ft253.zip/download
     dest: C:\temp\ft253.zip
-    checksum: sha256:cb7475e88852893b83d9c99a5ffedefd46398edc8ef8410396d4d73f1a1281b9
+    checksum: cb7475e88852893b83d9c99a5ffedefd46398edc8ef8410396d4d73f1a1281b9
+    checksum_algorithm: sha256
   when: (freetype_installed.stat.exists == false) and (freetype_download.stat.exists == false)
   tags: Freetype
 

--- a/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/roles/GIT/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/roles/GIT/tasks/main.yml
@@ -19,7 +19,8 @@
   win_get_url:
     url: 'https://github.com/git-for-windows/git/releases/download/v2.14.3.windows.1/Git-2.14.3-64-bit.exe'
     dest: 'C:\temp\git.exe'
-    checksum: sha256:9610e082b823beb7f0da91a98d9f73e1f3f2430c21b2c4e15517dea4f981be3f
+    checksum: 9610e082b823beb7f0da91a98d9f73e1f3f2430c21b2c4e15517dea4f981be3f
+    checksum_algorithm: sha256
   when: (git_download.stat.exists == false) and (git_installed.stat.exists == false)
   tags: git
 

--- a/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/roles/IcedTea-Web/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/roles/IcedTea-Web/tasks/main.yml
@@ -19,7 +19,8 @@
   win_get_url:
     url: https://github.com/AdoptOpenJDK/IcedTea-Web/releases/download/icedtea-web-1.8.2/icedtea-web-1.8.2.msi
     dest: 'C:\temp\icedteaWEB182.msi'
-    checksum: sha256:7887693462e357e9ea20901066f9cf015e8fd1b47f9eec9d075a5fd155de27ca
+    checksum: 7887693462e357e9ea20901066f9cf015e8fd1b47f9eec9d075a5fd155de27ca
+    checksum_algorithm: sha256
   when: (icedteaweb_download.stat.exists == false) and (icedteaweb_install.stat.exists == false)
   tags: IcedTea-Web
 

--- a/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/roles/Java7/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/roles/Java7/tasks/main.yml
@@ -19,7 +19,8 @@
   win_get_url:
     url: https://download.java.net/openjdk/jdk7u75/ri/jdk_ri-7u75-b13-windows-i586-18_dec_2014.zip
     dest: 'C:\temp\jdk7u75-b13.zip'
-    checksum: sha256:505a6a2440ae2d48e61a50049f0bb9fce789ab4618953e0c72e07c5987b725ab
+    checksum: 505a6a2440ae2d48e61a50049f0bb9fce789ab4618953e0c72e07c5987b725ab
+    checksum_algorithm: sha256
   when: (java7_download.stat.exists == false) and (java7_installed.stat.exists == false)
   tags: Java7
 

--- a/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/roles/MSVS_2010/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/roles/MSVS_2010/tasks/main.yml
@@ -12,7 +12,8 @@
   win_get_url:
     url: 'https://download.microsoft.com/download/D/B/C/DBC11267-9597-46FF-8377-E194A73970D6/vs_proweb.exe'
     dest: 'C:\temp\vs2010_professional.exe'
-    checksum: sha256:a03ef907e301ae9fc81c6b8bbe17112a449f1ab6c79eaa623b6e50a6cec366ba
+    checksum: a03ef907e301ae9fc81c6b8bbe17112a449f1ab6c79eaa623b6e50a6cec366ba
+    checksum_algorithm: sha256
   when: (vs2010_installed.stat.exists == false)
   tags: MSVS_2010
 

--- a/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/roles/MSVS_2017/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/roles/MSVS_2017/tasks/main.yml
@@ -14,7 +14,8 @@
     url: 'https://aka.ms/vs/15/release/vs_community.exe'
     dest: 'C:\TEMP\vs_community.exe'
     force: no
-    checksum: sha256:14559f581aa0d2bb841f236d00e02d8f743f881da9077dea630ecef3658c6593
+    checksum: 14559f581aa0d2bb841f236d00e02d8f743f881da9077dea630ecef3658c6593
+    checksum_algorithm: sha256
   when: (vs2017_installed.stat.exists == false)
   tags: MSVS_2017
 

--- a/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/roles/MSVS_2017/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/roles/MSVS_2017/tasks/main.yml
@@ -14,7 +14,7 @@
     url: 'https://aka.ms/vs/15/release/vs_community.exe'
     dest: 'C:\TEMP\vs_community.exe'
     force: no
-    checksum: 14559f581aa0d2bb841f236d00e02d8f743f881da9077dea630ecef3658c6593
+    checksum: 14e078f4da89990e3c05775283adb8802d937f69a08ac8d0b6c683dc3ab6a0e8
     checksum_algorithm: sha256
   when: (vs2017_installed.stat.exists == false)
   tags: MSVS_2017

--- a/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/roles/NVidia_Cuda_Toolkit/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/roles/NVidia_Cuda_Toolkit/tasks/main.yml
@@ -12,7 +12,8 @@
   win_get_url:
     url: 'https://developer.nvidia.com/compute/cuda/9.0/Prod/network_installers/cuda_9.0.176_windows_network-exe'
     dest: 'C:\temp\cuda_9.0.176_windows_network-exe.exe'
-    checksum: sha256:ab1c3d046d43e8c190f74a6a4ea94b2e87b9be4c8bc0e67304e460fc0d7caccc
+    checksum: ab1c3d046d43e8c190f74a6a4ea94b2e87b9be4c8bc0e67304e460fc0d7caccc
+    checksum_algorithm: sha256
   when: (cuda_installed.stat.exists == false) and (ansible_distribution_major_version == "5" or ansible_distribution_major_version == "6")
   tags: NVidia_Cuda_Toolkit
 
@@ -32,7 +33,8 @@
   win_get_url:
     url: 'https://developer.nvidia.com/compute/cuda/9.0/Prod/network_installers/cuda_9.0.176_win10_network-exe'
     dest: 'C:\temp\cuda_9.0.176_win10_network-exe.exe'
-    checksum: sha256:9a2f4bc524437b0b46e6374d69976bfda431c4d55c247078fb1fcad410573b15
+    checksum: 9a2f4bc524437b0b46e6374d69976bfda431c4d55c247078fb1fcad410573b15
+    checksum_algorithm: sha256
   when: (cuda_installed.stat.exists == false and ansible_distribution_major_version == "10")
   tags: NVidia_Cuda_Toolkit
 

--- a/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/roles/OpenSSL/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/roles/OpenSSL/tasks/main.yml
@@ -18,7 +18,8 @@
   win_get_url:
     url: https://www.openssl.org/source/openssl-1.1.1d.tar.gz
     dest: C:\temp\openssl-1.1.1d.tar.gz
-    checksum: sha256:1e3a91bc1f9dfce01af26026f856e064eab4c8ee0a8f457b5ae30b40b8b711f2
+    checksum: 1e3a91bc1f9dfce01af26026f856e064eab4c8ee0a8f457b5ae30b40b8b711f2
+    checksum_algorithm: sha256
   when: (openssl32_installed.stat.exists == false) or (openssl64_installed.stat.exists == false)
   tags: openssl
 

--- a/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/roles/Rust/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/roles/Rust/tasks/main.yml
@@ -14,7 +14,8 @@
     url: https://static.rust-lang.org/dist/rust-1.33.0-x86_64-pc-windows-msvc.msi
     dest: 'C:\temp\rust.msi'
     force: no
-    checksum: sha256:cc27799843a146745d4054afa5de1f1f5ab19d539d8c522a909b3c8119e46f99
+    checksum: cc27799843a146745d4054afa5de1f1f5ab19d539d8c522a909b3c8119e46f99
+    checksum_algorithm: sha256
   when: (rust_installed.stat.exists == false)
   tags: Rust
 

--- a/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/roles/Strawberry_Perl/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/roles/Strawberry_Perl/tasks/main.yml
@@ -19,7 +19,8 @@
   win_get_url:
     url: http://strawberryperl.com/download/5.26.0.1/strawberry-perl-5.26.0.1-64bit.zip
     dest: C:\temp\strawberry-perl.zip
-    checksum: sha256:0f89ce99be64679f930e9cca25ccec09de8aff2fc5db3c0dd4158d9606532ad5
+    checksum: 0f89ce99be64679f930e9cca25ccec09de8aff2fc5db3c0dd4158d9606532ad5
+    checksum_algorithm: sha256
   when: (strawberry_perl_download.stat.exists == false) and (strawberry_perl_installed.stat.exists == false)
   tags: Strawberry_Perl
 

--- a/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/roles/cmake/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/roles/cmake/tasks/main.yml
@@ -14,7 +14,8 @@
     url: https://cmake.org/files/v3.7/cmake-3.7.2-win64-x64.msi
     dest: 'C:\temp\cmake.msi'
     force: no
-    checksum: sha256:8b0cbfc6be83e31a058c8ef282fe204862809ffcd8788bc19a8f0eb457f71187
+    checksum: 8b0cbfc6be83e31a058c8ef282fe204862809ffcd8788bc19a8f0eb457f71187
+    checksum_algorithm: sha256
   when: (cmake_installed.stat.exists == false)
   tags: cmake
 

--- a/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/roles/cygwin/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/roles/cygwin/tasks/main.yml
@@ -20,7 +20,7 @@
     url: https://cygwin.com/setup-x86_64.exe
     dest: 'C:\temp\cygwin.exe'
     force: no
-    checksum: ae481452927771af871e218c85252192e1448c48fbc54bfe38c1bd2303af4ad0
+    checksum: c74f5e301bfc1c9b92f48922666c0f86944ff6bbdf09e1cf94f5b940b5b39c34
     checksum_algorithm: sha256
   tags: cygwin
 

--- a/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/roles/cygwin/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/roles/cygwin/tasks/main.yml
@@ -20,7 +20,8 @@
     url: https://cygwin.com/setup-x86_64.exe
     dest: 'C:\temp\cygwin.exe'
     force: no
-    checksum: sha256:ae481452927771af871e218c85252192e1448c48fbc54bfe38c1bd2303af4ad0
+    checksum: ae481452927771af871e218c85252192e1448c48fbc54bfe38c1bd2303af4ad0
+    checksum_algorithm: sha256
   tags: cygwin
 
 - name: Install Cygwin and its packages
@@ -70,7 +71,8 @@
     url: "{{ Cygwin_SITE_URL + '/x86_64/release/grep/grep-2.27-2.tar.xz' }}"
     dest: "{{ Cygwin_ROOT_INST_DIR + '\\tmp\\grep.tar.xz' }}"
     force: no
-    checksum: sha256:36ae2483f68b3c5a4bd93814fa4f7e2576dbe6559d4ffa0589c2159e85de91f6
+    checksum: 36ae2483f68b3c5a4bd93814fa4f7e2576dbe6559d4ffa0589c2159e85de91f6
+    checksum_algorithm: sha256
   tags: cygwin
 
 - name: Extract grep-2.27-2

--- a/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/roles/nasm/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/roles/nasm/tasks/main.yml
@@ -12,7 +12,8 @@
   win_get_url:
     url: https://www.nasm.us/pub/nasm/releasebuilds/2.13.03/win64/nasm-2.13.03-win64.zip
     dest: C:\temp\nasm-2.13.03.zip
-    checksum: sha256:23e1b679d64024863e2991e5c166e19309f0fe58a9765622b35bd31be5b2cc99
+    checksum: 23e1b679d64024863e2991e5c166e19309f0fe58a9765622b35bd31be5b2cc99
+    checksum_algorithm: sha256
   when: (nasm_installed.stat.exists == false)
   tags: nasm
 

--- a/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/roles/nasm/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/roles/nasm/tasks/main.yml
@@ -12,7 +12,7 @@
   win_get_url:
     url: https://www.nasm.us/pub/nasm/releasebuilds/2.13.03/win64/nasm-2.13.03-win64.zip
     dest: C:\temp\nasm-2.13.03.zip
-    checksum: 23e1b679d64024863e2991e5c166e19309f0fe58a9765622b35bd31be5b2cc99
+    checksum: b3a1f896b53d07854884c2e0d6be7defba7ebd09b864bbb9e6d69ada1c3e989f
     checksum_algorithm: sha256
   when: (nasm_installed.stat.exists == false)
   tags: nasm


### PR DESCRIPTION
Ref: #1058 

@Haroon-Khel found that as of ansible 2.8, the `win_get_url` module separates the checksum and checksum algorithm fields, however (weirdly) not Unix's `get_url` module. Before ansible 2.8, `checksum` wasn't in the documentation at all.
https://docs.ansible.com/ansible/latest/modules/win_get_url_module.html   <-- latest
https://docs.ansible.com/ansible/2.7/modules/win_get_url_module.html       <-- 2.7

However, before ansible 2.8, it must've been planned as putting the checksum option in (as it is now) doesn't cause crashes. This wasn't noticed as the Jenkins nodes that runs the `vagrantPlaybookCheck` job are on ansible 2.5.1, where (presumably) the checksum option was just ignored.
