### PR TITLE
unixPB: Add openj9 libraries, remove self-built zlib for OpenSUSE

### DIFF
--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/tasks/openSUSE.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/tasks/openSUSE.yml
@@ -71,50 +71,6 @@
     - ansible_architecture == "x86_64"
   tags: build_tools
 
-########
-# zlib #
-########
-- name: Check if zlib is already installed
-  stat:
-    path: /usr/local/lib/libz.so
-  register: zlib_status
-  tags: zlib
-
-- name: Download Zlib
-  get_url:
-    url: http://www.zlib.net/zlib-1.2.11.tar.gz
-    dest: /tmp/zlib-1.2.11.tar.gz
-    mode: 0440
-    checksum: sha256:c3e5e9fdd5004dcb542feda5ee4f0ff0744628baf8ed2dd5d66f8ca1197cb1a1
-  when:
-    - zlib_status.stat.islnk is not defined
-  tags: zlib
-
-- name: Extract Zlib
-  unarchive:
-    src: /tmp/zlib-1.2.11.tar.gz
-    dest: /tmp
-    copy: False
-  when:
-    - zlib_status.stat.islnk is not defined
-  tags: zlib
-
-- name: Running ./configure & make for Zlib on Linux x86-64 or PPC64LE
-  shell: cd /tmp/zlib-1.2.11 && ./configure && make -j {{ ansible_processor_vcpus }} && make install
-  become: yes
-  when:
-    - ansible_architecture != "s390x"
-    - zlib_status.stat.islnk is not defined
-  tags: zlib
-
-- name: Running ./configure & make for Zlib on Linux s390x
-  shell: cd /tmp/zlib-1.2.11 && ./configure && make -j {{ ansible_processor_cores }} && make install
-  become: yes
-  when:
-    - ansible_architecture == "s390x"
-    - zlib_status.stat.islnk is not defined
-  tags: zlib
-
 #################
 # xorg Packages #
 #################

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/vars/openSUSE.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/vars/openSUSE.yml
@@ -25,6 +25,13 @@ Build_Tool_Packages:
   - libelf0
   - libelf1
   - libnuma-devel
+  - libpng15-devel
+  - libXext-devel
+  - libXi-devel
+  - libXrandr-devel
+  - libXrender-devel
+  - libXt-devel
+  - libXtst-devel
   - make
   - ntp
   - numactl


### PR DESCRIPTION
Adding all libraries that were in `Common/vars/centos.yml`, and removing the self built `zlib` as it was causing issues with finding `libpng` in the build: 
https://ci.adoptopenjdk.net/view/Tooling/job/VagrantPlaybookCheck/507/OS=SUSE12,label=infra-vagrant-1/console

VPC Run: https://ci.adoptopenjdk.net/view/Tooling/job/VagrantPlaybookCheck/515/