### PR TITLE
UnixPB: Add support for SLES15-SP0

### DIFF
--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/tasks/SLES.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/tasks/SLES.yml
@@ -25,6 +25,15 @@
     - (ansible_distribution_major_version == "12" and ansible_architecture == "s390x")
   tags: patch_update
 
+- zypper_repository:
+    name: devel-tools
+    repo: "https://download.opensuse.org/repositories/devel:/tools/SLE_15/"
+    auto_import_keys: yes
+    state: present
+  when:
+    - ansible_distribution_major_version == "15"
+  tags: patch_update
+
 - name: zypper upgrade all packages
   zypper: name='*' state=latest update_cache=yes
   tags: patch_update
@@ -38,6 +47,13 @@
 ##########################
 # Additional build tools #
 ##########################
+- name: Install additional build tools for SLES 15
+  package: "name={{ item }} state=latest"
+  with_items: "{{ Additional_Build_Tools_SLES15 }}"
+  when:
+    - ansible_distribution_major_version == "15"
+  tags: build_tools
+
 - name: Install additional build tools for SLES 12
   package: "name={{ item }} state=latest"
   with_items: "{{ Additional_Build_Tools_SLES12 }}"
@@ -158,7 +174,8 @@
     path: /usr/local/lib/libexpat.so
   register: expat_installed
   when:
-    - ((ansible_distribution_major_version == "11" and ansible_architecture == "x86_64") or (ansible_distribution_major_version == "12" and ansible_architecture == "s390x"))
+    - (ansible_distribution_major_version == "11") or (ansible_distribution_major_version == "12")
+    - (ansible_architecture == "x86_64") or (ansible_architecture == "s390x")
   tags: expat
 
 - name: Download expat
@@ -170,7 +187,8 @@
     validate_certs: no
     checksum: sha256:d9dc32efba7e74f788fcc4f212a43216fc37cf5f23f4c2339664d473353aedf6
   when:
-    - ((ansible_distribution_major_version == "11" and ansible_architecture == "x86_64") or (ansible_distribution_major_version == "12" and ansible_architecture == "s390x"))
+    - (ansible_distribution_major_version == "11") or (ansible_distribution_major_version == "12")
+    - (ansible_architecture == "x86_64") or (ansible_architecture == "s390x")
     - expat_installed.stat.exists == false
   tags: expat
 
@@ -180,7 +198,8 @@
     dest: /tmp/
     copy: False
   when:
-    - ((ansible_distribution_major_version == "11" and ansible_architecture == "x86_64") or (ansible_distribution_major_version == "12" and ansible_architecture == "s390x"))
+    - (ansible_distribution_major_version == "11") or (ansible_distribution_major_version == "12")
+    - (ansible_architecture == "x86_64") or (ansible_architecture == "s390x")
     - expat_installed.stat.exists == false
   tags: expat
 
@@ -188,5 +207,7 @@
   shell: cd /tmp/expat-2.2.5 && ./configure && make -j {{ ansible_processor_vcpus }} && sudo make install
   become: yes
   when:
+    - (ansible_distribution_major_version == "11") or (ansible_distribution_major_version == "12")
+    - (ansible_architecture == "x86_64") or (ansible_architecture == "s390x")
     - expat_installed.stat.exists == false
   tags: expat

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/vars/SLES.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/vars/SLES.yml
@@ -17,7 +17,6 @@ Build_Tool_Packages:
   - libdw1
   - libelf1
   - make
-  - ntp
   - pkg-config
   - systemtap-sdt-devel
   - unzip
@@ -45,8 +44,8 @@ Additional_Build_Tools_SLES15:
 Additional_Build_Tools_SLES12:
   - java-1_8_0-openjdk
   - git-core
-  - libfreetype6
   - libelf0
+  - libfreetype6
   - libXext6
   - libXi6                        # JDK12+ compilation
   - libXrandr2                    # JDK12+ compilation
@@ -54,12 +53,14 @@ Additional_Build_Tools_SLES12:
   - libXt6
   - libXtst6
   - Mesa-libGL1
+  - ntp
   - perl-CPAN-Meta
 
 Additional_Build_Tools_SLES11:
   - perl-Error
   - libelf0
   - libwww-perl
+  - ntp
 
 Additional_Build_Tools_SLES_x86:
   - glibc-32bit                   # a dependency required for executing a 32-bit C binary

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/vars/SLES.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/vars/SLES.yml
@@ -15,7 +15,6 @@ Build_Tool_Packages:
   - glibc
   - glibc-devel
   - libdw1
-  - libelf0
   - libelf1
   - make
   - ntp
@@ -25,10 +24,29 @@ Build_Tool_Packages:
   - wget
   - zip
 
+Additional_Build_Tools_SLES15:
+  - alsa-devel
+  - cups-devel
+  - fontconfig-devel
+  - java-1_8_0-openjdk
+  - libcurl-devel
+  - libdwarf-devel
+  - libelf-devel
+  - libnuma-devel
+  - libX11-devel
+  - libXext-devel
+  - libXext-devel
+  - libXi-devel
+  - libXrandr-devel                 # JDK12+ compilation
+  - libXrender-devel
+  - libXt-devel
+  - libXtst-devel
+
 Additional_Build_Tools_SLES12:
   - java-1_8_0-openjdk
   - git-core
   - libfreetype6
+  - libelf0
   - libXext6
   - libXi6                        # JDK12+ compilation
   - libXrandr2                    # JDK12+ compilation
@@ -40,6 +58,7 @@ Additional_Build_Tools_SLES12:
 
 Additional_Build_Tools_SLES11:
   - perl-Error
+  - libelf0
   - libwww-perl
 
 Additional_Build_Tools_SLES_x86:

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/NTP_TIME/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/NTP_TIME/tasks/main.yml
@@ -45,11 +45,12 @@
     - ansible_architecture == "x86_64"
   tags: ntp_time
 
-- name: Start chronyd for RHEL8
+- name: Start chronyd for RHEL8 and SLES15
   service:
     name: chronyd
     state: restarted
     enabled: yes
   when:
-    - ansible_distribution == "RedHat" and ansible_distribution_major_version == "8"
+    - (ansible_distribution == "RedHat" and ansible_distribution_major_version == "8") or
+      (ansible_distribution == "SLES" and ansible_distribution_major_version == "15")
   tags: ntp_time


### PR DESCRIPTION
Requested by @sej-jackson 

Additions to the `../common/*/SLES.yml` files, to allow for the playbook to run through on SLES15 and build JDK8-J9 on it. Most of the added packages were available from the default repos on the machine, however `devel-tools` was added for `libdwarf-devel` to be installed. 
Tested on a SLES15 SP0 internal machine. This initially didn't have `sudo` installed however - the `git_source` role will fail if this is the case, however I assumed that _actual_ machines would already have this on the machine? 