### PR TITLE
winPB: Update Cygwin to use a prebuilt folder

### DIFF
--- a/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/main.yml
@@ -39,6 +39,7 @@
     - Jenkins                     # AdoptOpenJDK infrastructure
     - MSVS_2010
     - VS2010_SP1
+    - 7-Zip                       # Mostly extracting other prereqs :-)
     - cygwin
     - Firefox
     - Strawberry_Perl             # Testing
@@ -58,7 +59,6 @@
     - MSVS_2017                   # OpenJ9
     - NVidia_Cuda_Toolkit         # OpenJ9
     - NTP_TIME
-    - 7-Zip                       # Mostly extracting other prereqs :-)
     - Clang_64bit                 # OpenJ9
     - Clang_32bit                 # OpenJ9
     - nasm                        # OpenJ9

--- a/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/roles/cygwin/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/roles/cygwin/tasks/main.yml
@@ -29,8 +29,8 @@
     url: https://ci.adoptopenjdk.net/userContent/winansible/cygwin64.tar.xz
     dest: 'C:\temp\cygwin64.tar.xz'
     force: no
-    checksum: 
-    checksum_algorithm:
+    checksum: 5b2050882a4c13e2a6762bbe876eac153ce27cfd51b6963f976728917a461886
+    checksum_algorithm: sha256
   retries: 3
   delay: 5
   register: cached_folder_download

--- a/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/roles/cygwin/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/roles/cygwin/tasks/main.yml
@@ -24,6 +24,28 @@
     checksum_algorithm: sha256
   tags: cygwin
 
+- name: Get Cygwin64 cached folder
+  win_get_url:
+    url: https://ci.adoptopenjdk.net/userContent/winansible/cygwin64.tar.xz
+    dest: 'C:\temp\cygwin64.tar.xz'
+    force: no
+    checksum: 
+    checksum_algorithm:
+  retries: 3
+  delay: 5
+  register: cached_folder_download
+  until: cached_folder_download is not failed
+  when: (not cygwin_installed.stat.exists)
+  tags: cygwin
+
+- name: Decompress Cygwin64.tar.xz
+  win_shell: |
+    cd C:\
+    C:\7-Zip\7z.exe x C:\temp\cygwin64.tar.xz
+    C:\7-Zip\7z.exe x C:\cygwin64.tar
+  when: (not cygwin_installed.stat.exists)
+  tags: cygwin
+
 - name: Install Cygwin and its packages
   win_command: c:\temp\cygwin.exe --quiet-mode --download --local-install
                 --delete-orphans --site {{ Cygwin_SITE_URL }}
@@ -56,6 +78,16 @@
 
 - name: Change git config to not replace Line endings
   win_shell: "C:/cygwin64/bin/git config --system core.autocrlf false"
+  tags: cygwin
+
+- name: Remove temp cache files
+  win_file:
+    path: '{{ item }}'
+    state: absent
+  with_items:
+    - 'C:/temp/cygwin64.tar.xz'
+    - 'C:/cygwin64.tar'
+  when: (not cygwin_installed.stat.exists)
   tags: cygwin
 
 ###############################################################################


### PR DESCRIPTION
fixes: #1210 

Fix-up the playbooks to use https://ci.adoptopenjdk.net/userContent/winansible/ to significantly reduce time of Cygwin installation.
Testing at:
https://ci.adoptopenjdk.net/view/Tooling/job/VagrantPlaybookCheck/425/OS=Win2012,label=infra-vagrant-1/console