### PR TITLE
UnixPB: remove sudo from GIT_SOURCE role

### DIFF
--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/GIT_Source/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/GIT_Source/tasks/main.yml
@@ -60,7 +60,7 @@
     - skip_ansible_lint
 
 - name: Compile and install git from source on RHEL/CentOS6
-  shell: cd /tmp/git-2.15.0 && ./configure --with-curl=/usr/local/curl-7.61.1 --prefix=/usr/local --without-tcltk && make clean && make -j {{ ansible_processor_vcpus }} && sudo make install
+  shell: cd /tmp/git-2.15.0 && ./configure --with-curl=/usr/local/curl-7.61.1 --prefix=/usr/local --without-tcltk && make clean && make -j {{ ansible_processor_vcpus }} && make install
   become: yes
   when:
     - (git_installed.rc != 0 ) or (git_installed.rc == 0 and git_version.stdout is version_compare('2.15', operator='lt') )
@@ -69,7 +69,7 @@
   tags: git_source
 
 - name: Compile and install git from source on everything else
-  shell: cd /tmp/git-2.15.0 && ./configure --prefix=/usr/local --without-tcltk && make clean && make -j {{ ansible_processor_vcpus }} && sudo make install
+  shell: cd /tmp/git-2.15.0 && ./configure --prefix=/usr/local --without-tcltk && make clean && make -j {{ ansible_processor_vcpus }} && make install
   become: yes
   when:
     - (git_installed.rc != 0 ) or (git_installed.rc == 0 and git_version.stdout is version_compare('2.15', operator='lt') )
@@ -79,7 +79,7 @@
   tags: git_source
 
 - name: Compile and install git from source on s390x
-  shell: cd /tmp/git-2.15.0 && ./configure --prefix=/usr/local --without-tcltk && make -j {{ ansible_processor_cores }} && sudo make install
+  shell: cd /tmp/git-2.15.0 && ./configure --prefix=/usr/local --without-tcltk && make -j {{ ansible_processor_cores }} && make install
   become: yes
   when:
     - (git_installed.rc != 0 ) or (git_installed.rc == 0 and git_version.stdout is version_compare('2.15', operator='lt') )


### PR DESCRIPTION
Noticed whilst fixing the playbooks for SLES15 SP1, that the `GIT_SOURCE` role has tasks that use `sudo`. The SLES15 SP1 environment I was running didn't have `sudo` installed, and so the `./configure and make` task failed. However, `sudo` isn't required to be used as `become: yes` is used. 

VagrantPlaybookCheck Run: https://ci.adoptopenjdk.net/job/VagrantPlaybookCheck/365/