### PR TITLE
pbTests: Alter VPC to use ssh/WinRM to start build/test scripts

### DIFF
--- a/ansible/Vagrantfile.Win2012
+++ b/ansible/Vagrantfile.Win2012
@@ -20,6 +20,8 @@ if ([long]$currentDiskSize -lt $diskSizeBoundary) {
 }else {
         echo "Disk is already at max size"
 }
+Start-Process cmd -Verb runAs
+winrm set winrm/config/service '@{AllowUnencrypted="true"}'
 SCRIPT
 
 # 2 = version of configuration file for Vagrant 1.1+ leading up to 2.0.x

--- a/ansible/pbTestScripts/startScriptWin.py
+++ b/ansible/pbTestScripts/startScriptWin.py
@@ -1,8 +1,8 @@
 #!/usr/bin/python
 
 import sys
-import winrm
 import getopt
+import winrm
 
 def usage():
     print("Usage: %s -i <VM_IPAddress> -a <buildJDKWin_arguments>" % sys.argv[0])
@@ -16,10 +16,10 @@ def run_winrm(vmIP, buildArgs, mode):
         cmd_str += "buildJDKWin.sh "
     else:
         cmd_str += "testJDKWin.sh "
-    command_string += buildArgs
-    print("Running :      %s" %command_string)
+    cmd_str += buildArgs
+    print("Running :      %s" %cmd_str)
     session = winrm.Session(str(vmIP), auth=('vagrant', 'vagrant'))
-    session.run_ps(command_string, sys.stdout, sys.stderr)
+    session.run_ps(cmd_str, sys.stdout, sys.stderr)
 
 def main(argv):
     # mode refers to whether its running a build or a test

--- a/ansible/pbTestScripts/startScriptWin.py
+++ b/ansible/pbTestScripts/startScriptWin.py
@@ -1,0 +1,53 @@
+#!/usr/bin/python
+
+import sys
+import winrm
+import getopt
+
+def usage():
+    print("Usage: %s -i <VM_IPAddress> -a <buildJDKWin_arguments>" % sys.argv[0])
+    print("    Use '-b' to run a build or '-t' to run a test")
+    sys.exit(1)
+
+def run_winrm(vmIP, buildArgs, mode):
+    cmd_str = "Start-Process powershell.exe -Verb runAs; cd C:/tmp; sh C:/vagrant/pbTestScripts/"
+    print(mode)
+    if mode == 1:
+        cmd_str += "buildJDKWin.sh "
+    else:
+        cmd_str += "testJDKWin.sh "
+    command_string += buildArgs
+    print("Running :      %s" %command_string)
+    session = winrm.Session(str(vmIP), auth=('vagrant', 'vagrant'))
+    session.run_ps(command_string, sys.stdout, sys.stderr)
+
+def main(argv):
+    # mode refers to whether its running a build or a test
+    mode = 1
+    print("Running python script")
+    inputArgs = ""
+    ipAddress = ""
+    try:
+        opts, args = getopt.getopt(argv, "ha:i:bt")
+    except getopt.GetoptError as error:
+        print(str(error))
+        usage()
+
+    for current_option, current_value in opts:
+        if current_option == '-a':
+            inputArgs = current_value
+        elif current_option == '-i':
+            ipAddress = current_value
+        elif current_option == '-h':
+            usage()
+        elif current_option == '-b':
+            mode = 1
+        elif current_option == '-t':
+            mode = 2
+
+    print(" This is what is in the 'inputArgs' var: %s " %str(inputArgs))
+    print(" This is what is in the 'ipAddress' var: %s " %str(ipAddress))
+    run_winrm(str(ipAddress), str(inputArgs), mode)
+
+if __name__ == "__main__": # Execute only if run as a script
+    main(sys.argv[1:])

--- a/ansible/pbTestScripts/vagrantPlaybookCheck.sh
+++ b/ansible/pbTestScripts/vagrantPlaybookCheck.sh
@@ -230,10 +230,10 @@ startVMPlaybook()
 	local pb_failed=$?
 	cd $WORKSPACE/adoptopenjdkPBTests/$folderName-$branchName/ansible
 	if [[ "$testNativeBuild" = true && "$pb_failed" == 0 ]]; then
-		ansible all -i playbooks/AdoptOpenJDK_Unix_Playbook/hosts.unx -u vagrant -m raw -a "cd /vagrant/pbTestScripts && ./buildJDK.sh $buildURL $jdkToBuild $buildHotspot"
+		ssh -i $PWD/id_rsa vagrant@$vagrantIP "cd /vagrant/pbTestScripts && ./buildJDK.sh $buildURL $jdkToBuild $buildHotspot"
 		echo The build finished at : `date +%T`
 		if [[ "$runTest" = true ]]; then
-	        	ansible all -i playbooks/AdoptOpenJDK_Unix_Playbook/hosts.unx -u vagrant -m raw -a "cd /vagrant/pbTestScripts && ./testJDK.sh"
+	        	ssh -i $PWD/id_rsa vagrant@$vagrantIP "cd /vagrant/pbTestScripts && ./testJDK.sh"
 			echo The test finished at : `date +%T`
 		fi
 	fi
@@ -275,12 +275,12 @@ startVMPlaybookWin()
 		vagrant halt --force && vagrant up
 		# Runs the build script via ansible, as vagrant powershell gives error messages that ansible doesn't. 
         	# See: https://github.com/AdoptOpenJDK/openjdk-infrastructure/pull/942#issuecomment-539946564
-		ansible all -i playbooks/AdoptOpenJDK_Windows_Playbook/hosts.win -u vagrant -m raw -a "Start-Process powershell.exe -Verb runAs; cd C:/tmp; sh C:/vagrant/pbTestScripts/buildJDKWin.sh $buildURL $jdkToBuild $buildHotspot"
+		python pbTestScripts/startScriptWin.py -i $(cat playbooks/AdoptOpenJDK_Windows_Playbook/hosts.win) -a "$buildURL $jdkToBuild $buildHotspot" -b
 		echo The build finished at : `date +%T`
 		if [[ "$runTest" = true ]]; then
 			vagrant halt --force && vagrant up
 			# Runs a script on the VM to test the built JDK
-			ansible all -i playbooks/AdoptOpenJDK_Windows_Playbook/hosts.win -u vagrant -m raw -a "sh C:/vagrant/pbTestScripts/testJDKWin.sh"
+			python pbTestScripts/startScriptWin.py -i $(cat playbooks/AdoptOpenJDK_Windows_Playbook/hosts.win) -t
 			echo The test finished at : `date +%T`
 		fi
 	fi


### PR DESCRIPTION
Fixes: #1296 
ref: https://github.com/Willsparker/pywinrm/pull/1

Switching to using ssh/winrm as we want to have live stdout from the build/tests as they run on the `vagrantPlaybookCheck` Jenkins job.

Windows:
- [x] Fork pywinrm & put in old PR to allow live stdout/stderr
- [x] Install patched version of `pywinrm` on `infra-vagrant-1`
- [x] Write python script to call from `vagrantPlaybookCheck.sh` for Windows
- [x] Add command into Windows vagrantfile ( `winrm set winrm/config/service '@{AllowUnencrypted="true"}'`
- [x] Remove `ansible all` command from `VPC.sh`, replace with calling python script

Linux: 
- [x] Remove `ansible all` command for builds/tests on linux and replace for ssh commands

Testing:
- [x] Get a passing Linux / FreeBSD `VPC` run
- [ ] Get a passing Windows `VPC` run