### PR TITLE
pbTests: Update buildJDKWin to specify which JDK to build

### DIFF
--- a/ansible/pbTestScripts/buildJDKWin.sh
+++ b/ansible/pbTestScripts/buildJDKWin.sh
@@ -1,15 +1,136 @@
 #!/bin/bash
 set -eu
+
+processArgs() {
+	while [[ $# -gt 0 ]] && [[ ."$1" = .-* ]] ; do
+		local opt="$1";
+		shift;
+		case "$opt" in
+			"--version" | "-v" )
+				JAVA_TO_BUILD="$1"; shift;;
+			"--URL" | "-u" )
+				GIT_URL="$1"; shift;;
+			"--hotspot" | "-hs" )
+				export VARIANT=hotspot;;
+			"--clean-workspace" | "-c" )
+				CLEAN_WORKSPACE=true;;
+			"--help" | "-h" )
+				usage; exit 0;;
+			*) echo >&2 "Invalid option: ${opt}"; echo "This option was unrecognised."; usage; exit 1;;
+		esac
+	done
+
+	checkJDKVersion $JAVA_TO_BUILD
+	if [ -z "${WORKSPACE:-}" ]; then
+        	echo "WORKSPACE not found, setting it as environment variable 'HOME'"
+        	WORKSPACE=$HOME
+	fi
+	if [ $CLEAN_WORKSPACE == true ]; then
+		echo "Cleaning workspace"
+		rm -rf $WORKSPACE/openjdk-build
+	fi
+}
+
+usage() {
+	echo "Usage: ./buildJDK.sh <options>
+
+	Options:
+		--version | -v		Specify the JDK version to build
+		--URL | -u		Specify the github URL to clone openjdk-build from
+		--openj9 | -j9		Builds openJ9, instead of hotspot
+		--clean-workspace | -c 	Removes old openjdk-build folder before cloning
+		--help | -h		Shows this message
+
+	If not specified, JDK8-J9 will be built with the standard openjdk-build repo"
+	echo
+	showJDKVersions
+}
+
+showJDKVersions() {
+	echo "Currently supported JDK versions:
+		- JDK8
+		- JDK9
+		- JDK10
+		- JDK11
+		- JDK12
+		- JDK13
+		- JDK14"
+	echo
+}
+
+checkJDKVersion() {
+        local jdk=$1
+        case "$jdk" in
+                "jdk8u" | "jdk8" | "8" | "8u" )
+                        JAVA_TO_BUILD="jdk8u";
+			JDK_BOOT_DIR=/cygdrive/c/openjdk/jdk7;;
+                "jdk9u" | "jdk9" | "9" | "9u" )
+                        JAVA_TO_BUILD="jdk9u";
+			JDK_BOOT_DIR=/cygdrive/c/openjdk/jdk-8;;
+                "jdk10u" | "jdk10" | "10" | "10u" )
+                        JAVA_TO_BUILD="jdk10u";
+			JDK_BOOT_DIR=/cygdrive/c/openjdk/jdk-10;;
+                "jdk11u" | "jdk11" | "11" | "11u" )
+                        JAVA_TO_BUILD="jdk11u";
+			JDK_BOOT_DIR=/cygdrive/c/openjdk/jdk-10;;
+                "jdk12u" | "jdk12" | "12" | "12u" )
+                        JAVA_TO_BUILD="jdk12u";
+			JDK_BOOT_DIR=/cygdrive/c/openjdk/jdk-12;;
+                "jdk13u" | "jdk13" | "13" | "13u" )
+                        JAVA_TO_BUILD="jdk13u";
+			JDK_BOOT_DIR=/cygdrive/c/openjdk/jdk-12;;
+                "jdk14u" | "jdk14" | "14" | "14u" )
+                        JAVA_TO_BUILD="jdk14";
+			JDK_BOOT_DIR=/cygdrive/c/openjdk/jdk-13;;
+                *)
+                        echo "Not a valid JDK Version" ; showJDKVersions; exit 1;;
+        esac
+}
+
+cloneRepo() {
+	local branch=""
+	IFS='/' read -r -a urlArray <<< "$GIT_URL"
+	if [ -d $WORKSPACE/openjdk-build ]; then
+		echo "Found existing openjdk-build folder"
+		cd $WORKSPACE/openjdk-build && git pull
+	elif [ ${urlArray[@]: -2:1} == 'tree' ]; then
+		GIT_URL=""
+		echo "Branch detected"
+		branch=${urlArray[@]: -1:1}
+		unset 'urlArray[${#urlArray[@]}-1]'
+		unset 'urlArray[${#urlArray[@]}-1]'
+		for urlPart in "${urlArray[@]}"
+		do
+			GIT_URL="$GIT_URL$urlPart/"
+		done
+		git clone -b $branch $GIT_URL $WORKSPACE/openjdk-build
+	else
+		echo "No branch detected"
+		git clone $GIT_URL $WORKSPACE/openjdk-build
+	fi
+}
+# Set defaults
+export JAVA_TO_BUILD=jdk8
+export VARIANT=openj9
+export PATH=/usr/bin/:$PATH
 export TARGET_OS=windows
 export ARCHITECTURE=x64
-export JAVA_TO_BUILD=jdk8
-export VARIANT=hotspot
-export JDK7_BOOT_DIR=/cygdrive/c/openjdk/jdk7
-export PATH=/usr/bin/:$PATH
-# Git clone openjdk-build if it's not currently there.
-cd C:/
-if [ ! -d "openjdk-build" ]; then
-        echo 'Cloning openJDK-build repo'
-        git clone https://github.com/adoptopenjdk/openjdk-build
-fi
-/cygdrive/c/openjdk-build/makejdk-any-platform.sh -J /cygdrive/c/openjdk/jdk-8 --configure-args "--disable-ccache --with-toolchain-version=2013" --freetype-version 2.5.3 -v jdk8u
+export JAVA_HOME=/cygdrive/c/openjdk/jdk-8
+export JDK_BOOT_DIR=/cygdrive/c/openjdk/jdk-8
+GIT_URL=https://github.com/adoptopenjdk/openjdk-build
+CLEAN_WORKSPACE=false
+
+processArgs $*
+cloneRepo
+
+echo "DEBUG:
+	TARGET_OS=$TARGET_OS
+	ARCHITECTURE=$ARCHITECTURE
+	JAVA_TO_BUILD=$JAVA_TO_BUILD
+        VARIANT=$VARIANT
+        JDK_BOOT_DIR=$JDK_BOOT_DIR
+        JAVA_HOME=$JAVA_HOME
+        WORKSPACE=$WORKSPACE
+        GIT_URL=$GIT_URL"	
+
+/cygdrive/c/openjdk-build/build-farm/make-adopt-build-farm.sh

--- a/ansible/pbTestScripts/vagrantPlaybookCheck.sh
+++ b/ansible/pbTestScripts/vagrantPlaybookCheck.sh
@@ -13,6 +13,7 @@ vmHalt=true
 cleanWorkspace=false
 newVagrantFiles=false
 skipFullSetup=''
+jdkToBuild=''
 
 # Takes all arguments from the script, and determines options
 processArgs()
@@ -27,6 +28,8 @@ processArgs()
 				vagrantOS="all";;
 			"--build" | "-b" )
 				testNativeBuild=true;;
+			"--JDK-Version" | "-jdk" )
+				jdkToBuild="--version $1"; shift;;
 			"--retainVM" | "-r" )
 				retainVM=true;;
 			"--URL" | "-u" )
@@ -56,6 +59,8 @@ usage()
 					--all | -a 				Builds and tests playbook through every OS
 					--retainVM | -r				Option to retain the VM and folder after completion
 					--build | -b				Option to enable testing a native build on the VM
+					--JDK-Version | -jdk			Specify which JDK to build, if build is specified
+					--build-repo | -br			Specify the openjdk-build repo to build with
 					--clean-workspace | -c			Will remove the old work folder if detected
 					--URL | -u <GitURL>			The URL of the git repository
                                         --test | -t                             Runs a quick test on the built JDK
@@ -206,7 +211,7 @@ startVMPlaybook()
 	local pb_failed=$?
 	cd $WORKSPACE/adoptopenjdkPBTests/$folderName-$branchName/ansible
 	if [[ "$testNativeBuild" = true && "$pb_failed" == 0 ]]; then
-		ansible all -i playbooks/AdoptOpenJDK_Unix_Playbook/hosts.unx -u vagrant -m raw -a "cd /vagrant/pbTestScripts && ./buildJDK.sh $buildURL"
+		ansible all -i playbooks/AdoptOpenJDK_Unix_Playbook/hosts.unx -u vagrant -m raw -a "cd /vagrant/pbTestScripts && ./buildJDK.sh $buildURL $jdkToBuild"
 		echo The build finished at : `date +%T`
 		if [[ "$runTest" = true ]]; then
 	        	ansible all -i playbooks/AdoptOpenJDK_Unix_Playbook/hosts.unx -u vagrant -m raw -a "cd /vagrant/pbTestScripts && ./testJDK.sh"
@@ -250,7 +255,7 @@ startVMPlaybookWin()
 		# Runs the build script via ansible, as vagrant powershell gives error messages that ansible doesn't. 
         	# See: https://github.com/AdoptOpenJDK/openjdk-infrastructure/pull/942#issuecomment-539946564
 		vagrant reload
-		ansible all -i playbooks/AdoptOpenJDK_Windows_Playbook/hosts.win -u vagrant -m raw -a "Start-Process powershell.exe -Verb runAs; cd C:/; sh C:/vagrant/pbTestScripts/buildJDKWin.sh"
+		ansible all -i playbooks/AdoptOpenJDK_Windows_Playbook/hosts.win -u vagrant -m raw -a "Start-Process powershell.exe -Verb runAs; cd C:/; sh C:/vagrant/pbTestScripts/buildJDKWin.sh $buildURL $jdkToBuild"
 		echo The build finished at : `date +%T`
 		if [[ "$runTest" = true ]]; then
 			vagrant reload


### PR DESCRIPTION
Update to allow the VagrantPlaybookCheck Jenkins job to specify which jdk we want to build for both Unix and Windows, with defaults to JDK8 - OpenJ9.

