### PR TITLE
Playbook to configure machines for TRSS

### DIFF
--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/trss.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/trss.yml
@@ -20,9 +20,30 @@
           apt: upgrade=safe update_cache=yes
           tags: patch_update
 
-        - name: Add Node.js v12.x
-          raw: "curl -sL https://deb.nodesource.com/setup_12.x | sudo -E bash -"
-          tags: dependencies
+        - name: Download Nodev12.16.1 tarball
+          get_url:
+            url: https://nodejs.org/dist/v12.16.1/node-v12.16.1-linux-x64.tar.xz
+            dest: /tmp/node-v12.16.1-linux-x64.tar.xz
+            mode: 0440
+          tags: node_install
+        
+        - name: Extract Node tarball
+          unarchive:
+            src: /tmp/node-v12.16.1-linux-x64.tar.xz
+            dest: /usr/local/lib/
+            copy: False
+          tags: node_install
+
+        - name: Create symlinks for node, npm and npx from node install directory to /usr/local/bin/
+          file:
+            src: /usr/local/lib/node-v12.16.1-linux-x64/bin/{{ item }}
+            dest: /usr/local/bin/{{ item }}
+            state: link
+          with_items:
+            - node
+            - npm
+            - npx
+          tags: node_install
 
         - name: Import MongoDB 4.2 key
           raw: "wget -qO - https://www.mongodb.org/static/pgp/server-4.2.asc | sudo apt-key add -"
@@ -38,7 +59,6 @@
             update_cache: yes
           with_items:
             - git
-            - nodejs
             - mongodb-org
             - make
             - build-essential
@@ -101,7 +121,6 @@
             regex: 'root /var/www/html;'
             line: 'root /home/{{ Jenkins_Username }}/openjdk-test-tools/test-result-summary-client/build/;'
             state: present
-          when: nginx_installed.rc == 0
           tags: nginx_conf
 
         - name: Add server name trss.adoptopenjdk.net /etc/nginx/sites-enabled/default
@@ -110,7 +129,6 @@
             regex: 'server_name _;'
             line: 'server_name trss.adoptopenjdk.net;'
             state: present
-          when: nginx_installed.rc == 0
           tags: nginx_conf
 
         - name: Add Location /api/ to /etc/nginx/sites-enabled/default
@@ -119,7 +137,6 @@
             insertafter: 'server_name trss.adoptopenjdk.net;'
             line: 'location /api/ { proxy_pass http://localhost:3001; proxy_http_version 1.1; }'
             state: present
-          when: nginx_installed.rc == 0
           tags: nginx_conf
 
         - name: Add file extension rule to /etc/nginx/sites-enabled/default
@@ -128,23 +145,12 @@
             insertafter: 'server_name trss.adoptopenjdk.net;'
             line: 'location ~ ^.+\..+$ { try_files $uri =404; }'
             state: present
-          when: nginx_installed.rc == 0
-          tags: nginx_conf
-
-        - name: Add without file extension rule to /etc/nginx/sites-enabled/default
-          lineinfile:
-            path: /etc/nginx/sites-enabled/default
-            regexp: try_files \$uri \$uri/ =404;
-            line: 'try_files $uri $uri/ /index.html;'
-            state: present
-          when: nginx_installed.rc == 0
           tags: nginx_conf
 
         - name: Restart nginx service
           service:
             name: nginx
             state: restarted
-          when: nginx_installed.rc == 0
           tags: nginx_conf
 
         - name: Add cron job to check for updates

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/trss.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/trss.yml
@@ -40,6 +40,8 @@
             - git
             - nodejs
             - mongodb-org
+            - nginx
+            - make
           tags:
             - dependencies
             - skip_ansible_lint

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/trss.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/trss.yml
@@ -1,0 +1,91 @@
+---
+############################################
+# AdoptOpenJDK Ansible TRSS Playbook       #
+# Currently supports Ubuntu 18 on x64 only #
+############################################
+- hosts: all
+  user: root
+  become: yes
+  tasks:
+    - block:
+        - name: Load AdoptOpenJDKs variable file
+          include_vars: group_vars/all/adoptopenjdk_variables.yml
+
+        - name: Set hostname to trss.adoptopenjdk.net
+          hostname:
+            name: trss.adoptopenjdk.net
+          tags: hostname
+
+        - name: OS update -- apt-get upgrade
+          apt: upgrade=safe update_cache=yes
+          tags: patch_update
+
+        - name: Add Node.js v8.x
+          raw: "curl -sL https://deb.nodesource.com/setup_8.x | sudo -E bash -"
+          tags: dependencies
+
+        - name: Import MongoDB key
+          raw: "wget -qO - https://www.mongodb.org/static/pgp/server-4.2.asc | sudo apt-key add -"
+          tags: mongodb
+
+        - name: Create list file for MongoDB
+          raw: "echo \"deb [ arch=amd64 ] https://repo.mongodb.org/apt/ubuntu bionic/mongodb-org/4.2 multiverse\" | sudo tee /etc/apt/sources.list.d/mongodb-org-4.2.list"
+          tags: mongodb
+
+        - name: Install API prerequisistes
+          apt:
+            name: "{{ item }}"
+            update_cache: yes
+          with_items:
+            - git
+            - nodejs
+            - mongodb-org
+          tags:
+            - dependencies
+            - skip_ansible_lint
+
+        - name: Start mongoDB
+          systemd:
+            name: mongod
+            state: started
+          tags: mongodb
+
+        - name: Create Jenkins user
+          action: user name={{ Jenkins_Username }} state=present shell=/bin/bash
+          ignore_errors: yes
+          tags: jenkins_user
+
+        - name: Install NPM packages globally
+          npm:
+            name: "{{ item }}"
+            global: yes
+            state: present
+          with_items:
+            - forever-service
+            - yarn
+          tags: forever
+
+        - name: Git Clone openjdk-test-tools.git
+          git:
+            repo: 'https://github.com/AdoptOpenJDK/openjdk-test-tools.git'
+            dest: "/home/{{ Jenkins_Username }}/openjdk-test-tools"
+            update: yes
+            force: yes
+          tags:
+            # TODO: Git checkouts must contain explicit version
+            - skip_ansible_lint
+
+        - name: Change owner permissions
+          file:
+            path: /home/{{ Jenkins_Username }}/openjdk-test-tools
+            owner: "{{ Jenkins_Username }}"
+            group: "{{ Jenkins_Username }}"
+
+        - name: Add cron job to check for updates
+          cron: name="Check for Updates every Sunday at 5am"
+            weekday="6"
+            minute="0"
+            hour="5"
+            user=root
+            job="/usr/bin/apt-get update && /usr/bin/apt-get -y upgrade"
+            state=present

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/trss.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/trss.yml
@@ -101,7 +101,7 @@
             regex: 'root /var/www/html;'
             line: 'root /home/{{ Jenkins_Username }}/openjdk-test-tools/test-result-summary-client/build/;'
             state: present
-          when: nginx_installed.rc == 0
+          # when: nginx_installed.rc == 0
           tags: nginx_conf
 
         - name: Add server name trss.adoptopenjdk.net /etc/nginx/sites-enabled/default
@@ -110,23 +110,41 @@
             regex: 'server_name _;'
             line: 'server_name trss.adoptopenjdk.net;'
             state: present
-          when: nginx_installed.rc == 0
+          # when: nginx_installed.rc == 0
           tags: nginx_conf
 
-        - name: Add Location line to /etc/nginx/sites-enabled/default
+        - name: Add Location /api/ to /etc/nginx/sites-enabled/default
           lineinfile:
             path: /etc/nginx/sites-enabled/default
             insertafter: 'server_name trss.adoptopenjdk.net;'
             line: 'location /api/ { proxy_pass http://localhost:3001; proxy_http_version 1.1; }'
             state: present
-          when: nginx_installed.rc == 0
+          # when: nginx_installed.rc == 0
+          tags: nginx_conf
+
+        - name: Add file extension rule to /etc/nginx/sites-enabled/default
+          lineinfile:
+            path: /etc/nginx/sites-enabled/default
+            insertafter: 'server_name trss.adoptopenjdk.net;'
+            line: 'location ~ ^.+\..+$ { try_files $uri =404; }'
+            state: present
+          # when: nginx_installed.rc == 0
+          tags: nginx_conf
+
+        - name: Add without file extension rule to /etc/nginx/sites-enabled/default
+          lineinfile:
+            path: /etc/nginx/sites-enabled/default
+            regexp: try_files \$uri \$uri/ =404;
+            line: 'try_files $uri $uri/ /index.html;'
+            state: present
+          # when: nginx_installed.rc == 0
           tags: nginx_conf
 
         - name: Restart nginx service
           service:
             name: nginx
             state: restarted
-          when: nginx_installed.rc == 0
+          # when: nginx_installed.rc == 0
           tags: nginx_conf
 
         - name: Add cron job to check for updates

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/trss.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/trss.yml
@@ -101,7 +101,7 @@
             regex: 'root /var/www/html;'
             line: 'root /home/{{ Jenkins_Username }}/openjdk-test-tools/test-result-summary-client/build/;'
             state: present
-          # when: nginx_installed.rc == 0
+          when: nginx_installed.rc == 0
           tags: nginx_conf
 
         - name: Add server name trss.adoptopenjdk.net /etc/nginx/sites-enabled/default
@@ -110,7 +110,7 @@
             regex: 'server_name _;'
             line: 'server_name trss.adoptopenjdk.net;'
             state: present
-          # when: nginx_installed.rc == 0
+          when: nginx_installed.rc == 0
           tags: nginx_conf
 
         - name: Add Location /api/ to /etc/nginx/sites-enabled/default
@@ -119,7 +119,7 @@
             insertafter: 'server_name trss.adoptopenjdk.net;'
             line: 'location /api/ { proxy_pass http://localhost:3001; proxy_http_version 1.1; }'
             state: present
-          # when: nginx_installed.rc == 0
+          when: nginx_installed.rc == 0
           tags: nginx_conf
 
         - name: Add file extension rule to /etc/nginx/sites-enabled/default
@@ -128,7 +128,7 @@
             insertafter: 'server_name trss.adoptopenjdk.net;'
             line: 'location ~ ^.+\..+$ { try_files $uri =404; }'
             state: present
-          # when: nginx_installed.rc == 0
+          when: nginx_installed.rc == 0
           tags: nginx_conf
 
         - name: Add without file extension rule to /etc/nginx/sites-enabled/default
@@ -137,14 +137,14 @@
             regexp: try_files \$uri \$uri/ =404;
             line: 'try_files $uri $uri/ /index.html;'
             state: present
-          # when: nginx_installed.rc == 0
+          when: nginx_installed.rc == 0
           tags: nginx_conf
 
         - name: Restart nginx service
           service:
             name: nginx
             state: restarted
-          # when: nginx_installed.rc == 0
+          when: nginx_installed.rc == 0
           tags: nginx_conf
 
         - name: Add cron job to check for updates

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/trss.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/trss.yml
@@ -20,11 +20,11 @@
           apt: upgrade=safe update_cache=yes
           tags: patch_update
 
-        - name: Add Node.js v8.x
-          raw: "curl -sL https://deb.nodesource.com/setup_8.x | sudo -E bash -"
+        - name: Add Node.js v12.x
+          raw: "curl -sL https://deb.nodesource.com/setup_12.x | sudo -E bash -"
           tags: dependencies
 
-        - name: Import MongoDB key
+        - name: Import MongoDB 4.2 key
           raw: "wget -qO - https://www.mongodb.org/static/pgp/server-4.2.asc | sudo apt-key add -"
           tags: mongodb
 
@@ -40,8 +40,9 @@
             - git
             - nodejs
             - mongodb-org
-            - nginx
             - make
+            - build-essential
+            - g++
           tags:
             - dependencies
             - skip_ansible_lint
@@ -63,6 +64,7 @@
             global: yes
             state: present
           with_items:
+            - forever
             - forever-service
             - yarn
           tags: forever
@@ -73,9 +75,6 @@
             dest: "/home/{{ Jenkins_Username }}/openjdk-test-tools"
             update: yes
             force: yes
-          tags:
-            # TODO: Git checkouts must contain explicit version
-            - skip_ansible_lint
 
         - name: Change owner permissions
           file:
@@ -83,6 +82,53 @@
             owner: "{{ Jenkins_Username }}"
             group: "{{ Jenkins_Username }}"
 
+        - name: npm ci && npm run build of test-result-summary-client
+          shell: cd /home/{{ Jenkins_Username }}/openjdk-test-tools/test-result-summary-client/ && npm ci && npm run build
+
+        - name: npm ci of TestResultSummaryService
+          shell: cd /home/{{ Jenkins_Username }}/openjdk-test-tools/TestResultSummaryService/ && npm ci
+
+        - name: Install nginx seperately
+          apt:
+            name: nginx
+            state: present
+          tags: nginx_conf
+          register: nginx_installed
+
+        - name: Add app root directorty to /etc/nginx/sites-enabled/default
+          lineinfile:
+            path: /etc/nginx/sites-enabled/default
+            regex: 'root /var/www/html;'
+            line: 'root /home/{{ Jenkins_Username }}/openjdk-test-tools/test-result-summary-client/build/;'
+            state: present
+          when: nginx_installed.rc == 0
+          tags: nginx_conf
+
+        - name: Add server name trss.adoptopenjdk.net /etc/nginx/sites-enabled/default
+          lineinfile:
+            path: /etc/nginx/sites-enabled/default
+            regex: 'server_name _;'
+            line: 'server_name trss.adoptopenjdk.net;'
+            state: present
+          when: nginx_installed.rc == 0
+          tags: nginx_conf
+
+        - name: Add Location line to /etc/nginx/sites-enabled/default
+          lineinfile:
+            path: /etc/nginx/sites-enabled/default
+            insertafter: 'server_name trss.adoptopenjdk.net;'
+            line: 'location /api/ { proxy_pass http://localhost:3001; proxy_http_version 1.1; }'
+            state: present
+          when: nginx_installed.rc == 0
+          tags: nginx_conf
+
+        - name: Restart nginx service
+          service:
+            name: nginx
+            state: restarted
+          when: nginx_installed.rc == 0
+          tags: nginx_conf
+          
         - name: Add cron job to check for updates
           cron: name="Check for Updates every Sunday at 5am"
             weekday="6"

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/trss.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/trss.yml
@@ -128,7 +128,7 @@
             state: restarted
           when: nginx_installed.rc == 0
           tags: nginx_conf
-          
+
         - name: Add cron job to check for updates
           cron: name="Check for Updates every Sunday at 5am"
             weekday="6"

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/trss.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/trss.yml
@@ -95,7 +95,7 @@
           tags: nginx_conf
           register: nginx_installed
 
-        - name: Add app root directorty to /etc/nginx/sites-enabled/default
+        - name: Add app root directory to /etc/nginx/sites-enabled/default
           lineinfile:
             path: /etc/nginx/sites-enabled/default
             regex: 'root /var/www/html;'

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/trss.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/trss.yml
@@ -26,7 +26,7 @@
             dest: /tmp/node-v12.16.1-linux-x64.tar.xz
             mode: 0440
           tags: node_install
-        
+
         - name: Extract Node tarball
           unarchive:
             src: /tmp/node-v12.16.1-linux-x64.tar.xz


### PR DESCRIPTION
The `AdoptOpenJDK_Unix_Playbook/trss.yml` contains **most** of the manual steps to configure machines to run the TRSS service. 
The playbook currently only supports Ubuntu 18 on x86_64.
The manual steps that were omitted from the playbook are:

- `forever-service install TRSSFrontend -e "NODE_ENV=production" -f " --workingDir /home/jenkins/openjdk-test-tools/TestResultSummaryService" --script /home/jenkins/openjdk-test-tools/TestResultSummaryService/frontend.js  -o " --configFile=path-to-trssConf.json"`
- `forever-service install TRSSBackend -e "NODE_ENV=production" -f " --workingDir /home/jenkins/openjdk-test-tools/TestResultSummaryService" --script /home/jenkins/openjdk-test-tools/TestResultSummaryService/backend.js  -o " --configFile=/dev/mongodb/credentials/path-to-trssConf.json"`
- Credentials for the database
 
The forever commands were omitted because they require the trssConf.json file to exist, which will contain the database username and password. I thought this file, as well as the creation of those database credentials, could be best done manually.

The installation of `nginx` can be a bit finicky. Though this issue didnt appear on the new TRSS machine, when testing this playbook on a fyre machine the nginx service tries to start automatically upon installation, that is, it attempts to listen on port 80. If this port is in use, or for any other reason, this will cause an error and the playbook will crash.

Thoughts?