### PR TITLE
[wip] WinPB: Revert Cygwin cache, pin Make to v4.2.1-2

### DIFF
--- a/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/roles/cygwin/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/roles/cygwin/tasks/main.yml
@@ -22,6 +22,7 @@
     force: no
     checksum: 4a3fc472b6051d8ec136831e64b9b4bbd328b587d66eef1eedf2a58a620bde97
     checksum_algorithm: sha256
+  when: (not cygwin_installed.stat.exists)
   tags: cygwin
 
 - name: Install Cygwin and its packages
@@ -37,10 +38,11 @@
   win_command: C:\temp\cygwin.exe -q -P "{{ item }}"
   with_items:
     - autoconf
-    - make
+    - cpio
+    - libguile2.0_22            # Required for Make v4.2.1-2
     - unzip
     - zip
-    - cpio
+  when: (not cygwin_installed.stat.exists)
   tags: cygwin
 
 - name: Install Cygwin test extra packages
@@ -52,6 +54,7 @@
     - libpng15
     - libpng-devel
     - perl-Text-CSV
+  when: (not cygwin_installed.stat.exists)
   tags: cygwin
 
 - name: Change git config to not replace Line endings
@@ -73,10 +76,12 @@
     force: no
     checksum: 36ae2483f68b3c5a4bd93814fa4f7e2576dbe6559d4ffa0589c2159e85de91f6
     checksum_algorithm: sha256
+  when: (not cygwin_installed.stat.exists)
   tags: cygwin
 
 - name: Extract grep-2.27-2
   win_command: "{{ Cygwin_ROOT_INST_DIR + '\\bin\\bash.exe -l -c \"tar -C / -xvf /tmp/grep.tar.xz\"' }}"
+  when: (not cygwin_installed.stat.exists)
   tags: cygwin
 
 - name: Download make-4.2.1-2
@@ -86,10 +91,12 @@
     force: no
     checksum: 919037ac0ae0402639a08b474a60807499ae47b0aec98e7009820f9c05ea6515
     checksum_algorithm: sha256
+  when: (not cygwin_installed.stat.exists)
   tags: cygwin
 
 - name: Extract make-4.2.1-2
   win_command: "{{ Cygwin_ROOT_INST_DIR + '\\bin\\bash.exe -l -c \"tar -C / -xvf /tmp/make.tar.xz\"' }}"
+  when: (not cygwin_installed.stat.exists)
   tags: cygwin
 
 - name: Remove c:\cygwin64\bin from the path if it exists

--- a/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/roles/cygwin/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/roles/cygwin/tasks/main.yml
@@ -24,28 +24,6 @@
     checksum_algorithm: sha256
   tags: cygwin
 
-- name: Get Cygwin64 cached folder
-  win_get_url:
-    url: https://ci.adoptopenjdk.net/userContent/winansible/cygwin64.tar.xz
-    dest: 'C:\temp\cygwin64.tar.xz'
-    force: no
-    checksum: 5b2050882a4c13e2a6762bbe876eac153ce27cfd51b6963f976728917a461886
-    checksum_algorithm: sha256
-  retries: 3
-  delay: 5
-  register: cached_folder_download
-  until: cached_folder_download is not failed
-  when: (not cygwin_installed.stat.exists)
-  tags: cygwin
-
-- name: Decompress Cygwin64.tar.xz
-  win_shell: |
-    cd C:\
-    C:\7-Zip\7z.exe x C:\temp\cygwin64.tar.xz
-    C:\7-Zip\7z.exe x C:\cygwin64.tar
-  when: (not cygwin_installed.stat.exists)
-  tags: cygwin
-
 - name: Install Cygwin and its packages
   win_command: c:\temp\cygwin.exe --quiet-mode --download --local-install
                 --delete-orphans --site {{ Cygwin_SITE_URL }}
@@ -80,16 +58,6 @@
   win_shell: "C:/cygwin64/bin/git config --system core.autocrlf false"
   tags: cygwin
 
-- name: Remove temp cache files
-  win_file:
-    path: '{{ item }}'
-    state: absent
-  with_items:
-    - 'C:/temp/cygwin64.tar.xz'
-    - 'C:/cygwin64.tar'
-  when: (not cygwin_installed.stat.exists)
-  tags: cygwin
-
 ###############################################################################
 # Cygwin by default installs latest versions of packages, which is 3.0-2 for
 # grep. This version of grep is unable to match EOL (with $) when the file use
@@ -109,6 +77,19 @@
 
 - name: Extract grep-2.27-2
   win_command: "{{ Cygwin_ROOT_INST_DIR + '\\bin\\bash.exe -l -c \"tar -C / -xvf /tmp/grep.tar.xz\"' }}"
+  tags: cygwin
+
+- name: Download make-4.2.1-2
+  win_get_url:
+    url: "{{ Cygwin_SITE_URL + '/x86_64/release/make/make-4.2.1-2.tar.xz' }}"
+    dest: "{{ Cygwin_ROOT_INST_DIR + '\\tmp\\make.tar.xz' }}"
+    force: no
+    checksum: 919037ac0ae0402639a08b474a60807499ae47b0aec98e7009820f9c05ea6515
+    checksum_algorithm: sha256
+  tags: cygwin
+
+- name: Extract make-4.2.1-2
+  win_command: "{{ Cygwin_ROOT_INST_DIR + '\\bin\\bash.exe -l -c \"tar -C / -xvf /tmp/make.tar.xz\"' }}"
   tags: cygwin
 
 - name: Remove c:\cygwin64\bin from the path if it exists


### PR DESCRIPTION
I've taken the Cygwin cache PR ( #1219 ) out, as there were some issues with Git : 

```
Cloning into 'C://openjdk-build'...
fatal: unable to access 'https://github.com/adoptopenjdk/openjdk-build/': SSL: couldn't create a context: error:0E079065:configuration file routines:def_load_bio:missing equal sign
``` 
When installed normally, this issue doesn't occur.

I've also pinned Cygwin's Make version to `4.2.1-2` as there was an issue building JDK11 with Make version 4.3 : https://www.mail-archive.com/bug-make@gnu.org/msg12006.html
which causes this issue: 

```
make[3]: *** No rule to make target '/cygdrive/c/workspace/build/src/build/windows-x86_64-normal-server-release/buildtools/langtools_tools_classes/_the.BUILD_TOOLS_LANGTOOLS.vardeps', needed by '/cygdrive/c/workspace/build/src/build/windows-x86_64-normal-server-release/buildtools/langtools_tools_classes/_the.BUILD_TOOLS_LANGTOOLS_batch'.  Stop.
``` 