### PR TITLE
unixPB: Revert CentOS locale changes

### DIFF
--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/tasks/CentOS.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/tasks/CentOS.yml
@@ -228,30 +228,32 @@
     - locales
     - skip_ansible_lint
 
+# Skipping linting as locale_gen module isn't usable on CentOS6/7
+# https://github.com/ansible/ansible/issues/44708
 - name: Create Japanese locale
-  locale_gen:
-    name: ja_JP.UTF-8
-    state: present
+  shell: localedef -i ja_JP -c -f UTF-8 ja_JP.UTF-8
   when: localeList.stdout|lower is not search("ja_jp\.utf8")
-  tags: locales
+  tags:
+    - locales
+    - skip_ansible_lint
 
 - name: Create Korean locale
-  locale_gen:
-    name: ko_KR.UTF-8
-    state: present
+  shell: localedef -i ko_KR -c -f UTF-8 ko_KR.UTF-8
   when: localeList.stdout|lower is not search("ko_kr\.utf8")
-  tags: locales
+  tags:
+    - locales
+    - skip_ansible_lint
 
 - name: Create Chinese locale
-  locale_gen:
-    name: zh_CN.UTF-8
-    state: present
+  shell: localedef -i zh_CN -c -f UTF-8 zh_CN.UTF-8
   when: localeList.stdout|lower is not search("zh_cn\.utf8")
-  tags: locales
+  tags:
+    - locales
+    - skip_ansible_lint
 
 - name: Create Taiwanese locale
-  locale_gen:
-    name: zh_TW.UTF-8
-    state: present
+  shell: localedef -i zh_TW -c -f UTF-8 zh_TW.UTF-8
   when: localeList.stdout|lower is not search("zh_tw\.utf8")
-  tags: locales
+  tags:
+    - locales
+    - skip_ansible_lint


### PR DESCRIPTION
Ref: https://github.com/ansible/ansible/issues/44708
#1190 

With the above PR, CentOS' locale jobs were changes from using the `shell` module to the `locale_gen` module, however this caused an issue with `CentOS7` in the `vagrantPlaybookCheck` job (See: https://ci.adoptopenjdk.net/view/Tooling/job/VagrantPlaybookCheck/420/OS=CentOS7,label=vagrant/)

This PR reverts those changes, as well as adding the `skip_ansible_lint` tag, to stop the linter flagging `[305] Use shell only when shell functionality is required` rule.