### PR TITLE
Build protobuf with gcc 7.5 and remove 7.3/7.4 locally installed options

### DIFF
--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Protobuf/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Protobuf/tasks/main.yml
@@ -31,25 +31,14 @@
   when: gcc7.stat.exists == True
   tags: protobuf
 
-- name: Checking for gcc-7.3 binary installation
-  stat: path=/usr/local/gcc/bin/gcc-7.3
+- name: Checking for gcc-7.5 binary installation
+  stat: path=/usr/local/gcc/bin/gcc-7.5
   register: gcc7
   tags: protobuf
-- name: Setting CC to gcc-7.3 binary found
+- name: Setting CC to gcc-7.5 binary found
   set_fact:
-    CC: "/usr/local/gcc/bin/gcc-7.3"
-    CXX: "/usr/local/gcc/bin/g++-7.3"
-  when: gcc7.stat.exists == True
-  tags: protobuf
-
-- name: Checking for gcc-7.4 binary installation
-  stat: path=/usr/local/gcc/bin/gcc-7.4
-  register: gcc7
-  tags: protobuf
-- name: Setting CC to gcc-7.4 binary found
-  set_fact:
-    CC: "/usr/local/gcc/bin/gcc-7.4"
-    CXX: "/usr/local/gcc/bin/g++-7.4"
+    CC: "/usr/local/gcc/bin/gcc-7.5"
+    CXX: "/usr/local/gcc/bin/g++-7.5"
   when: gcc7.stat.exists == True
   tags: protobuf
 


### PR DESCRIPTION
Latest playbooks only install GCC 7.5 into /usr/local/gcc (from https://github.com/AdoptOpenJDK/openjdk-build/issues/1508) so this removes 7.4 and 7.3 options from the list of things to search for.