### PR TITLE
inventory: Move ubuntu build machines to docker group

### DIFF
--- a/ansible/inventory.yml
+++ b/ansible/inventory.yml
@@ -53,20 +53,17 @@ hosts:
           rhel77-s390x-2: {ip: 148.100.86.218, user: linux1}
           rhel77-s390x-3: {ip: 148.100.244.180, user: linux1}
           rhel77-s390x-4: {ip: 148.100.245.197, user: linux1}
-          ubuntu1604-s390x-1: {ip: 148.100.113.58, user: ubuntu}
           zos21-s390x-1: {ip: 148.100.36.136, user: OPEN1}
           zos21-s390x-2: {ip: 148.100.36.137, user: OPEN1}
 
       - osuosl:
           centos74-ppc64le-1: {ip: 140.211.168.138}
           centos74-ppc64le-2: {ip: 140.211.168.117}
-          ubuntu1604-ppc64le-1: {ip: 140.211.168.243}
           aix71-ppc64-1: {ip: 140.211.9.10}
           aix71-ppc64-2: {ip: 140.211.9.12}
 
       - packet:
           centos74-armv8-1: {ip: 147.75.196.30}
-          ubuntu1604-armv8-2: {ip: 147.75.77.146}
 
       - scaleway:
           ubuntu1604-x64-2: {ip: 51.15.46.107}
@@ -77,6 +74,24 @@ hosts:
           win2012r2-x64-1: {ip: 37.58.103.195, user: Administrator}
           win2012r2-x64-2: {ip: 37.58.103.196, user: Administrator}
           centos6-x64-1: {ip: 52.117.29.5}
+
+  - docker:
+
+      - aws:
+          ubuntu1604-x64-1: {ip: 34.253.28.27, user: ubuntu}
+          ubuntu1604-x64-2: {ip: 34.250.61.39, user: ubuntu}
+
+      - godaddy:
+          ubuntu1604-x64-1: {ip: 160.153.235.114, user: adoptopenjdk}
+
+      - packet:
+          ubuntu1604-armv8-1: {ip: 147.75.77.146}
+
+      - osuosl:
+          ubuntu1604-ppc64le-1: {ip: 140.211.168.243}
+
+      - scaleway:
+          ubuntu1604-armv7-1: {ip: 51.158.73.136}
 
   - perf:
 
@@ -174,14 +189,3 @@ hosts:
           rhel69-x64-1: {ip: 169.55.150.147}
           win2012r2-x64-1: {ip: 169.55.170.72, user: admin}
 
-  - docker:
-
-      - aws:
-          ubuntu1604-x64-1: {ip: 34.253.28.27, user: ubuntu}
-          ubuntu1604-x64-2: {ip: 34.250.61.39, user: ubuntu}
-
-      - godaddy:
-          ubuntu1604-x64-1: {ip: 160.153.235.114, user: adoptopenjdk}
-
-      - scaleway:
-          ubuntu1604-armv7-1: {ip: 51.158.73.136}


### PR DESCRIPTION
Also move `docker` section to be in the correct place alphabetically :-)