### PR TITLE
VFs: Ref #685 non-zero exit status fix

### DIFF
--- a/ansible/Vagrantfile.CentOS6
+++ b/ansible/Vagrantfile.CentOS6
@@ -26,7 +26,9 @@ echo "--------------------------------------------------------------------------
 # Get IPs of the VM, and output to shared folder
 ifconfig | grep "inet" | awk '{print $2}' | sed 's/addr://'  >> /vagrant/playbooks/AdoptOpenJDK_Unix_Playbook/hosts.tmp
 # Put the host machine's IP into the authorised_keys file on the VM
-[ -r /vagrant/id_rsa.pub ] && mkdir -p $HOME/.ssh && cat /vagrant/id_rsa.pub >> $HOME/.ssh/authorized_keys
+if [ -r /vagrant/id_rsa.pub ]; then
+	mkdir -p $HOME/.ssh && cat /vagrant/id_rsa.pub >> $HOME/.ssh/authorized_keys
+fi
 SCRIPT
 
 # 2 = version of configuration file for Vagrant 1.1+ leading up to 2.0.x

--- a/ansible/Vagrantfile.CentOS7
+++ b/ansible/Vagrantfile.CentOS7
@@ -26,7 +26,9 @@ echo "--------------------------------------------------------------------------
 # Get IPs of the VM, and output to shared folder
 ifconfig | grep "inet" | awk '{print $2}' | sed 's/addr://'  >> /vagrant/playbooks/AdoptOpenJDK_Unix_Playbook/hosts.tmp
 # Put the host machine's IP into the authorised_keys file on the VM
-[ -r /vagrant/id_rsa.pub ] && mkdir -p $HOME/.ssh && cat /vagrant/id_rsa.pub >> $HOME/.ssh/authorized_keys
+if [ -r /vagrant/id_rsa.pub ]; then
+        mkdir -p $HOME/.ssh && cat /vagrant/id_rsa.pub >> $HOME/.ssh/authorized_keys
+fi
 SCRIPT
 
 # 2 = version of configuration file for Vagrant 1.1+ leading up to 2.0.x

--- a/ansible/Vagrantfile.Debian8
+++ b/ansible/Vagrantfile.Debian8
@@ -29,7 +29,9 @@ echo "--------------------------------------------------------------------------
 # Get IPs of the VM, and output to shared folder
 ip address show | grep -e "\\binet\\b" | cut -d' ' -f6 | cut -d/ -f1  >> /vagrant/playbooks/AdoptOpenJDK_Unix_Playbook/hosts.tmp
 # Put the host machine's IP into the authorised_keys file on the VM
-[ -r /vagrant/id_rsa.pub ] && mkdir -p $HOME/.ssh && cat /vagrant/id_rsa.pub >> $HOME/.ssh/authorized_keys
+if [ -r /vagrant/id_rsa.pub ]; then
+        mkdir -p $HOME/.ssh && cat /vagrant/id_rsa.pub >> $HOME/.ssh/authorized_keys
+fi
 SCRIPT
 
 # 2 = version of configuration file for Vagrant 1.1+ leading up to 2.0.x

--- a/ansible/Vagrantfile.FreeBSD12
+++ b/ansible/Vagrantfile.FreeBSD12
@@ -8,7 +8,9 @@ sudo ln -sf /usr/local/bin/python /usr/bin/python
 # Get IPs of the VM, and output to shared folder
 ifconfig | grep "inet" | awk '{print $2}' | sed 's/addr://'  >> /vagrant/playbooks/AdoptOpenJDK_Unix_Playbook/hosts.tmp
 # Put the host machine's IP into the authorised_keys file on the VM
-[ -r /vagrant/id_rsa.pub ] && mkdir -p $HOME/.ssh && cat /vagrant/id_rsa.pub >> $HOME/.ssh/authorized_keys
+if [ -r /vagrant/id_rsa.pub ]; then
+        mkdir -p $HOME/.ssh && cat /vagrant/id_rsa.pub >> $HOME/.ssh/authorized_keys
+fi
 SCRIPT
 
 # 2 = version of configuration file for Vagrant 1.1+ leading up to 2.0.x

--- a/ansible/Vagrantfile.SUSE12
+++ b/ansible/Vagrantfile.SUSE12
@@ -8,7 +8,9 @@ sudo zypper -n install python python-xml
 # Get IPs of the VM, and output to shared folder
 ip address show | grep -e "\\binet\\b" | cut -d' ' -f6 | cut -d/ -f1  >> /vagrant/playbooks/AdoptOpenJDK_Unix_Playbook/hosts.tmp
 # Put the host machine's IP into the authorised_keys file on the VM
-[ -r /vagrant/id_rsa.pub ] && mkdir -p $HOME/.ssh && cat /vagrant/id_rsa.pub >> $HOME/.ssh/authorized_keys
+if [ -r /vagrant/id_rsa.pub ]; then
+        mkdir -p $HOME/.ssh && cat /vagrant/id_rsa.pub >> $HOME/.ssh/authorized_keys
+fi
 SCRIPT
 
 # 2 = version of configuration file for Vagrant 1.1+ leading up to 2.0.x

--- a/ansible/Vagrantfile.Ubuntu1604
+++ b/ansible/Vagrantfile.Ubuntu1604
@@ -28,7 +28,9 @@ echo "--------------------------------------------------------------------------
 # Get IPs of the VM, and output to shared folder
 ifconfig | grep "inet" | awk '{print $2}' | sed 's/addr://'  >> /vagrant/playbooks/AdoptOpenJDK_Unix_Playbook/hosts.tmp
 # Put the host machine's IP into the authorised_keys file on the VM
-[ -r /vagrant/id_rsa.pub ] && mkdir -p $HOME/.ssh && cat /vagrant/id_rsa.pub >> $HOME/.ssh/authorized_keys
+if [ -r /vagrant/id_rsa.pub ]; then
+        mkdir -p $HOME/.ssh && cat /vagrant/id_rsa.pub >> $HOME/.ssh/authorized_keys
+fi
 SCRIPT
 
 # 2 = version of configuration file for Vagrant 1.1+ leading up to 2.0.x

--- a/ansible/Vagrantfile.Ubuntu1804
+++ b/ansible/Vagrantfile.Ubuntu1804
@@ -28,7 +28,9 @@ echo "--------------------------------------------------------------------------
 # Get IPs of the VM, and output to shared folder
 ifconfig | grep "inet" | awk '{print $2}' | sed 's/addr://'  >> /vagrant/playbooks/AdoptOpenJDK_Unix_Playbook/hosts.tmp
 # Put the host machine's IP into the authorised_keys file on the VM
-[ -r /vagrant/id_rsa.pub ] && mkdir -p $HOME/.ssh && cat /vagrant/id_rsa.pub >> $HOME/.ssh/authorized_keys
+if [ -r /vagrant/id_rsa.pub ]; then
+        mkdir -p $HOME/.ssh && cat /vagrant/id_rsa.pub >> $HOME/.ssh/authorized_keys
+fi
 SCRIPT
 
 # 2 = version of configuration file for Vagrant 1.1+ leading up to 2.0.x


### PR DESCRIPTION
Stops Vagrantfiles from showing: 
```
The SSH command responded with a non-zero exit status. Vagrant
assumes that this means the command failed. The output for this command
should be in the log above. Please read the output to determine what
went wrong.
```
At the end of `vagrant up` if no `id_rsa.pub` file is found.