### PR TITLE
winPB: WMF role Condition fix

### DIFF
--- a/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/roles/WMF_5.1/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/roles/WMF_5.1/tasks/main.yml
@@ -8,8 +8,7 @@
   args:
     executable: powershell
   register: powershell_output
-  tags:
-    - WMF
+  tags: WMF
 
 - name: Get WMF 5.1 Packages
   win_get_url:
@@ -33,6 +32,6 @@
   win_reboot:
     reboot_timeout: 1800
   when:
-    - hotfix_install.reboot_required
     - (powershell_output.stdout < '5')
+    - hotfix_install.reboot_required
   tags: WMF


### PR DESCRIPTION
ref: #1239 #1255 

`hotfix_install.reboot_required` was undefined when the Powershell version was already 5, as the proceeding task didn't run. 