### PR TITLE
pbTests: Change buildJDK to build from other URLs

### DIFF
--- a/ansible/pbTestScripts/buildJDK.sh
+++ b/ansible/pbTestScripts/buildJDK.sh
@@ -1,6 +1,63 @@
 #!/bin/bash
 set -eu
 
+processArgs() {
+	while [[ $# -gt 0 ]] && [[ ."$1" = .-* ]] ; do
+		local opt="$1";
+		shift;
+		case "$opt" in
+			"--version" | "-v" )
+				JAVA_TO_BUILD="$1"; shift;;
+			"--URL" | "-u" )
+				GIT_URL="$1"; shift;;
+			"--openj9" | "-j9" )
+				VARIANT=openj9;;
+			"--clean-workspace" | "-c" )
+				CLEAN_WORKSPACE=true;;
+			"--help" | "-h" )
+				usage; exit 0;;
+			*) echo >&2 "Invalid option: ${opt}"; echo "This option was unrecognised."; usage; exit 1;;
+		esac
+	done
+
+	checkJDKVersion $JAVA_TO_BUILD
+	if [ -z "${WORKSPACE:-}" ]; then
+        	echo "WORKSPACE not found, setting it as environment variable 'HOME'"
+        	WORKSPACE=$HOME
+	fi
+	if [ $CLEAN_WORKSPACE == true ]; then
+		echo "Cleaning workspace"
+		rm -rf $WORKSPACE/openjdk-build
+	fi
+}
+
+usage() {
+	echo "Usage: ./buildJDK.sh <options>
+	
+	Options:
+		--version | -v		Specify the JDK version to build
+		--URL | -u		Specify the github URL to clone openjdk-build from
+		--openj9 | -j9		Builds openJ9, instead of hotspot
+		--clean-workspace | -c 	Removes old openjdk-build folder before cloning
+		--help | -h		Shows this message
+		
+	If not specified, JDK8-HS will be built with the standard openjdk-build repo"
+	echo
+	showJDKVersions
+}
+
+showJDKVersions() {
+	echo "Currently supported JDK versions: 
+		- JDK8
+		- JDK9
+		- JDK10
+		- JDK11
+		- JDK12
+		- JDK13
+		- JDK14"
+	echo
+}
+
 checkJDKVersion() {
         local jdk=$1
         case "$jdk" in
@@ -19,30 +76,43 @@ checkJDKVersion() {
                 "jdk14u" | "jdk14" | "14" | "14u" )
                         JAVA_TO_BUILD="jdk14u";;
                 *)
-                        echo "Not a valid JDK Version" ; exit 1;;
+                        echo "Not a valid JDK Version" ; showJDKVersions; exit 1;;
         esac
 }
 
-# Argument parsing
+cloneRepo() {
+	local branch=""
+	IFS='/' read -r -a urlArray <<< "$GIT_URL"
+	if [ -d $WORKSPACE/openjdk-build ]; then
+		echo "Found existing openjdk-build folder"
+		cd $WORKSPACE/openjdk-build && git pull
+	elif [ ${urlArray[@]: -2:1} == 'tree' ]; then
+		GIT_URL=""
+		echo "Branch detected"
+		branch=${urlArray[@]: -1:1}
+		unset 'urlArray[${#urlArray[@]}-1]'
+		unset 'urlArray[${#urlArray[@]}-1]'
+		for urlPart in "${urlArray[@]}"
+		do
+			GIT_URL="$GIT_URL$urlPart/"
+		done
+		git clone -b $branch $GIT_URL $WORKSPACE/openjdk-build
+	else
+		echo "No branch detected"
+		git clone $GIT_URL $WORKSPACE/openjdk-build
+	fi
+}
+
+# Default values
 export JAVA_TO_BUILD=jdk8u
-if [[ $# == 0 ]]; then
-        echo "No arguments input, defaulting to JDK8"
-elif [[ $# == 1 ]]; then
-	checkJDKVersion $1
-else
-        echo "Too many arguments"
-        exit 1;
-fi
-
 export PATH=/usr/local/bin/:$PATH
-if [ -z "${WORKSPACE:-}" ]; then
-	echo "WORKSPACE not found, setting it as environment variable 'HOME'"
-	WORKSPACE=$HOME
-fi
-
 export TARGET_OS=linux
-export VARIANT=openj9
+export VARIANT=hotspot
 export ARCHITECTURE=x64
+GIT_URL="https://github.com/adoptopenjdk/openjdk-build"
+CLEAN_WORKSPACE=false
+
+processArgs $*
 
 # Differences in openJDK7 name between OSs. Search for CentOS one
 export JDK7_BOOT_DIR=$(find /usr/lib/jvm/ -name java-1.7.0-openjdk.x86_64)
@@ -76,13 +146,10 @@ echo "DEBUG:
         VARIANT=$VARIANT
         JDK7_BOOT_DIR=$JDK7_BOOT_DIR
         JAVA_HOME=$JAVA_HOME
-        WORKSPACE=$WORKSPACE"
+        WORKSPACE=$WORKSPACE
+	GIT_URL=$GIT_URL"
 
-if [[ ! -d "$WORKSPACE/openjdk-build" && "$TARGET_OS" == "FreeBSD" ]]; then
-  git clone -b freebsd https://github.com/gdams/openjdk-build $WORKSPACE/openjdk-build
-elif [[ ! -d "$WORKSPACE/openjdk-build" ]]; then
-  git clone https://github.com/adoptopenjdk/openjdk-build $WORKSPACE/openjdk-build
-fi
+cloneRepo 
 
 cd $WORKSPACE/openjdk-build
 build-farm/make-adopt-build-farm.sh

--- a/ansible/pbTestScripts/buildJDK.sh
+++ b/ansible/pbTestScripts/buildJDK.sh
@@ -10,8 +10,8 @@ processArgs() {
 				JAVA_TO_BUILD="$1"; shift;;
 			"--URL" | "-u" )
 				GIT_URL="$1"; shift;;
-			"--openj9" | "-j9" )
-				VARIANT=openj9;;
+			"--hotspot" | "-hs" )
+				VARIANT=hotspot;;
 			"--clean-workspace" | "-c" )
 				CLEAN_WORKSPACE=true;;
 			"--help" | "-h" )
@@ -41,7 +41,7 @@ usage() {
 		--clean-workspace | -c 	Removes old openjdk-build folder before cloning
 		--help | -h		Shows this message
 		
-	If not specified, JDK8-HS will be built with the standard openjdk-build repo"
+	If not specified, JDK8-J9 will be built with the standard openjdk-build repo"
 	echo
 	showJDKVersions
 }
@@ -107,7 +107,7 @@ cloneRepo() {
 export JAVA_TO_BUILD=jdk8u
 export PATH=/usr/local/bin/:$PATH
 export TARGET_OS=linux
-export VARIANT=hotspot
+export VARIANT=openj9
 export ARCHITECTURE=x64
 GIT_URL="https://github.com/adoptopenjdk/openjdk-build"
 CLEAN_WORKSPACE=false
@@ -147,7 +147,7 @@ echo "DEBUG:
         JDK7_BOOT_DIR=$JDK7_BOOT_DIR
         JAVA_HOME=$JAVA_HOME
         WORKSPACE=$WORKSPACE
-	GIT_URL=$GIT_URL"
+        GIT_URL=$GIT_URL"
 
 cloneRepo 
 

--- a/ansible/pbTestScripts/buildJDK.sh
+++ b/ansible/pbTestScripts/buildJDK.sh
@@ -1,12 +1,34 @@
 #!/bin/bash
 set -eu
 
+checkJDKVersion() {
+        local jdk=$1
+        case "$jdk" in
+                "jdk8u" | "jdk8" | "8" | "8u" )
+                        JAVA_TO_BUILD="jdk8u";;
+                "jdk9u" | "jdk9" | "9" | "9u" )
+                        JAVA_TO_BUILD="jdk9u";;
+                "jdk10u" | "jdk10" | "10" | "10u" )
+                        JAVA_TO_BUILD="jdk10u";;
+                "jdk11u" | "jdk11" | "11" | "11u" )
+                        JAVA_TO_BUILD="jdk11u";;
+                "jdk12u" | "jdk12" | "12" | "12u" )
+                        JAVA_TO_BUILD="jdk12u";;
+                "jdk13u" | "jdk13" | "13" | "13u" )
+                        JAVA_TO_BUILD="jdk13u";;
+                "jdk14u" | "jdk14" | "14" | "14u" )
+                        JAVA_TO_BUILD="jdk14u";;
+                *)
+                        echo "Not a valid JDK Version" ; exit 1;;
+        esac
+}
+
 # Argument parsing
+export JAVA_TO_BUILD=jdk8u
 if [[ $# == 0 ]]; then
         echo "No arguments input, defaulting to JDK8"
-        export JAVA_TO_BUILD=jdk8u
 elif [[ $# == 1 ]]; then
-        export JAVA_TO_BUILD=$1
+	checkJDKVersion $1
 else
         echo "Too many arguments"
         exit 1;


### PR DESCRIPTION
Requested by @sxa555 

Update `buildJDK.sh` to be able to build JDKs other than JDK8-J9, as well as give it the option to use other branches of the openjdk-build repository. 