### PR TITLE
add gnu-sed to macOS playbook

### DIFF
--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/vars/MacOSX.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/vars/MacOSX.yml
@@ -10,6 +10,7 @@ Build_Tool_Packages:
   - bash # OpenJ9 needs bash v4 or later
   - ccache
   - coreutils
+  - gnu-sed
   - gnu-tar
   - nasm # openj9 jdk13+
   - wget
@@ -21,7 +22,6 @@ Build_Tool_Casks:
 Test_Tool_Packages:
   - mercurial
   - pulseaudio
-  - p7zip # required for the codesign job to extract jmods and because unzip can't handle pkzip file-created files
 
 Test_Tool_Casks:
   - xquartz


### PR DESCRIPTION
closes: https://github.com/AdoptOpenJDK/openjdk-infrastructure/issues/1271

Also removes `p7zip` as it's no longer needed