### PR TITLE
inventory: Remove already-decommissioned JCK systems

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,7 +133,6 @@ The following items are stored in GitHub.
 |  Description | Storage Location | Frequency  |
 |---|---|---|
 | Jenkins (ci) - Configuration and Settings | localhost `/mnt/backup-server/jenkins_backup` | Daily |
-| Jenkins (ci-jck) - Configuration and Settings | localhost `/mnt/backup/` | Daily |
 | Nagios - Configuration and Settings | localhost `/root/backups` | Weekly |
 | AWX - Configuration and Settings | not currently backed up | N/A |
 

--- a/ansible/inventory.yml
+++ b/ansible/inventory.yml
@@ -139,6 +139,7 @@ hosts:
 
       - packet:
           ubuntu1604-armv8-1: {ip: 147.75.74.50}
+          ubuntu1604-armv8-2: {ip: 147.75.193.234}
           ubuntu1604-x64-1: {ip: 147.75.204.239}
           ubuntu1604-x64-2: {ip: 147.75.100.127}
           ubuntu1604-x64-3: {ip: 147.75.83.133}
@@ -177,16 +178,3 @@ hosts:
 
       - scaleway:
           ubuntu1604-armv7-1: {ip: 51.158.73.136}
-
-  - jck:
-
-      - marist:
-          ubuntu1604-s390x-1: {ip: 148.100.33.183, user: linux1}
-
-      - packet:
-          ubuntu1604-armv8-1: {ip: 147.75.193.234}
-
-      - softlayer:
-          ubuntu1604-x64-1: {ip: 159.122.210.205}
-          ubuntu1604-x64-2: {ip: 159.122.210.194}
-          win2012r2-x64-1: {ip: 169.55.170.68, user: Administrator}

--- a/ansible/plugins/inventory/adoptopenjdk_yaml.py
+++ b/ansible/plugins/inventory/adoptopenjdk_yaml.py
@@ -42,7 +42,7 @@ valid = {
   'arch': ('armv7', 'armv8', 'ppc64le', 'ppc64', 'x64', 's390x'),
 
   # valid roles - add as necessary
-  'type': ('build', 'test', 'jck', 'infrastructure', 'perf', 'docker'),
+  'type': ('build', 'test', 'infrastructure', 'perf', 'docker'),
 
   # providers - validated for consistency
   'provider': ('azure', 'marist', 'osuosl', 'scaleway',


### PR DESCRIPTION
- Remove softlayer machines that had already been decomissioned
- Move aarch64 machine into a test role (New machine [test-packet-ubuntu1604-x64-2[(https://ci.adoptopenjdk.net/computer/test-packet-ubuntu1604-armv8-2/) active)
- Remove obsolete category from adoptopenjdk_yaml.py
- Update README.md to remove decommissioned ci-jck server

Signed-off-by: Stewart Addison <sxa@uk.ibm.com>