### PR TITLE
Remove zulu-9 from Additional_Build_Tools var lists

### DIFF
--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/tasks/CentOS.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/tasks/CentOS.yml
@@ -20,27 +20,6 @@
     state: latest
   tags: patch_update
 
-#########################################
-# Configure Repos and Update the system #
-#########################################
-- name: Import AZUL public key
-  rpm_key:
-    state: present
-    key: http://repos.azulsystems.com/RPM-GPG-KEY-azulsystems
-  when:
-    - ansible_architecture == "x86_64"
-  tags: azul-key
-
-- name: Add AZUL to yum repo
-  get_url:
-    url: http://repos.azulsystems.com/rhel/zulu.repo
-    dest: /etc/yum.repos.d/zulu.repo
-    timeout: 25
-    checksum: sha256:a7403b21c3eaad3104195746bfb0784fe2747a2722cf7ffb787f9ea4fc0cd39b
-  when:
-    - ansible_architecture == "x86_64"
-  tags: build_tools
-
 ############################
 # Build Packages and tools #
 ############################

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/vars/CentOS.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/vars/CentOS.yml
@@ -68,7 +68,6 @@ Additional_Build_Tools_CentOS7:
   - libstdc++-static
 
 Additional_Build_Tools_CentOS_x86:
-  - zulu-9
   - glibc.i686                    # a dependency required for executing a 32-bit C binary
   - glibc-devel.i686              # a dependency required for executing a 32-bit C binary
   - libstdc++.i686                # a dependency required for executing a 32-bit C binary

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/vars/Debian.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/vars/Debian.yml
@@ -73,7 +73,6 @@ Additional_Packages_Debian8:
   - libmpfr4-dbg
 
 Additional_Build_Tools_x86_64:
-  - zulu-9
   - libnuma-dev
   - numactl
   - gcc-7

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/vars/Ubuntu.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/vars/Ubuntu.yml
@@ -79,7 +79,6 @@ Additional_Packages_Ubuntu18:
   - libgstreamer-plugins-base1.0-dev    # OpenJFX prereq
 
 Additional_Build_Tools_x86:
-  - zulu-9
   - libnuma-dev
   - numactl
   - gcc-7


### PR DESCRIPTION
The inclusion of zulu-9 in the Additional_Build_Tools variables lists causes the `/etc/alternatives/java` symlink to be redirected to the zulu-9 version of java on those systems where it is installed.

Removing zulu-9 from the list fixes #1108