### PR TITLE
WinPB: Add playbook role to set shortpaths in 'Program Files (x86)'

### DIFF
--- a/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/main.yml
@@ -67,3 +67,4 @@
     - Rust                        # IcedTea-Web
     - IcedTea-Web                 # For Jenkins webstart
     - WiX                         # For creating installers
+    - Shortnames

--- a/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/roles/Common/scripts/shortName.ps1
+++ b/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/roles/Common/scripts/shortName.ps1
@@ -1,0 +1,10 @@
+$dirName=$Args[0]
+$shortName=$Args[1]
+
+$string=(cmd /c dir /x "C:\Program Files (x86)" | grep "$dirName")
+$result=($string.split(" ")[17])
+
+If ($result -eq ""){
+	echo "Setting Shortname"
+	fsutil file setshortname "C:\Program Files (x86)\$dirName" $shortName
+}

--- a/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/roles/shortNames/scripts/shortName.ps1
+++ b/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/roles/shortNames/scripts/shortName.ps1
@@ -1,3 +1,5 @@
+# This script checks if an 8dot3 shortname exists for a specified directory in the Program Files (x86) folder
+
 $dirName=$Args[0]
 $shortName=$Args[1]
 

--- a/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/roles/shortNames/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/roles/shortNames/tasks/main.yml
@@ -1,0 +1,39 @@
+---
+##############
+# Shortnames #
+##############
+
+# Ensures that directories have alternative shortnames for the builds
+
+- name: Check if shortName.ps1 has been downloaded
+  win_stat:
+    path: C:\temp\shortName.ps1
+  register: script_download
+  tags:
+    - shortnames
+
+- name: Download shortName.ps1
+  win_get_url:
+    url: https://raw.githubusercontent.com/AdoptOpenJDK/openjdk-infrastructure/master/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/roles/Common/scripts/shortName.ps1
+    dest: C:\temp\shortName.ps1
+  when: (not script_download.stat.exists)
+  tags:
+    - shortnames
+
+- name: Enable shortnames on drive C:/
+  win_shell: fsutil 8dot3name set C: 0
+  tags:
+    - shortnames
+
+- name: Run shortname script against Vars list
+  win_shell: C:\temp\shortName.ps1 "{{ item.name }}" "{{ item.shortname }}"
+  with_items:
+    - { name: "Microsoft Visual Studio", shortname: "MIB055~1" }
+    - { name: "Microsoft Visual Studio 9.0" , shortname: "MICROS~2.0" }
+    - { name: "Microsoft Visual Studio 10.0" , shortname: "MICROS~3.0" }
+    - { name: "Microsoft Visual Studio 11.0" , shortname: "MICROS~4.0" }
+    - { name: "Microsoft Visual Studio 12.0" , shortname: "MICROS~1.0" }
+    - { name: "Microsoft Visual Studio 14.0" , shortname: "MI0E91~1.0" }
+    - { name: "Windows Kits" , sname: "WINDOW~4" }
+  tags:
+    - shortnames

--- a/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/roles/shortNames/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/roles/shortNames/tasks/main.yml
@@ -3,37 +3,31 @@
 # Shortnames #
 ##############
 
-# Ensures that directories have alternative shortnames for the builds
+# Ensures that directories have an 8dot3 shortname
 
-- name: Check if shortName.ps1 has been downloaded
-  win_stat:
-    path: C:\temp\shortName.ps1
-  register: script_download
-  tags:
-    - shortnames
-
-- name: Download shortName.ps1
-  win_get_url:
-    url: https://raw.githubusercontent.com/AdoptOpenJDK/openjdk-infrastructure/master/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/roles/Common/scripts/shortName.ps1
-    dest: C:\temp\shortName.ps1
-  when: (not script_download.stat.exists)
+- name: Query to see if shortnames are enabled
+  win_shell: "fsutil 8dot3name query C: | grep enabled"
+  register: enabled_shortnames
+  ignore_errors: true
   tags:
     - shortnames
 
 - name: Enable shortnames on drive C:/
-  win_shell: fsutil 8dot3name set C: 0
+  win_shell: "fsutil 8dot3name set C: 0"
+  when: (not enabled_shortnames.stdout)
   tags:
     - shortnames
 
-- name: Run shortname script against Vars list
-  win_shell: C:\temp\shortName.ps1 "{{ item.name }}" "{{ item.shortname }}"
+- name: Create 8dot3 shortnames
+  script: scripts/shortName.ps1 "{{ item.name }}" "{{ item.shortname }}"
   with_items:
+    - { name: "WiX Toolset v3.14", shortname: "WIXTOO~1.14" }
     - { name: "Microsoft Visual Studio", shortname: "MIB055~1" }
     - { name: "Microsoft Visual Studio 9.0" , shortname: "MICROS~2.0" }
     - { name: "Microsoft Visual Studio 10.0" , shortname: "MICROS~3.0" }
     - { name: "Microsoft Visual Studio 11.0" , shortname: "MICROS~4.0" }
     - { name: "Microsoft Visual Studio 12.0" , shortname: "MICROS~1.0" }
     - { name: "Microsoft Visual Studio 14.0" , shortname: "MI0E91~1.0" }
-    - { name: "Windows Kits" , sname: "WINDOW~4" }
+    - { name: "Windows Kits" , shortname: "WINDOW~4" }
   tags:
     - shortnames


### PR DESCRIPTION
Ref: #1239 

When setting up the Azure machines, `short names` weren't enabled on the `C:/` drive, which stopped builds as it didn't like the spaces in directories such as `Microsoft Visual Studio`.