### PR TITLE
PBs: Update OpenSSL URL

### DIFF
--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/OpenSSL102/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/OpenSSL102/tasks/main.yml
@@ -12,7 +12,7 @@
 
 - name: Download OpenSSL v1.0.2r
   get_url:
-    url: https://www.openssl.org/source/openssl-1.0.2r.tar.gz
+    url: https://www.openssl.org/source/old/1.0.2/openssl-1.0.2r.tar.gz
     dest: /tmp/openssl-1.0.2r.tar.gz
     force: no
     mode: 0755

--- a/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/roles/OpenSSL/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/roles/OpenSSL/tasks/main.yml
@@ -22,7 +22,7 @@
 
 - name: Download OpenSSL-1.1.1e
   win_get_url:
-    url: https://www.openssl.org/source/openssl-1.1.1e.tar.gz
+    url: https://www.openssl.org/source/old/1.1.1/openssl-1.1.1e.tar.gz
     dest: C:\temp\openssl-1.1.1e.tar.gz
     checksum: 694f61ac11cb51c9bf73f54e771ff6022b0327a43bbdfa1b2f19de1662a6dcbe
     checksum_algorithm: sha256


### PR DESCRIPTION
Recently OpenSSL change the URLs to retrieve the old versions of their source. Checksums won't need to change as the tarballs are the same (though I did check).

