### PR TITLE
pbTest: set correct params running buildJDKWin w/JDK8

### DIFF
--- a/ansible/pbTestScripts/buildJDKWin.sh
+++ b/ansible/pbTestScripts/buildJDKWin.sh
@@ -116,8 +116,6 @@ export PATH=/usr/bin/:$PATH
 export TARGET_OS=windows
 export ARCHITECTURE=x64
 export JAVA_HOME=/cygdrive/c/openjdk/jdk-8
-export JDK8_BOOT_DIR=/cygdrive/c/openjdk/jdk-8
-export JDK_BOOT_DIR=/cygdrive/c/openjdk/jdk-8
 GIT_URL=https://github.com/adoptopenjdk/openjdk-build
 CLEAN_WORKSPACE=false
 
@@ -129,7 +127,6 @@ echo "DEBUG:
 	JAVA_TO_BUILD=$JAVA_TO_BUILD
         VARIANT=$VARIANT
         JDK_BOOT_DIR=$JDK_BOOT_DIR
-        JDK8_BOOT_DIR=$JDK8_BOOT_DIR
         JAVA_HOME=$JAVA_HOME
         WORKSPACE=$WORKSPACE
         GIT_URL=$GIT_URL"	

--- a/ansible/pbTestScripts/buildJDKWin.sh
+++ b/ansible/pbTestScripts/buildJDKWin.sh
@@ -63,25 +63,25 @@ checkJDKVersion() {
         case "$jdk" in
                 "jdk8u" | "jdk8" | "8" | "8u" )
                         JAVA_TO_BUILD="jdk8u";
-			JDK_BOOT_DIR=/cygdrive/c/openjdk/jdk7;;
+                        export JDK_BOOT_DIR=/cygdrive/c/openjdk/jdk7;;
                 "jdk9u" | "jdk9" | "9" | "9u" )
                         JAVA_TO_BUILD="jdk9u";
-			JDK_BOOT_DIR=/cygdrive/c/openjdk/jdk-8;;
+                        export JDK_BOOT_DIR=/cygdrive/c/openjdk/jdk-8;;
                 "jdk10u" | "jdk10" | "10" | "10u" )
                         JAVA_TO_BUILD="jdk10u";
-			JDK_BOOT_DIR=/cygdrive/c/openjdk/jdk-10;;
+                        export JDK_BOOT_DIR=/cygdrive/c/openjdk/jdk-10;;
                 "jdk11u" | "jdk11" | "11" | "11u" )
                         JAVA_TO_BUILD="jdk11u";
-			JDK_BOOT_DIR=/cygdrive/c/openjdk/jdk-10;;
+                        export JDK_BOOT_DIR=/cygdrive/c/openjdk/jdk-10;;
                 "jdk12u" | "jdk12" | "12" | "12u" )
                         JAVA_TO_BUILD="jdk12u";
-			JDK_BOOT_DIR=/cygdrive/c/openjdk/jdk-12;;
+                        export JDK_BOOT_DIR=/cygdrive/c/openjdk/jdk-12;;
                 "jdk13u" | "jdk13" | "13" | "13u" )
                         JAVA_TO_BUILD="jdk13u";
-			JDK_BOOT_DIR=/cygdrive/c/openjdk/jdk-12;;
+                        export JDK_BOOT_DIR=/cygdrive/c/openjdk/jdk-12;;
                 "jdk14u" | "jdk14" | "14" | "14u" )
                         JAVA_TO_BUILD="jdk14";
-			JDK_BOOT_DIR=/cygdrive/c/openjdk/jdk-13;;
+                        export JDK_BOOT_DIR=/cygdrive/c/openjdk/jdk-13;;
                 *)
                         echo "Not a valid JDK Version" ; showJDKVersions; exit 1;;
         esac
@@ -115,19 +115,21 @@ export VARIANT=openj9
 export PATH=/usr/bin/:$PATH
 export TARGET_OS=windows
 export ARCHITECTURE=x64
+export JAVA_HOME=/cygdrive/c/openjdk/jdk-8
+export JDK8_BOOT_DIR=/cygdrive/c/openjdk/jdk-8
 export JDK_BOOT_DIR=/cygdrive/c/openjdk/jdk-8
 GIT_URL=https://github.com/adoptopenjdk/openjdk-build
 CLEAN_WORKSPACE=false
 
 processArgs $*
 cloneRepo
-export JAVA_HOME=/cygdrive/c/openjdk/jdk-8
 echo "DEBUG:
 	TARGET_OS=$TARGET_OS
 	ARCHITECTURE=$ARCHITECTURE
 	JAVA_TO_BUILD=$JAVA_TO_BUILD
         VARIANT=$VARIANT
         JDK_BOOT_DIR=$JDK_BOOT_DIR
+        JDK8_BOOT_DIR=$JDK8_BOOT_DIR
         JAVA_HOME=$JAVA_HOME
         WORKSPACE=$WORKSPACE
         GIT_URL=$GIT_URL"	

--- a/ansible/pbTestScripts/buildJDKWin.sh
+++ b/ansible/pbTestScripts/buildJDKWin.sh
@@ -37,7 +37,7 @@ usage() {
 	Options:
 		--version | -v		Specify the JDK version to build
 		--URL | -u		Specify the github URL to clone openjdk-build from
-		--openj9 | -j9		Builds openJ9, instead of hotspot
+		--hotspot | -hs		Builds hotspot, instead of openj9 (openj9 by default)
 		--clean-workspace | -c 	Removes old openjdk-build folder before cloning
 		--help | -h		Shows this message
 
@@ -116,7 +116,6 @@ export PATH=/usr/bin/:$PATH
 export TARGET_OS=windows
 export ARCHITECTURE=x64
 export JAVA_HOME=/cygdrive/c/openjdk/jdk-8
-export JDK8_BOOT_DIR=/cygdrive/c/openjdk/jdk-8
 GIT_URL=https://github.com/adoptopenjdk/openjdk-build
 CLEAN_WORKSPACE=false
 

--- a/ansible/pbTestScripts/buildJDKWin.sh
+++ b/ansible/pbTestScripts/buildJDKWin.sh
@@ -116,20 +116,23 @@ export PATH=/usr/bin/:$PATH
 export TARGET_OS=windows
 export ARCHITECTURE=x64
 export JAVA_HOME=/cygdrive/c/openjdk/jdk-8
+export JDK8_BOOT_DIR=/cygdrive/c/openjdk/jdk-8
 GIT_URL=https://github.com/adoptopenjdk/openjdk-build
 CLEAN_WORKSPACE=false
 
 processArgs $*
 cloneRepo
+export FILENAME="${JAVA_TO_BUILD}_${VARIANT}_${ARCHITECTURE}"
 echo "DEBUG:
 	TARGET_OS=$TARGET_OS
 	ARCHITECTURE=$ARCHITECTURE
 	JAVA_TO_BUILD=$JAVA_TO_BUILD
-        VARIANT=$VARIANT
-        JDK_BOOT_DIR=$JDK_BOOT_DIR
-        JAVA_HOME=$JAVA_HOME
-        WORKSPACE=$WORKSPACE
-        GIT_URL=$GIT_URL"	
+	VARIANT=$VARIANT
+	JDK_BOOT_DIR=$JDK_BOOT_DIR
+	JAVA_HOME=$JAVA_HOME
+	WORKSPACE=$WORKSPACE
+	GIT_URL=$GIT_URL
+	FILENAME=$FILENAME"
 
 echo "Running $WORKSPACE/openjdk-build/build-farm/make-adopt-build-farm.sh"
 $WORKSPACE/openjdk-build/build-farm/make-adopt-build-farm.sh

--- a/ansible/pbTestScripts/buildJDKWin.sh
+++ b/ansible/pbTestScripts/buildJDKWin.sh
@@ -22,8 +22,8 @@ processArgs() {
 
 	checkJDKVersion $JAVA_TO_BUILD
 	if [ -z "${WORKSPACE:-}" ]; then
-        	echo "WORKSPACE not found, setting it as to C:/ drive"
-        	WORKSPACE=C:/
+        	echo "WORKSPACE not found, setting it to /tmp"
+        	WORKSPACE=/tmp/
 	fi
 	if [ $CLEAN_WORKSPACE == true ]; then
 		echo "Cleaning workspace"

--- a/ansible/pbTestScripts/testJDKWin.sh
+++ b/ansible/pbTestScripts/testJDKWin.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 
-# Script to execute the MachineInfo test on the previously built JDK.
+# Script to execute System tests on the previously built JDK.
 
-mv /tmp/openjdk-build/workspace/build/src/build/*/images/jdk* $HOME
+mv /cygdrive/c/tmp/workspace/build/src/build/*/images/jdk* $HOME
 # Ensures to set it to the JDK, not JRE or different images
 export TEST_JDK_HOME=C:/cygwin64$(find ~ -maxdepth 1 -type d -name "*jdk*"|grep -v ".*jre"| grep -v ".*-image")
 

--- a/ansible/pbTestScripts/testJDKWin.sh
+++ b/ansible/pbTestScripts/testJDKWin.sh
@@ -2,7 +2,7 @@
 
 # Script to execute the MachineInfo test on the previously built JDK.
 
-mv /cygdrive/c/workspace/build/src/build/*/images/jdk* $HOME
+mv /tmp/openjdk-build/workspace/build/src/build/*/images/jdk* $HOME
 # Ensures to set it to the JDK, not JRE or different images
 export TEST_JDK_HOME=C:/cygwin64$(find ~ -maxdepth 1 -type d -name "*jdk*"|grep -v ".*jre"| grep -v ".*-image")
 

--- a/ansible/pbTestScripts/vagrantPlaybookCheck.sh
+++ b/ansible/pbTestScripts/vagrantPlaybookCheck.sh
@@ -260,7 +260,7 @@ startVMPlaybookWin()
 		vagrant halt --force && vagrant up
 		# Runs the build script via ansible, as vagrant powershell gives error messages that ansible doesn't. 
         	# See: https://github.com/AdoptOpenJDK/openjdk-infrastructure/pull/942#issuecomment-539946564
-		ansible all -i playbooks/AdoptOpenJDK_Windows_Playbook/hosts.win -u vagrant -m raw -a "Start-Process powershell.exe -Verb runAs; cd C:/; sh C:/vagrant/pbTestScripts/buildJDKWin.sh $buildURL $jdkToBuild $buildHotspot"
+		ansible all -i playbooks/AdoptOpenJDK_Windows_Playbook/hosts.win -u vagrant -m raw -a "Start-Process powershell.exe -Verb runAs; cd C:/tmp; sh C:/vagrant/pbTestScripts/buildJDKWin.sh $buildURL $jdkToBuild $buildHotspot"
 		echo The build finished at : `date +%T`
 		if [[ "$runTest" = true ]]; then
 			vagrant halt --force && vagrant up


### PR DESCRIPTION
When running VagrantPlaybookCheck Jenkins job and building JDK8, the Windows VM will fail as it attempts to run Gradle with jdk-7, as that was `JDK_BOOT_DIR` was set to. I've found that setting the `JDK8_BOOT_DIR` variable will run Gradle w/ JDK8, but keep the `JDK_BOOT_DIR` variable at jdk-7, thereby simulating what we do on our Jenkins build jobs.