### PR TITLE
UnixPB:IPv6

### DIFF
--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/main.yml
@@ -70,3 +70,4 @@
     - Clean_Up
     - Security
     - Vendor
+    - IPv6

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/IPv6/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/IPv6/tasks/main.yml
@@ -1,0 +1,23 @@
+##############################
+# Enable IPv6 in sysctl.conf #
+##############################
+
+- sysctl:
+    name: net.ipv6.conf.all.disable_ipv6
+    value: '0'
+    sysctl_set: yes
+    state: present
+    reload: no
+  when:
+    - ansible_distribution == "RedHat"
+  tags: IPv6_sysctl
+
+- sysctl:
+    name: net.ipv6.conf.default.disable_ipv6
+    value: '0'
+    sysctl_set: yes
+    state: present
+    reload: yes
+  when:
+    - ansible_distribution == "RedHat"
+  tags: IPv6_sysctl

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/IPv6/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/IPv6/tasks/main.yml
@@ -2,7 +2,8 @@
 # Enable IPv6 in sysctl.conf #
 ##############################
 
-- sysctl:
+- name: Setting net.ipv6.conf.all.disable_ipv6 = 0
+  sysctl:
     name: net.ipv6.conf.all.disable_ipv6
     value: '0'
     sysctl_set: yes
@@ -14,7 +15,8 @@
     - IPv6_sysctl
     - adoptopenjdk
 
-- sysctl:
+- name: Setting net.ipv6.conf.default.disable_ipv6 = 0
+  sysctl:
     name: net.ipv6.conf.default.disable_ipv6
     value: '0'
     sysctl_set: yes

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/IPv6/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/IPv6/tasks/main.yml
@@ -9,8 +9,10 @@
     state: present
     reload: no
   when:
-    - ansible_distribution == "RedHat"
-  tags: IPv6_sysctl
+    - (ansible_distribution == "RedHat" or ansible_distribution == "CentOS")
+  tags:
+    - IPv6_sysctl
+    - adoptopenjdk
 
 - sysctl:
     name: net.ipv6.conf.default.disable_ipv6
@@ -19,5 +21,8 @@
     state: present
     reload: yes
   when:
-    - ansible_distribution == "RedHat"
-  tags: IPv6_sysctl
+    - (ansible_distribution == "RedHat" or ansible_distribution == "CentOS")
+  tags:
+    - IPv6_sysctl
+    - adoptopenjdk
+

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/IPv6/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/IPv6/tasks/main.yml
@@ -25,4 +25,3 @@
   tags:
     - IPv6_sysctl
     - adoptopenjdk
-


### PR DESCRIPTION
Added IPv6 Role

Enables IPv6 via sysctl.conf on RHEL systems.

Allows for IPv6 testing.

Pav.Salimon@ibm.com