### PR TITLE
Remove azul repo from Icedtea web playbook

### DIFF
--- a/ansible/playbooks/AdoptOpenJDK_ITW_Playbook/roles/Common/tasks/CentOS.yml
+++ b/ansible/playbooks/AdoptOpenJDK_ITW_Playbook/roles/Common/tasks/CentOS.yml
@@ -20,26 +20,6 @@
     state: latest
   tags: patch_update
 
-#########################################
-# Configure Repos and Update the system #
-#########################################
-- name: Import AZUL public key
-  rpm_key:
-    state: present
-    key: http://repos.azulsystems.com/RPM-GPG-KEY-azulsystems
-  when:
-    - ansible_architecture == "x86_64"
-  tags: azul-key
-
-- name: Add AZUL to yum repo
-  get_url:
-    url: http://repos.azulsystems.com/rhel/zulu.repo
-    dest: /etc/yum.repos.d/zulu.repo
-    timeout: 25
-  when:
-    - ansible_architecture == "x86_64"
-  tags: build_tools
-
 ############################
 # Build Packages and tools #
 ############################


### PR DESCRIPTION
Following on from https://github.com/AdoptOpenJDK/openjdk-infrastructure/issues/1108, it would make sense to remove the task of adding the Zulu repo from the icedtea web playbook.