### PR TITLE
pbTests: Force vagrant halt for Windows runs

### DIFF
--- a/ansible/pbTestScripts/vagrantPlaybookCheck.sh
+++ b/ansible/pbTestScripts/vagrantPlaybookCheck.sh
@@ -44,7 +44,7 @@ processArgs()
 			"--new-vagrant-files" | "-nv" )
 				newVagrantFiles=true;;
 			"--skip-more" | "-sm" )
-				skipFullSetup=",nvidia_cuda_toolkit,MSVS_2010,VS2010_SP1";;
+				skipFullSetup=",nvidia_cuda_toolkit,MSVS_2010,MSVS_2017";;
 			"--build-repo" | "-br" )
 				buildURL="--URL $1"; shift;;
 			"--build-hotspot" )


### PR DESCRIPTION
Small changes I've been meaning to get round to.
1) Remove `SLES-12` to run `vagrant rsync-back`, as we no longer have a SLES vagrantfile
2) Remove MSVS_2017 from 'fastmode', as it's required for Window's OpenSSL role now, and OpenJ9 requires MSVS_2017 for some (if not all) builds.
  - Add VS2012_SP1 to fastmode as MSVS_2010 is required to install it, but is ignored when fastmode is specified.
3) Replace `vagrant reload` for `vagrant halt --force && vagrant up` and add `--force` on standalone `vagrant halt`s. This is due to a bug where the Windows Vagrant VM hangs when `vagrant halt` tries to shutdown the VM 'gracefully'. 
4) Added a note explaining why the VM needs to be restarted via Vagrant