### PR TITLE
UnixPB: Correct gcc_7 conditions

### DIFF
--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/gcc_7/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/gcc_7/tasks/main.yml
@@ -21,7 +21,7 @@
     mode: 0644
   when:
     - ansible_distribution == "RedHat" or ansible_distribution == "CentOS" or ansible_distribution == "openSUSE"
-    - ansible_architecture != "CentOS" and ansible_architecture != "x86-64"
+    - ansible_architecture != "CentOS" and ansible_architecture != "x86_64"
     - gcc7_installed.rc != 0
   tags: gcc-7
 
@@ -32,7 +32,7 @@
     copy: False
   when:
     - ansible_distribution == "RedHat" or ansible_distribution == "CentOS" or ansible_distribution == "openSUSE"
-    - ansible_architecture != "CentOS" and ansible_architecture != "x86-64"
+    - ansible_architecture != "CentOS" and ansible_architecture != "x86_64"
     - gcc7_installed.rc != 0
   tags: gcc-7
 
@@ -42,6 +42,6 @@
     state: absent
   when:
     - ansible_distribution == "RedHat" or ansible_distribution == "CentOS" or ansible_distribution == "openSUSE"
-    - ansible_architecture != "CentOS" and ansible_architecture != "x86-64"
+    - ansible_architecture != "CentOS" and ansible_architecture != "x86_64"
     - gcc7_installed.rc != 0
   tags: gcc-7

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/gcc_7/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/gcc_7/tasks/main.yml
@@ -11,7 +11,7 @@
   tags: gcc-7
   when: ansible_distribution == "RedHat" or ansible_distribution == "CentOS" or ansible_distribution == "openSUSE"
 
-# Installation on CentOS x86_64 will be handled via the scl repo in the Common CentOS playbook
+  # Unable to check the checksum of the binary as it'll be different for each architecture's tar.xz file
 
 - name: Download AdoptOpenJDK gcc-7.5.0 binary
   get_url:
@@ -21,7 +21,6 @@
     mode: 0644
   when:
     - ansible_distribution == "RedHat" or ansible_distribution == "CentOS" or ansible_distribution == "openSUSE"
-    - ansible_architecture != "CentOS" and ansible_architecture != "x86_64"
     - gcc7_installed.rc != 0
   tags: gcc-7
 
@@ -32,7 +31,6 @@
     copy: False
   when:
     - ansible_distribution == "RedHat" or ansible_distribution == "CentOS" or ansible_distribution == "openSUSE"
-    - ansible_architecture != "CentOS" and ansible_architecture != "x86_64"
     - gcc7_installed.rc != 0
   tags: gcc-7
 
@@ -42,6 +40,5 @@
     state: absent
   when:
     - ansible_distribution == "RedHat" or ansible_distribution == "CentOS" or ansible_distribution == "openSUSE"
-    - ansible_architecture != "CentOS" and ansible_architecture != "x86_64"
     - gcc7_installed.rc != 0
   tags: gcc-7


### PR DESCRIPTION
Noticed the discrepancy awhile ago. I'm going to try running the change through the `vagrantPlaybookCheck` job as I'm not sure the condition is necessary required anymore. As can be seen from the below link, the gcc_7 task is run despite it not being intended to, but the build still succeeded: https://ci.adoptopenjdk.net/view/Tooling/job/VagrantPlaybookCheck/OS=CentOS6,label=infra-vagrant-1/464/consoleFull

It's been succeeding in CentOS7 and CentOS8, so it's worth testing them too. 