### PR TITLE
UnixPB: Arm specific adoptopenjdk_install task

### DIFF
--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/adoptopenjdk_install/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/adoptopenjdk_install/tasks/main.yml
@@ -66,7 +66,22 @@
     - ansible_os_family != "Darwin"
   tags: adoptopenjdk_install
 
-- name: Install latest release if one not already installed (Linux/NOT x64)
+- name: Install latest release if one not already installed (Linux/arm)
+  unarchive:
+    src: https://api.adoptopenjdk.net/v3/binary/latest/{{ jdk_version }}/ga/linux/arm/jdk/{{ bootjdk }}/normal/adoptopenjdk?project=jdk
+    dest: /usr/lib/jvm
+    remote_src: yes
+  retries: 3
+  delay: 5
+  register: adoptopenjdk_download
+  until: adoptopenjdk_download is not failed
+  when:
+    - adoptopenjdk_installed.rc != 0
+    - ansible_architecture == "armv7l"
+    - ansible_os_family != "Darwin"
+  tags: adoptopenjdk_install
+
+- name: Install latest release if one not already installed (Linux/Everything else)
   unarchive:
     src: https://api.adoptopenjdk.net/v3/binary/latest/{{ jdk_version }}/ga/linux/{{ ansible_architecture }}/jdk/{{ bootjdk }}/normal/adoptopenjdk?project=jdk
     dest: /usr/lib/jvm
@@ -78,6 +93,7 @@
   when:
     - adoptopenjdk_installed.rc != 0
     - ansible_architecture != "x86_64"
+    - ansible_architecture != "armv7l"
     - ansible_os_family != "Darwin"
   tags: adoptopenjdk_install
 

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/adoptopenjdk_install/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/adoptopenjdk_install/tasks/main.yml
@@ -23,6 +23,31 @@
     - ansible_os_family != "Darwin"
   tags: adoptopenjdk_install
 
+- name: Set api_architecture variable for x86_64
+  set_fact:
+    api_architecture: x64
+  when:
+    - ansible_os_family != "Darwin"
+    - ansible_architecture == "x86_64"
+
+- name: Set api_architecture variable for armv7l
+  set_fact:
+    api_architecture: arm
+  when:
+    - ansible_os_family != "Darwin"
+    - ansible_architecture == "armv7l"
+
+- name: Set api_architecture variable for everything else
+  set_fact:
+    api_architecture: "{{ ansible_architecture }}"
+  when:
+    - ansible_os_family != "Darwin"
+    - ansible_architecture != "armv7l" and
+      ansible_architecture != "x86_64"
+
+- debug:
+    var: api_architecture
+
 - name: Checking for /usr/lib/jvm
   stat: path=/usr/lib/jvm
   register: usr_lib_jvm_exists
@@ -51,9 +76,9 @@
     - adoptopenjdk_install
     - skip_ansible_lint
 
-- name: Install latest release if one not already installed (Linux/x64)
+- name: Install latest release if one not already installed
   unarchive:
-    src: https://api.adoptopenjdk.net/v3/binary/latest/{{ jdk_version }}/ga/linux/x64/jdk/{{ bootjdk }}/normal/adoptopenjdk?project=jdk
+    src: https://api.adoptopenjdk.net/v3/binary/latest/{{ jdk_version }}/ga/linux/{{ api_architecture }}/jdk/{{ bootjdk }}/normal/adoptopenjdk?project=jdk
     dest: /usr/lib/jvm
     remote_src: yes
   retries: 3
@@ -62,38 +87,6 @@
   until: adoptopenjdk_download is not failed
   when:
     - adoptopenjdk_installed.rc != 0
-    - ansible_architecture == "x86_64"
-    - ansible_os_family != "Darwin"
-  tags: adoptopenjdk_install
-
-- name: Install latest release if one not already installed (Linux/arm)
-  unarchive:
-    src: https://api.adoptopenjdk.net/v3/binary/latest/{{ jdk_version }}/ga/linux/arm/jdk/{{ bootjdk }}/normal/adoptopenjdk?project=jdk
-    dest: /usr/lib/jvm
-    remote_src: yes
-  retries: 3
-  delay: 5
-  register: adoptopenjdk_download
-  until: adoptopenjdk_download is not failed
-  when:
-    - adoptopenjdk_installed.rc != 0
-    - ansible_architecture == "armv7l"
-    - ansible_os_family != "Darwin"
-  tags: adoptopenjdk_install
-
-- name: Install latest release if one not already installed (Linux/Everything else)
-  unarchive:
-    src: https://api.adoptopenjdk.net/v3/binary/latest/{{ jdk_version }}/ga/linux/{{ ansible_architecture }}/jdk/{{ bootjdk }}/normal/adoptopenjdk?project=jdk
-    dest: /usr/lib/jvm
-    remote_src: yes
-  retries: 3
-  delay: 5
-  register: adoptopenjdk_download
-  until: adoptopenjdk_download is not failed
-  when:
-    - adoptopenjdk_installed.rc != 0
-    - ansible_architecture != "x86_64"
-    - ansible_architecture != "armv7l"
     - ansible_os_family != "Darwin"
   tags: adoptopenjdk_install
 


### PR DESCRIPTION
fixes: #697 

The issues listed on the #697  are no longer relevant to the current playbooks as the `adoptopenjdk9` role no longer exists, and we're not able to add the `openjdk-7-jdk` package as the `openjdk-r` repository doesn't have it available for `arm`, however we can build `jdk8` with `jdk8` so this isn't an issue.

 However, whilst running through the playbook to ensure it worked, the `adoptopenjdk_install` role doesn't work as the `ansible_architecture` variable is set as `armv7l`, not `arm` as APIv3 requires, so I've made an ARM specific role for it.