### PR TITLE
pbTests: Detect TEST_JDK_HOME properly

### DIFF
--- a/ansible/pbTestScripts/testJDK.sh
+++ b/ansible/pbTestScripts/testJDK.sh
@@ -6,8 +6,7 @@ if [[ $(uname) == "FreeBSD" ]]; then
 	cp -r $HOME/openjdk-build/workspace/build/src/build/*/jdk* $HOME
 	export TEST_JDK_HOME=$HOME/jdk
 else
-	mv $HOME/openjdk-build/workspace/build/src/build/*/images/jdk* $HOME
-	export TEST_JDK_HOME=$(find $HOME -maxdepth 1 -type d -name "*jdk*"|grep -v ".*jre.*"|grep -v ".*test-image.*")
+	export TEST_JDK_HOME=$(find $HOME/openjdk-build/workspace/build/src/build/*/images/ -maxdepth 1 -type d -name "*jdk*"|grep -v ".*jre.*"|grep -v ".*test-image.*")
 fi
 
 mkdir -p $HOME/testLocation


### PR DESCRIPTION
Tested on Debian8 VM - was able to build/test `jdk11` and `jdk14`.

