### PR TITLE
unixPB: Pass CC/CXX variables to Protobuf build task

### DIFF
--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Protobuf/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Protobuf/tasks/main.yml
@@ -116,6 +116,9 @@
 
 - name: Build and install Protocol Buffers v3.7.1
   shell: cd /tmp/protobuf-3.7.1 && ./configure --disable-shared --with-pic && make && make install && ldconfig
+  environment:
+    - CC: "{{ CC }}"
+    - CXX: "{{ CXX }}"
   when:
     - (ansible_distribution == "RedHat" or ansible_distribution == "CentOS" or ansible_distribution == "Ubuntu" or ansible_distribution == "SLES" or ansible_distribution == "openSUSE")
     - protobuf_status.stat.exists == False


### PR DESCRIPTION
Problem found as of upgrading Ansible to 2.9.4 - Using the `set_fact` module doesn't actually set the variables for the environment anymore, therefore they need to be passed in on the task. 
This wouldn't be an issue as supposedly GCC 4.8 can build Protobuf, as well as GCC-7, however in the instances when the default GCC is <4.8 (i.e. the OpenSUSE Vagrant VM), this is required.

