### PR TITLE
pbTests: Fixup last buildJDK.sh commit

### DIFF
--- a/ansible/pbTestScripts/buildJDK.sh
+++ b/ansible/pbTestScripts/buildJDK.sh
@@ -18,12 +18,6 @@ if [ -z "${WORKSPACE:-}" ]; then
 	WORKSPACE=$HOME
 fi
 
-if [[ ! -d "$WORKSPACE/openjdk-build" ]]; then
-  git clone -b freebsd https://github.com/gdams/openjdk-build $WORKSPACE/openjdk-build $WORKSPACE/openjdk-build
-else
-  git clone https://github.com/adoptopenjdk/openjdk-build $WORKSPACE/openjdk-build $WORKSPACE/openjdk-build
-fi
-
 export TARGET_OS=linux
 export VARIANT=openj9
 export ARCHITECTURE=x64
@@ -61,6 +55,12 @@ echo "DEBUG:
         JDK7_BOOT_DIR=$JDK7_BOOT_DIR
         JAVA_HOME=$JAVA_HOME
         WORKSPACE=$WORKSPACE"
+
+if [[ ! -d "$WORKSPACE/openjdk-build" && "$TARGET_OS" == "FreeBSD" ]]; then
+  git clone -b freebsd https://github.com/gdams/openjdk-build $WORKSPACE/openjdk-build
+elif [[ ! -d "$WORKSPACE/openjdk-build" ]]; then
+  git clone https://github.com/adoptopenjdk/openjdk-build $WORKSPACE/openjdk-build
+fi
 
 cd $WORKSPACE/openjdk-build
 build-farm/make-adopt-build-farm.sh


### PR DESCRIPTION
Removed the extra arguments from `git clone`, move the function into a better place (i.e after `$TARGET_OS` is defined), and use `$TARGET_OS` to determine if we should build use @gdams FreeBSD build repo, or the standard build repo. 