### PR TITLE
pbTests: Test script fixes

### DIFF
--- a/ansible/pbTestScripts/buildJDKWin.sh
+++ b/ansible/pbTestScripts/buildJDKWin.sh
@@ -115,14 +115,13 @@ export VARIANT=openj9
 export PATH=/usr/bin/:$PATH
 export TARGET_OS=windows
 export ARCHITECTURE=x64
-export JAVA_HOME=/cygdrive/c/openjdk/jdk-8
 export JDK_BOOT_DIR=/cygdrive/c/openjdk/jdk-8
 GIT_URL=https://github.com/adoptopenjdk/openjdk-build
 CLEAN_WORKSPACE=false
 
 processArgs $*
 cloneRepo
-
+export JAVA_HOME=/cygdrive/c/openjdk/jdk-8
 echo "DEBUG:
 	TARGET_OS=$TARGET_OS
 	ARCHITECTURE=$ARCHITECTURE

--- a/ansible/pbTestScripts/testJDK.sh
+++ b/ansible/pbTestScripts/testJDK.sh
@@ -6,7 +6,7 @@ if [[ $(uname) == "FreeBSD" ]]; then
 	cp -r $HOME/openjdk-build/workspace/build/src/build/*/jdk* $HOME
 	export TEST_JDK_HOME=$HOME/jdk
 else
-	export TEST_JDK_HOME=$(find $HOME/openjdk-build/workspace/build/src/build/*/images/ -maxdepth 1 -type d -name "jdk*"|grep -v ".*jre.*"|grep -v ".*test-image.*")
+	export TEST_JDK_HOME=$(find $HOME/openjdk-build/workspace/build/src/build/*/images/ -maxdepth 1 -type d -name "jdk*"|grep -v ".*jre.*"|grep -v ".*-image")
 fi
 
 mkdir -p $HOME/testLocation

--- a/ansible/pbTestScripts/testJDKWin.sh
+++ b/ansible/pbTestScripts/testJDKWin.sh
@@ -2,17 +2,9 @@
 
 # Script to execute the MachineInfo test on the previously built JDK.
 
-cd /cygdrive/c/workspace/build/src/build/windows-x86_64-normal-server-release/images/
-
-# If the JDK is where it is after building
-if [[ $(find . -name "jdk8*" -type d) ]];
-then
-	echo "Moving JDK to correct directory";
-	mv /cygdrive/c/workspace/build/src/build/windows-x86_64-normal-server-release/images/jdk8* $HOME
-fi
-
-# Ensures to set it to the JDK, not the JRE
-export TEST_JDK_HOME=C:/cygwin64$(find ~ -maxdepth 1 -type d -name "*jdk8u*"|grep -v ".*jre.*")
+mv /cygdrive/c/workspace/build/src/build/*/images/jdk* $HOME
+# Ensures to set it to the JDK, not JRE or different images
+export TEST_JDK_HOME=C:/cygwin64$(find ~ -maxdepth 1 -type d -name "*jdk*"|grep -v ".*jre"| grep -v ".*-image")
 
 cd $HOME
 if [ ! -d "testLocation" ];
@@ -30,7 +22,6 @@ cd openjdk-tests
 
 ./get.sh -t $HOME/testLocation/openjdk-tests -p x64_windows
 cd TKG
-make -f run_configure.mk AUTO_DETECT=true
 export BUILD_LIST=system
 make compile
 make _extended.system 


### PR DESCRIPTION
Additional fixes to :
1) stop `testJDK.sh` finding the `debug-image` thats produced when building JDKs

2) Allow `testJDKWin.sh` to find built JDKs other than JDK8