### PR TITLE
unixPB: Add autoconf to SUSE playbook

### DIFF
--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/vars/openSUSE.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/vars/openSUSE.yml
@@ -6,6 +6,7 @@
 # Command Build Tool Packages
 Build_Tool_Packages:
   - alsa-devel
+  - autoconf
   - bind-utils
   - bison                         # OpenJ9
   - cpio


### PR DESCRIPTION
Due to : https://ci.adoptopenjdk.net/view/Tooling/job/VagrantPlaybookCheck/OS=SUSE12,label=infra-vagrant-1/441/consoleFull

Not quite sure how we got this far without it, to be honest. Tested on the SUSE Vagrant VM, installs `autoconf v2.69` fine.