### PR TITLE
Ansible pulls from userContent/winansible

### DIFF
--- a/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/roles/Clang_32bit/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/roles/Clang_32bit/tasks/main.yml
@@ -14,7 +14,7 @@
 
 - name: Download Clang 32bit
   win_get_url:
-    url: https://ci.adoptopenjdk.net/userContent/llvm700/llvm-7.0.0-win32.zip
+    url: https://ci.adoptopenjdk.net/userContent/winansible/llvm-7.0.0-win32.zip
     dest: 'C:\temp\'
     force: no
     checksum: 89dcd42d240b3e7ef3a5487855e224f2f90a23a2a194dbadd8c427c2dd59df79

--- a/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/roles/Clang_64bit/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/roles/Clang_64bit/tasks/main.yml
@@ -16,7 +16,7 @@
     url: https://ci.adoptopenjdk.net/userContent/winansible/llvm-7.0.0-win64.zip
     dest: 'C:\temp\'
     force: no
-    checksum: 74b197a3959b0408adf0824be01db8dddfa2f9a967f4085af3fad900ed5fdbf6
+    checksum: e61c3d115778dbb54f91cec8ca7682cbad601d61e2c40a9a97e554aa1f1bb2b6
     checksum_algorithm: sha256
   when: not clang_64bit_installed.stat.exists
   tags: clang_64bit

--- a/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/roles/Clang_64bit/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/roles/Clang_64bit/tasks/main.yml
@@ -3,6 +3,7 @@
 # LLVM/Clang 64bit #
 ####################
 # Clang 64bit is an OpenJ9 prerequisite.
+# The original source of Clang64 was https://releases.llvm.org/7.0.0/LLVM-7.0.0-win64.exe being executed with the /S parameter
 
 - name: Test if Clang 64bit is already installed (required by OpenJ9)
   win_stat:

--- a/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/roles/Clang_64bit/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/roles/Clang_64bit/tasks/main.yml
@@ -6,7 +6,7 @@
 
 - name: Test if Clang 64bit is already installed (required by OpenJ9)
   win_stat:
-    path: 'C:\Program Files\LLVM\bin\clang.exe'
+    path: 'C:\Program Files\LLVM64\bin\clang.exe'
   register: clang_64bit_installed
   tags: clang_64bit
 
@@ -20,8 +20,11 @@
   when: not clang_64bit_installed.stat.exists
   tags: clang_64bit
 
-- name: Install Clang 64bit
-  win_command: 'c:\temp\llvm-7.0.0-win64.exe /S'
+- name: Install (unzip) Clang 64bit
+  win_unzip:
+    src: C:\temp\llvm-7.0.0-win64.zip
+    dest: C:\
+    creates: 'C:\Program Files\LLVM64\bin\clang.exe'
   when: not clang_64bit_installed.stat.exists
   tags: clang_64bit
 
@@ -32,13 +35,13 @@
   tags: clang_64bit
 
 - name: Create symlink to C:\openjdk\LLVM64
-  raw: cmd /c mklink /D "C:\openjdk\LLVM64" "C:\Program Files\LLVM"
+  raw: cmd /c mklink /D "C:\openjdk\LLVM64" "C:\Program Files\LLVM64"
   when: not llvm64_symlink.stat.exists
   tags: clang_64bit
 
 - name: Cleanup Clang 64bit installer
   win_file:
-    path: 'c:\temp\llvm-7.0.0-win64.exe'
+    path: 'C:\temp\llvm-7.0.0-win64.zip'
     state: absent
   ignore_errors: yes
   tags: clang_64bit

--- a/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/roles/Clang_64bit/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/roles/Clang_64bit/tasks/main.yml
@@ -12,7 +12,7 @@
 
 - name: Download Clang 64bit
   win_get_url:
-    url: https://releases.llvm.org/7.0.0/LLVM-7.0.0-win64.exe
+    url: https://ci.adoptopenjdk.net/userContent/winansible/llvm-7.0.0-win64.zip
     dest: 'C:\temp\'
     force: no
     checksum: 74b197a3959b0408adf0824be01db8dddfa2f9a967f4085af3fad900ed5fdbf6
@@ -21,7 +21,7 @@
   tags: clang_64bit
 
 - name: Install Clang 64bit
-  win_command: 'c:\temp\LLVM-7.0.0-win64.exe /S'
+  win_command: 'c:\temp\llvm-7.0.0-win64.exe /S'
   when: not clang_64bit_installed.stat.exists
   tags: clang_64bit
 
@@ -38,7 +38,7 @@
 
 - name: Cleanup Clang 64bit installer
   win_file:
-    path: 'c:\temp\LLVM-7.0.0-win64.exe'
+    path: 'c:\temp\llvm-7.0.0-win64.exe'
     state: absent
   ignore_errors: yes
   tags: clang_64bit

--- a/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/roles/Clang_64bit/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/roles/Clang_64bit/tasks/main.yml
@@ -7,7 +7,7 @@
 
 - name: Test if Clang 64bit is already installed (required by OpenJ9)
   win_stat:
-    path: 'C:\Program Files\LLVM64\bin\clang.exe'
+    path: 'C:\Program Files\LLVM\bin\clang.exe'
   register: clang_64bit_installed
   tags: clang_64bit
 
@@ -25,7 +25,7 @@
   win_unzip:
     src: C:\temp\llvm-7.0.0-win64.zip
     dest: C:\
-    creates: 'C:\Program Files\LLVM64\bin\clang.exe'
+    creates: 'C:\Program Files\LLVM\bin\clang.exe'
   when: not clang_64bit_installed.stat.exists
   tags: clang_64bit
 
@@ -36,7 +36,7 @@
   tags: clang_64bit
 
 - name: Create symlink to C:\openjdk\LLVM64
-  raw: cmd /c mklink /D "C:\openjdk\LLVM64" "C:\Program Files\LLVM64"
+  raw: cmd /c mklink /D "C:\openjdk\LLVM64" "C:\Program Files\LLVM"
   when: not llvm64_symlink.stat.exists
   tags: clang_64bit
 

--- a/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/roles/OpenSSL/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/roles/OpenSSL/tasks/main.yml
@@ -31,7 +31,7 @@
 
 - name: Retrieve OpenSSL-1.1.1d 64-bit (VS2017)
   win_get_url:
-    url: https://ci.adoptopenjdk.net/userContent/OpenSSL111win/OpenSSL111d-64bitVS2017.tgz
+    url: https://ci.adoptopenjdk.net/userContent/winansible/openssl/OpenSSL111d-64bitVS2017.tgz
     dest: C:\temp\openssl-1.1.1d-VS2017.tar.gz
     checksum: 60ef36d98a369ad9086347b0cfb87816c472ac4b048e5aea178134e8ab82e0b1
     checksum_algorithm: sha256


### PR DESCRIPTION
On the windows playbook, I have changed download source of the openssl and llvm 32bit from `userContent` to `userContent/winansible` (https://ci.adoptopenjdk.net/userContent/winansible/), as per https://github.com/AdoptOpenJDK/openjdk-infrastructure/issues/1215

The source for the cygwin download was already set to the winansible directory by a previous commit