### PR TITLE
remove p7zip dependency on macOS

### DIFF
--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/vars/MacOSX.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/vars/MacOSX.yml
@@ -22,7 +22,6 @@ Test_Tool_Packages:
   - mercurial
   - pulseaudio
   - cpanminus
-  - p7zip # required for the codesign job to extract jmods and because unzip can't handle pkzip file-created files
 
 Test_Tool_Casks:
   - xquartz


### PR DESCRIPTION
This is no longer needed.