### PR TITLE
winPB: Change checksum for MSVS_2017

### DIFF
--- a/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/roles/MSVS_2017/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/roles/MSVS_2017/tasks/main.yml
@@ -14,7 +14,7 @@
     url: 'https://aka.ms/vs/15/release/vs_community.exe'
     dest: 'C:\TEMP\vs_community.exe'
     force: no
-    checksum: 14e078f4da89990e3c05775283adb8802d937f69a08ac8d0b6c683dc3ab6a0e8
+    checksum: 91d7b8d8ba556b1e8723ca67a0f1e2e4a8274f7dfccbeae567e78b22f0db3f6d
     checksum_algorithm: sha256
   when: (vs2017_installed.stat.exists == false)
   tags: MSVS_2017


### PR DESCRIPTION
ref: #1149  

To fix the problem seen here:
https://ci.adoptopenjdk.net/job/VagrantPlaybookCheck/OS=Win2012,label=vagrant/369/console

The checksum must've been changed around the same time as the cygwin one.