### PR TITLE
WinPB: Add CodesignCert roles

### DIFF
--- a/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/main.yml
@@ -37,6 +37,7 @@
     - Common
     - Windows_Updates
     - Jenkins                     # AdoptOpenJDK infrastructure
+    - CodesignCert
     - MSVS_2010
     - VS2010_SP1
     - 7-Zip                       # Mostly extracting other prereqs :-)

--- a/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/roles/CodesignCert/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/roles/CodesignCert/tasks/main.yml
@@ -1,0 +1,23 @@
+---
+################
+# CodesignCert #
+################
+
+- name: Check if windows.p12 exists
+  win_stat:
+    path: C:\Users\jenkins\windows.p12
+  register: cert_installed
+  tags:
+    - ccert
+    - jenkins
+
+- name: Get windows.p12 and put in Jenkins Home Directory
+  win_get_url:
+    url: https://github.com/AdoptOpenJDK/openjdk-installer/raw/master/windows.p12
+    dest: C:\Users\jenkins
+    checksum: 836c302e944cae970b1fa57b9e5cff552e3d61f0ce4445e79185900c1098e40e
+    checksum_algorithm: sha256
+  when: (not cert_installed.stat.exists)
+  tags:
+    - ccert
+    - jenkins


### PR DESCRIPTION
Requested by @gdams 

When running the Installer job on the machine, it looks for the `windows.p12` file, which isn't added in by the playbook.