### PR TITLE
inventory: Renumber marist zlinux build machines after handing two back

### DIFF
--- a/ansible/inventory.yml
+++ b/ansible/inventory.yml
@@ -48,9 +48,7 @@ hosts:
 
       - marist:
           rhel77-s390x-1: {ip: 148.100.86.102, user: linux1}
-          rhel77-s390x-2: {ip: 148.100.86.218, user: linux1}
-          rhel77-s390x-3: {ip: 148.100.244.180, user: linux1}
-          rhel77-s390x-4: {ip: 148.100.245.197, user: linux1}
+          rhel77-s390x-2: {ip: 148.100.245.197, user: linux1}
           zos21-s390x-1: {ip: 148.100.36.136, user: OPEN1}
           zos21-s390x-2: {ip: 148.100.36.137, user: OPEN1}
 


### PR DESCRIPTION
Two machines were created in order to check out solutions to https://github.com/AdoptOpenJDK/openjdk-infrastructure/issues/1154 - I gave back the "middle two" in order to retain one we had created with 16Gb of RAM. That was `-4` and is now `-2` after removing the middle two

Signed-off-by: Stewart Addison <sxa@uk.ibm.com>