### PR TITLE
UnixPB: Make nasm pickup gcc7.5, revert opensuse gcc4.3 install task

### DIFF
--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/tasks/openSUSE.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/tasks/openSUSE.yml
@@ -40,7 +40,7 @@
   shell: zypper -n in --force-resolution gcc48
   when:
     - (ansible_distribution_major_version == "12" and ansible_architecture == "x86_64")
-  tags: 
+  tags:
     - patch_update
     - skip_ansible_lint
 

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/tasks/openSUSE.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/tasks/openSUSE.yml
@@ -35,14 +35,14 @@
     - (ansible_distribution_major_version == "12" and ansible_architecture == "x86_64")
   tags: SUSE_gcc48
 
+# Skipping ansible lint as shell module is required to use the --force-resolution option (lint error 305)
 - name: Install gcc48
-  zypper:
-    name: gcc48
-    extra_args_precommand: "-non-interactive"
-    state: present
+  shell: zypper -n in --force-resolution gcc48
   when:
     - (ansible_distribution_major_version == "12" and ansible_architecture == "x86_64")
-  tags: patch_update
+  tags: 
+    - patch_update
+    - skip_ansible_lint
 
 - name: zypper upgrade all packages
   zypper: name='*' state=latest update_cache=yes

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/nasm/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/nasm/tasks/main.yml
@@ -32,13 +32,13 @@
   when: gcc7.stat.exists and CC is not defined
   tags: nasm
 
-- name: Checking for gcc-7.3 binary installation
-  stat: path=/usr/local/gcc/bin/gcc-7.3
+- name: Checking for gcc-7.5 binary installation
+  stat: path=/usr/local/gcc/bin/gcc-7.5
   register: gcc7
   tags: nasm
-- name: Setting CC to gcc-7.3 binary found
+- name: Setting CC to gcc-7.5 binary found
   set_fact:
-    CC: "/usr/local/gcc/bin/gcc-7.3"
+    CC: "/usr/local/gcc/bin/gcc-7.5"
   when: gcc7.stat.exists and CC is not defined
   tags: nasm
 


### PR DESCRIPTION
Issues noticed when running the VagrantPlaybookCheck job.

nasm was looking for gcc7.3, which has been taken out of the playbooks since #1158 ,
The OpenSUSE role had to be reverted back from #1190 , as replacing the `shell` module for the `zypper` module means the `--force-resolution` argument can't be put in. The `skip_ansible_lint` tag has been put in, with a comment for justification.