### PR TITLE
UnixPB: Add role for riscv building

### DIFF
--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/main.yml
@@ -63,6 +63,7 @@
     # - Nagios_Plugins              # AdoptOpenJDK Infrastructure
     # - Nagios_Master_Config        # AdoptOpenJDK Infrastructure
     # - Nagios_Tunnel               # AdoptOpenJDK Infrastructure
+    - riscv_cross_compiler        # For building JDK11/J9 on RISC-V architecture
     - Clean_Up
     - Security
     - Vendor

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/riscv_cross_compiler/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/riscv_cross_compiler/tasks/main.yml
@@ -1,0 +1,60 @@
+---
+########################
+# riscv_cross_compiler #
+########################
+
+# An optional role for CentOS machines to enable them building JDK11/J9 for riscv64
+
+- name: Check if the riscv toolchain is installed
+  stat:
+    path: /opt/riscv_toolchain_linux
+  register: riscv_toolchain_installed
+  when:
+    - ansible_distribution == "CentOS" and ansible_architecture == "x86_64"
+  tags:
+    - riscv
+    - adoptopenjdk
+
+- name: Check if the fedora sysroot folder is in place
+  stat:
+    path: /opt/fedora28_riscv_root
+  register: fedora_folder
+  when:
+    - ansible_distribution == "CentOS" and ansible_architecture == "x86_64"
+  tags:
+    - riscv
+    - adoptopenjdk
+
+- name: Yum install libmpc-devel
+  yum:
+    name: libmpc-devel
+    state: latest
+  when:
+    - ansible_distribution == "CentOS" and ansible_architecture == "x86_64"
+  tags:
+    - riscv
+    - adoptopenjdk
+
+- name: Retrieve and unpack the riscv toolchain
+  unarchive:
+    src: https://ci.adoptopenjdk.net/userContent/riscv/riscv_toolchain_linux64.tar.xz
+    dest: /opt/
+    remote_src: yes
+  when:
+    - not riscv_toolchain_installed.stat.exists
+    - ansible_distribution == "CentOS" and ansible_architecture == "x86_64"
+  tags:
+    - riscv
+    - adoptopenjdk
+
+- name: Retrieve and Unpack the fedora sysroot folder
+  unarchive:
+    src: https://ci.adoptopenjdk.net/userContent/riscv/fedora28_riscv_smlroot.tar.xz
+    dest: /opt/
+    remote_src: yes
+  when:
+    - not fedora_folder.stat.exists
+    - ansible_distribution == "CentOS" and ansible_architecture == "x86_64"
+  tags:
+    - riscv
+    - adoptopenjdk

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/riscv_cross_compiler/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/riscv_cross_compiler/tasks/main.yml
@@ -10,7 +10,8 @@
     path: /opt/riscv_toolchain_linux
   register: riscv_toolchain_installed
   when:
-    - ansible_distribution == "CentOS" and ansible_architecture == "x86_64"
+    - (ansible_distribution == "CentOS" or ansible_distribution == "RedHat") and ansible_distribution_major_version == "6" 
+    - ansible_architecture == "x86_64"
   tags:
     - riscv
     - adoptopenjdk
@@ -20,7 +21,8 @@
     path: /opt/fedora28_riscv_root
   register: fedora_folder
   when:
-    - ansible_distribution == "CentOS" and ansible_architecture == "x86_64"
+    - (ansible_distribution == "CentOS" or ansible_distribution == "RedHat") and ansible_distribution_major_version == "6"
+    - ansible_architecture == "x86_64"
   tags:
     - riscv
     - adoptopenjdk
@@ -30,7 +32,8 @@
     name: libmpc-devel
     state: latest
   when:
-    - ansible_distribution == "CentOS" and ansible_architecture == "x86_64"
+    - (ansible_distribution == "CentOS" or ansible_distribution == "RedHat") and ansible_distribution_major_version == "6"
+    - ansible_architecture == "x86_64"
   tags:
     - riscv
     - adoptopenjdk
@@ -42,7 +45,8 @@
     remote_src: yes
   when:
     - not riscv_toolchain_installed.stat.exists
-    - ansible_distribution == "CentOS" and ansible_architecture == "x86_64"
+    - (ansible_distribution == "CentOS" or ansible_distribution == "RedHat") and ansible_distribution_major_version == "6"
+    - ansible_architecture == "x86_64"
   tags:
     - riscv
     - adoptopenjdk
@@ -54,7 +58,8 @@
     remote_src: yes
   when:
     - not fedora_folder.stat.exists
-    - ansible_distribution == "CentOS" and ansible_architecture == "x86_64"
+    - (ansible_distribution == "CentOS" or ansible_distribution == "RedHat") and ansible_distribution_major_version == "6"
+    - ansible_architecture == "x86_64"
   tags:
     - riscv
     - adoptopenjdk


### PR DESCRIPTION
ref: https://github.com/eclipse/openj9/issues/7421

This adds a role that installs all the additional tools necessary to build JDK11/J9 for riscv64. Currently, the tasks have the `adoptopenjdk` tags on them as this isn't necessarily wanted as standard on the machines. This roles is also only for CentOS x86_64 machines, as the `riscv_toolchain_linux` was built for CentOS. 

The role is currently pulling from https://ci.adoptopenjdk.net/userContent/riscv/ to get the prebuilt toolchain and qemu fedora `sysroot` folder. The UserContent folder also includes instructions on how to setup a machine manually, and start that build. 

Given the tag, this role can't be tested on `VagrantPlaybookCheck`, however I manually tested on a CentOS6 VM made from our Vagrantfiles and was able to build the JDK :-) 