### PR TITLE
UnixPB: Allow unauthorised packages on Deb8

### DIFF
--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/tasks/Debian.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/tasks/Debian.yml
@@ -81,8 +81,17 @@
     - (ansible_distribution_major_version == "9" and ansible_architecture == "armv7l")
   tags: patch_update
 
+  # Required as a Debian 8 GPG key has expired
+- name: Allow unauthenticated packages on Debian 8
+  shell: echo "APT { Get { AllowUnauthenticated \"1\"; }; };" > /etc/apt/apt.conf.d/99allow_unauth
+  when: (ansible_distribution_major_version == "8") and (ansible_architecture == "x86_64")
+  tags: patch_update
+
 - name: Run apt-get upgrade
-  apt: upgrade=safe update_cache=yes
+  apt:
+    upgrade: safe
+    update_cache: yes
+    force: yes
   tags: patch_update
 
 ############################


### PR DESCRIPTION
Ref: https://adoptopenjdk.slack.com/archives/C53GHCXL4/p1588329011104200

Annoyingly, one of Debian 8 's GPG keys have been expired since 25/04, with no indication that it will be renewed as Debian 8 falls out of support on the 30th of June. However, as we have some test machines that are still running Debian 8, for the time being it's better to have the capability to install packages in case we need it, rather than not.