### PR TITLE
UnixPB: Remove pulseaudio from Common/vars/SLES.yml

### DIFF
--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/vars/SLES.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/vars/SLES.yml
@@ -70,7 +70,6 @@ Test_Tool_Packages:
   - gcc
   - gcc-c++
   - perl
-  - pulseaudio
   - xorg-x11
   - xorg-x11-server
   - xorg-x11-server-extra


### PR DESCRIPTION
fixes: #1141 
ref: #1140 , #1147 

Should be the last thing to allow SLES15-SP1 to work with our playbooks. SLES15-SP1 specific repos don't have `pulseaudio` like SP0 does. However, this has been determined to not be needed anyway: https://adoptopenjdk.slack.com/archives/C5219G28G/p1582041329095100?thread_ts=1582035001.094600&cid=C5219G28G
