### PR TITLE
inventory: Add ex-build Ubuntu/s390x machine to docker group

### DIFF
--- a/ansible/inventory.yml
+++ b/ansible/inventory.yml
@@ -82,6 +82,9 @@ hosts:
       - godaddy:
           ubuntu1604-x64-1: {ip: 160.153.235.114, user: adoptopenjdk}
 
+      - marist:
+          ubuntu1603-s390x-1: {ip: 148.100.113.58, user: ubuntu}
+
       - packet:
           ubuntu1604-armv8-1: {ip: 147.75.77.146}
 


### PR DESCRIPTION
Found a machine that was offline but still available to us, so I've cleared it up (full of old docker images) and have connected it back into jenkins to increase capacity

Signed-off-by: Stewart Addison <sxa@uk.ibm.com>