### PR TITLE
UnixPB: add JDK11 to list of JDKs to install

### DIFF
--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/main.yml
@@ -54,6 +54,9 @@
     - role: adoptopenjdk_install  # JDK11 Build Bootstrap
       jdk_version: 10
       tags: build_tools
+    - role: adoptopenjdk_install
+      jdk_version: 11
+      tags: build_tools
     - role: adoptopenjdk_install  # JDK13 Build Bootstrap
       jdk_version: 12
       tags: build_tools


### PR DESCRIPTION
fixes: #1251 

Add JDK-11 to the list of JDKs to install for the Unix PB, as requested by @sxa555.