### PR TITLE
Replace -s to -b in ansible-playbook command-line examples

### DIFF
--- a/FAQ.md
+++ b/FAQ.md
@@ -42,7 +42,7 @@ repository, create an `inventory` text file with the word `localhost`
 and run this from the `ansible` directory:
 
 ```
-ansible-playbook -i inventory_file --skip-tags adoptopenjdk,jenkins_user playbooks/AdoptOpenJDK_Unix_Playbook/main.yml
+ansible-playbook -b -i inventory_file --skip-tags adoptopenjdk,jenkins_user playbooks/AdoptOpenJDK_Unix_Playbook/main.yml
 ```
 
 NOTE: For windows machines you cannot use this method as ansible does not

--- a/ansible/README.md
+++ b/ansible/README.md
@@ -117,7 +117,7 @@ whether that's really what you want to do if you add that to your skip list.
 The below example is appropriate to run playbook by skipping tasks by using a combination of conditionals and tags (linked and dependent tasks will not be executed):
 
 ```bash
-ansible-playbook -i [/path/to/hosts] AdoptOpenJDK_Unix_Playbook/main.yml --extra-vars "Jenkins_Username=jenkins Jenkins_User_SSHKey=[/path/to/id_rsa.pub] Nagios_Plugins=Disabled Slack_Notification=Disabled Superuser_Account=Disabled" --skip-tags="adoptopenjdk,jenkins,dont_remove_system"
+ansible-playbook -i [/path/to/hosts] -b AdoptOpenJDK_Unix_Playbook/main.yml --extra-vars "Jenkins_Username=jenkins Jenkins_User_SSHKey=[/path/to/id_rsa.pub] Nagios_Plugins=Disabled Slack_Notification=Disabled Superuser_Account=Disabled" --skip-tags="adoptopenjdk,jenkins,dont_remove_system"
 ```
 
 Note that when running from inside a `vagrant` instance:
@@ -131,10 +131,10 @@ This is useful if one or more tasks are failing to execute successfully or if th
 Below are the levels of verbosity available with using ansible scripts:
 
 ```bash
-ansible-playbook -v playbooks/AdoptOpenJDK_Unix_Playbook/main.yml
-ansible-playbook -vv playbooks/AdoptOpenJDK_Unix_Playbook/main.yml
-ansible-playbook -vvv playbooks/AdoptOpenJDK_Unix_Playbook/main.yml
-ansible-playbook -vvvv playbooks/AdoptOpenJDK_Unix_Playbook/main.yml
+ansible-playbook -v -b playbooks/AdoptOpenJDK_Unix_Playbook/main.yml
+ansible-playbook -vv -b playbooks/AdoptOpenJDK_Unix_Playbook/main.yml
+ansible-playbook -vvv -b playbooks/AdoptOpenJDK_Unix_Playbook/main.yml
+ansible-playbook -vvvv -b playbooks/AdoptOpenJDK_Unix_Playbook/main.yml
 ```
 
 A snippet from the man pages of Ansible:
@@ -217,12 +217,12 @@ Note when using our Vagrantfiles:
 
 1) Run a playbook to install dependencies, for Linux on x86:
 
-`ansible-playbook AdoptOpenJDK_Unix_Playbook/main.yml --skip-tags=adoptopenjdk,jenkins`
+`ansible-playbook -b AdoptOpenJDK_Unix_Playbook/main.yml --skip-tags=adoptopenjdk,jenkins`
 
 In case one or more tasks fail or should not be run in the local environment, see [Skipping one or more tags via CLI when running Ansible playbooks](https://github.com/AdoptOpenJDK/openjdk-infrastructure/tree/master/ansible#skipping-one-or-more-tags-via-cli-when-running-ansible-playbooks) for further details. Ideally, the below can be run for smooth execution in the `vagrant` box:
 
 ```bash
-ansible-playbook AdoptOpenJDK_Unix_Playbook/main.yml --skip-tags="install_zulu,jenkins_authorized_key,nagios_add_key,add_zeus_user_key"
+ansible-playbook -b AdoptOpenJDK_Unix_Playbook/main.yml --skip-tags="install_zulu,jenkins_authorized_key,nagios_add_key,add_zeus_user_key"
 ```
 ## Using Ansible to modify Vagrant VM remote hosts (linux)
 

--- a/ansible/README.md
+++ b/ansible/README.md
@@ -117,7 +117,7 @@ whether that's really what you want to do if you add that to your skip list.
 The below example is appropriate to run playbook by skipping tasks by using a combination of conditionals and tags (linked and dependent tasks will not be executed):
 
 ```bash
-ansible-playbook -i [/path/to/hosts] -s AdoptOpenJDK_Unix_Playbook/main.yml --extra-vars "Jenkins_Username=jenkins Jenkins_User_SSHKey=[/path/to/id_rsa.pub] Nagios_Plugins=Disabled Slack_Notification=Disabled Superuser_Account=Disabled" --skip-tags="adoptopenjdk,jenkins,dont_remove_system"
+ansible-playbook -i [/path/to/hosts] AdoptOpenJDK_Unix_Playbook/main.yml --extra-vars "Jenkins_Username=jenkins Jenkins_User_SSHKey=[/path/to/id_rsa.pub] Nagios_Plugins=Disabled Slack_Notification=Disabled Superuser_Account=Disabled" --skip-tags="adoptopenjdk,jenkins,dont_remove_system"
 ```
 
 Note that when running from inside a `vagrant` instance:
@@ -131,10 +131,10 @@ This is useful if one or more tasks are failing to execute successfully or if th
 Below are the levels of verbosity available with using ansible scripts:
 
 ```bash
-ansible-playbook -v -s playbooks/AdoptOpenJDK_Unix_Playbook/main.yml
-ansible-playbook -vv -s playbooks/AdoptOpenJDK_Unix_Playbook/main.yml
-ansible-playbook -vvv -s playbooks/AdoptOpenJDK_Unix_Playbook/main.yml
-ansible-playbook -vvvv -s playbooks/AdoptOpenJDK_Unix_Playbook/main.yml
+ansible-playbook -v playbooks/AdoptOpenJDK_Unix_Playbook/main.yml
+ansible-playbook -vv playbooks/AdoptOpenJDK_Unix_Playbook/main.yml
+ansible-playbook -vvv playbooks/AdoptOpenJDK_Unix_Playbook/main.yml
+ansible-playbook -vvvv playbooks/AdoptOpenJDK_Unix_Playbook/main.yml
 ```
 
 A snippet from the man pages of Ansible:
@@ -217,12 +217,12 @@ Note when using our Vagrantfiles:
 
 1) Run a playbook to install dependencies, for Linux on x86:
 
-`ansible-playbook -s AdoptOpenJDK_Unix_Playbook/main.yml --skip-tags=adoptopenjdk,jenkins`
+`ansible-playbook AdoptOpenJDK_Unix_Playbook/main.yml --skip-tags=adoptopenjdk,jenkins`
 
 In case one or more tasks fail or should not be run in the local environment, see [Skipping one or more tags via CLI when running Ansible playbooks](https://github.com/AdoptOpenJDK/openjdk-infrastructure/tree/master/ansible#skipping-one-or-more-tags-via-cli-when-running-ansible-playbooks) for further details. Ideally, the below can be run for smooth execution in the `vagrant` box:
 
 ```bash
-ansible-playbook -s AdoptOpenJDK_Unix_Playbook/main.yml --skip-tags="install_zulu,jenkins_authorized_key,nagios_add_key,add_zeus_user_key"
+ansible-playbook AdoptOpenJDK_Unix_Playbook/main.yml --skip-tags="install_zulu,jenkins_authorized_key,nagios_add_key,add_zeus_user_key"
 ```
 ## Using Ansible to modify Vagrant VM remote hosts (linux)
 


### PR DESCRIPTION
Hi,

In the README.md, the option **-s** seems an option not anymore present with ansible-playbook CLI, at least for the version 2.9.7.
On my Ubuntu 18.04, it seems to run correctly without this option.

Regards