### PR TITLE
pbTests: Alter location of FreeBSD built JDK

### DIFF
--- a/ansible/pbTestScripts/testJDK.sh
+++ b/ansible/pbTestScripts/testJDK.sh
@@ -3,9 +3,13 @@
 export MAKE_COMMAND="make"
 if [[ $(uname) == "FreeBSD" ]]; then
 	export MAKE_COMMAND="gmake"
+	cp -r $HOME/openjdk-build/workspace/build/src/build/*/jdk $HOME
+	export TEST_JDK_HOME=$HOME/jdk
+else
+	mv $HOME/openjdk-build/workspace/build/src/build/*/images/jdk8* $HOME
+	export TEST_JDK_HOME=$(find $HOME -maxdepth 1 -type d -name "*jdk8u*"|grep -v ".*jre.*")
 fi
-mv $HOME/openjdk-build/workspace/build/src/build/*/images/jdk8* $HOME
-export TEST_JDK_HOME=$(find $HOME -maxdepth 1 -type d -name "*jdk8u*"|grep -v ".*jre.*")
+
 mkdir -p $HOME/testLocation
 [ ! -d $HOME/testLocation/openjdk-tests ] && git clone https://github.com/adoptopenjdk/openjdk-tests $HOME/testLocation/openjdk-tests
 $HOME/testLocation/openjdk-tests/get.sh -t $HOME/testLocation/openjdk-tests


### PR DESCRIPTION
ref: https://ci.adoptopenjdk.net/view/Tooling/job/VagrantPlaybookCheck/OS=FreeBSD12,label=vagrant/381/

FreeBSD (when building using @gdams openjdk-build/freebsd branch) will put it's built jdk in the same equivalent folders, but call it just `jdk`, therefore, alter in the case of testing FreeBSD's built JDK.