### PR TITLE
unixPB: Remove checksum for gcc_7 task

### DIFF
--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/gcc_7/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/gcc_7/tasks/main.yml
@@ -19,7 +19,6 @@
     dest: '/tmp/ansible-adoptopenjdk-gcc-7.tar.xz'
     force: no
     mode: 0644
-    checksum: sha256:db3dcf4867acbf0cdcd9cb3a97f2e47d72d1a2a59e9e60359f267742f5fa650a
   when:
     - ansible_distribution == "RedHat" or ansible_distribution == "CentOS" or ansible_distribution == "openSUSE"
     - ansible_architecture != "CentOS" and ansible_architecture != "x86-64"


### PR DESCRIPTION
Ref: #1158 

Initially I was going to change the checksum to be correct now that we've changed what we're downloading, however now the role has been changed to only have one downloading task for all of the architectures, we can't put only one checksum on the task. Therefore, removing it.