### PR TITLE
pbTests: Change Fast-mode to change depending on other parameters

### DIFF
--- a/ansible/pbTestScripts/vagrantPlaybookCheck.sh
+++ b/ansible/pbTestScripts/vagrantPlaybookCheck.sh
@@ -115,7 +115,7 @@ checkVars()
 					skipFullSetup="$skipFullSetup,MSVS_2010,VS2010_SP1"
 				fi
 				;;
-                	"jdk11" | "jdk13" | "jdk14" )
+                	*)
 				skipFullSetup="$skipFullSetup,MSVS_2010,VS2010_SP1,MSVS_2013";;
 		esac
 	fi

--- a/ansible/pbTestScripts/vagrantPlaybookCheck.sh
+++ b/ansible/pbTestScripts/vagrantPlaybookCheck.sh
@@ -12,6 +12,7 @@ runTest=false
 vmHalt=true
 cleanWorkspace=false
 newVagrantFiles=false
+fastMode=false
 skipFullSetup=''
 jdkToBuild=''
 buildHotspot=''
@@ -30,7 +31,7 @@ processArgs()
 			"--build" | "-b" )
 				testNativeBuild=true;;
 			"--JDK-Version" | "-jdk" )
-				jdkToBuild="--version $1"; shift;;
+				jdkToBuild="$1"; shift;;
 			"--retainVM" | "-r" )
 				retainVM=true;;
 			"--URL" | "-u" )
@@ -44,7 +45,7 @@ processArgs()
 			"--new-vagrant-files" | "-nv" )
 				newVagrantFiles=true;;
 			"--skip-more" | "-sm" )
-				skipFullSetup=",nvidia_cuda_toolkit,MSVS_2010,MSVS_2017";;
+				fastMode=true;;
 			"--build-repo" | "-br" )
 				buildURL="--URL $1"; shift;;
 			"--build-hotspot" )
@@ -105,6 +106,20 @@ checkVars()
                 echo "Can't find vagrant-rsync-back plugin, installing . . ."
                 vagrant plugin install vagrant-rsync-back
         fi
+	if [[ "$fastMode" == true ]]; then
+		skipFullSetup=",nvidia_cuda_toolkit"
+		case "$jdkToBuild" in
+			"jdk8" )
+				skipFullSetup="$skipFullSetup,MSVS_2017";
+				if [ "$buildHotspot" != "" ]; then
+					skipFullSetup="$skipFullSetup,MSVS_2010,VS2010_SP1"
+				fi
+				;;
+                	"jdk11" | "jdk13" | "jdk14" )
+				skipFullSetup="$skipFullSetup,MSVS_2010,VS2010_SP1,MSVS_2013";;
+		esac
+	fi
+	jdkToBuild="--version $jdkToBuild"
 }
 
 checkVagrantOS()

--- a/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/roles/OpenSSL/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/roles/OpenSSL/tasks/main.yml
@@ -43,7 +43,9 @@
     chdir: 'C:\Program Files (x86)\Microsoft Visual Studio 12.0\Common7\Tools'
     executable: cmd
   when: (not openssl32_installed.stat.exists)
-  tags: openssl
+  tags:
+    - openssl
+    - MSVS_2013
 
 - name: Install OpenSSL-1.1.1e 64-bit (VS2013)
   win_shell: set PATH=C:\Strawberry\perl\bin;C:\openjdk\nasm-2.13.03;%PATH% && .\vcvarsall.bat AMD64 && cd C:\temp\openssl-1.1.1e && perl C:\temp\openssl-1.1.1e\Configure VC-WIN64A --prefix=C:\openjdk\OpenSSL-1.1.1e-x86_64-VS2013 && nmake install > C:\temp\openssl64.log && nmake -f makefile clean
@@ -51,7 +53,9 @@
     chdir: 'C:\Program Files (x86)\Microsoft Visual Studio 12.0\VC'
     executable: cmd
   when: (not openssl64_vs2013_installed.stat.exists)
-  tags: openssl
+  tags:
+    - openssl
+    - MSVS_2013
 
 - name: Install OpenSSL-1.1.1e 64-bit (VS2017)
   win_shell: set PATH=C:\Strawberry\perl\bin;C:\openjdk\nasm-2.13.03;%PATH% && .\vcvarsall.bat AMD64 && cd C:\temp\openssl-1.1.1e && perl C:\temp\openssl-1.1.1e\Configure VC-WIN64A --prefix=C:\openjdk\OpenSSL-1.1.1e-x86_64-VS2017 && nmake install > C:\temp\openssl64.log && nmake -f makefile clean
@@ -59,7 +63,9 @@
     chdir: 'C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\VC\Auxiliary\Build'
     executable: cmd
   when: (not openssl64_vs2017_installed.stat.exists)
-  tags: openssl
+  tags:
+    - openssl
+    - MSVS_2017
 
 - name: Cleanup OpenSSL source files
   win_file:

--- a/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/roles/shortNames/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/roles/shortNames/tasks/main.yml
@@ -29,5 +29,6 @@
     - {name: "Microsoft Visual Studio 12.0", shortname: "MICROS~1.0"}
     - {name: "Microsoft Visual Studio 14.0", shortname: "MI0E91~1.0"}
     - {name: "Windows Kits", shortname: "WINDOW~4"}
+  when: (not enabled_shortnames.stdout)
   tags:
     - shortnames


### PR DESCRIPTION
As this script is mainly for the `vagrantPlaybookCheck` Jenkins job, I've only catered for the parameters that are able to be entered in that Jenkins job. (i.e. put in the cases for JDK8, 11, 13 and 14)
Fast-mode now gives the option for some roles to be skipped (mainly in the case of Windows), depending on what JDK is being built and it's variant, so that it only installs what's required to build that specific JDK.

ref: https://github.com/AdoptOpenJDK/openjdk-infrastructure/pull/1273#pullrequestreview-392833354

When given a chance, I'll put this through the VagrantPlaybookCheck job to ensure it works- I'll keep the [wip] tag until I can get a successful build on at least JDK8 and JDK11