### PR TITLE
pbTests: Added option to specify openjdk-build repo

### DIFF
--- a/ansible/pbTestScripts/buildJDK.sh
+++ b/ansible/pbTestScripts/buildJDK.sh
@@ -142,7 +142,7 @@ if [[ $(uname) == "FreeBSD" ]]; then
         export TARGET_OS=FreeBSD
         export VARIANT=hotspot
         export JAVA_TO_BUILD=jdk11u
-        export JDK_BOOT_DIR=/usr/local/openjdk10
+        export JDK_BOOT_DIR=/usr/local/openjdk11
         export JAVA_HOME=/usr/local/openjdk8
 fi
 

--- a/ansible/pbTestScripts/vagrantPlaybookCheck.sh
+++ b/ansible/pbTestScripts/vagrantPlaybookCheck.sh
@@ -4,6 +4,7 @@ set -eu
 branchName=''
 folderName=''
 gitURL=''
+buildURL=''
 vagrantOS=''
 retainVM=false
 testNativeBuild=false
@@ -40,6 +41,8 @@ processArgs()
 				newVagrantFiles=true;;
 			"--skip-more" | "-sm" )
 				skipFullSetup=",nvidia_cuda_toolkit,MSVS_2010,MSVS_2017";;
+			"--build-repo" | "-br" )
+				buildURL="--URL $1"; shift;;
 			"--help" | "-h" )
 				usage; exit 0;;
 			*) echo >&2 "Invalid option: ${opt}"; echo "This option was unrecognised."; usage; exit 1;;
@@ -203,7 +206,7 @@ startVMPlaybook()
 	local pb_failed=$?
 	cd $WORKSPACE/adoptopenjdkPBTests/$folderName-$branchName/ansible
 	if [[ "$testNativeBuild" = true && "$pb_failed" == 0 ]]; then
-		ansible all -i playbooks/AdoptOpenJDK_Unix_Playbook/hosts.unx -u vagrant -m raw -a "cd /vagrant/pbTestScripts && ./buildJDK.sh"
+		ansible all -i playbooks/AdoptOpenJDK_Unix_Playbook/hosts.unx -u vagrant -m raw -a "cd /vagrant/pbTestScripts && ./buildJDK.sh $buildURL"
 		echo The build finished at : `date +%T`
 		if [[ "$runTest" = true ]]; then
 	        	ansible all -i playbooks/AdoptOpenJDK_Unix_Playbook/hosts.unx -u vagrant -m raw -a "cd /vagrant/pbTestScripts && ./testJDK.sh"

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/vars/FreeBSD.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/vars/FreeBSD.yml
@@ -26,6 +26,7 @@ Build_Tool_Packages:
   - libXtst
   - openjdk
   - openjdk8
+  - openjdk11
   - pkgconf
   - png
   - unzip


### PR DESCRIPTION
Ref: #1152 

Added the option to specify the build repo so these can be checked in the `VagrantPlaybookCheck` Jenkins job too. This will also allow the FreeBSD12 Vagrant VM to pull from @gdams 's fork of `openjdk-build` to build, in the job.

I've also added jdk11 to the `../Common/vars/FreeBSD.yml` list as this is required to build JDK11.