### PR TITLE
pbTests: VPC.sh: destroy only the correct OS VM

### DIFF
--- a/ansible/pbTestScripts/vagrantPlaybookCheck.sh
+++ b/ansible/pbTestScripts/vagrantPlaybookCheck.sh
@@ -287,7 +287,7 @@ destroyVM()
 {
 	local OS=$1
 	echo "Destroying the $OS Machine"
-	vagrant global-status --prune | awk "/${folderName}-${branchName}/ { print \$1 }" | xargs vagrant destroy -f	
+	vagrant global-status --prune | grep $OS | awk "/${folderName}-${branchName}/ { print \$1 }" | xargs vagrant destroy -f	
 }
 
 processArgs $*


### PR DESCRIPTION
ref : https://ci.adoptopenjdk.net/view/Tooling/job/VagrantPlaybookCheck/OS=CentOS8,label=infra-vagrant-1/523/console

I noticed at the end of this run, that the function was destroying all of the currently running VMs, not just the one that had finished. Addition of `grep $OS` will stop this.