### PR TITLE
UnixPB: Add Deb10 VF and 'Common/task/Debian.yml' changes to support it

### DIFF
--- a/ansible/Vagrantfile.Debian10
+++ b/ansible/Vagrantfile.Debian10
@@ -1,0 +1,32 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+$script = <<SCRIPT
+sudo apt-get install tree -y
+sudo apt-get install software-properties-common -y
+sudo apt-get install gpg -y	
+sudo apt-get update
+# Get IPs of the VM, and output to shared folder
+ip address show | grep -e "\\binet\\b" | cut -d' ' -f6 | cut -d/ -f1  >> /vagrant/playbooks/AdoptOpenJDK_Unix_Playbook/hosts.tmp
+# Put the host machine's IP into the authorised_keys file on the VM
+if [ -r /vagrant/id_rsa.pub ]; then
+        mkdir -p $HOME/.ssh && cat /vagrant/id_rsa.pub >> $HOME/.ssh/authorized_keys
+fi
+SCRIPT
+
+# 2 = version of configuration file for Vagrant 1.1+ leading up to 2.0.x
+Vagrant.configure("2") do |config|
+
+  config.vm.define :adoptopenjdkD10 do |adoptopenjdkD10|
+    adoptopenjdkD10.vm.box = "debian/buster64"
+    adoptopenjdkD10.vm.synced_folder ".", "/vagrant"
+    adoptopenjdkD10.vm.hostname = "adoptopenjdkD10"
+    adoptopenjdkD10.vm.network :private_network, type: "dhcp"
+    adoptopenjdkD10.vm.provision "shell", inline: $script, privileged: false
+  end
+  config.vm.provider "virtualbox" do |v|
+    v.gui = false
+    v.memory = 2560
+    v.customize ["modifyvm", :id, "--cpuexecutioncap", "50"]
+  end
+end

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/tasks/Debian.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/tasks/Debian.yml
@@ -13,6 +13,7 @@
   apt_repository: repo='ppa:openjdk-r/ppa' update_cache=no
   when:
     - ansible_architecture != "armv7l"
+    - ansible_distribution_major_version != "10"
   tags: patch_update
 
 - name: Add AdoptOpenJDK GPG key
@@ -27,6 +28,7 @@
   apt_repository: repo='ppa:ubuntu-toolchain-r/test' update_cache=no
   when:
     - ansible_architecture != "armv7l"
+    - ansible_distribution_major_version != "10"
   tags: patch_update
 
 # Required as 'Ubuntu Jessie' doesn't exist. See openjdk-infrastructure issue #1015
@@ -40,6 +42,7 @@
     - /etc/apt/sources.list.d/ppa_ubuntu_toolchain_r_test_jessie.list
   when:
     - ansible_architecture != "armv7l"
+    - ansible_distribution_major_version == "8"
   tags: patch_update
 
 - name: Add Azul Zulu GPG Package Signing Key for x86_64


### PR DESCRIPTION
ref: #1308 

As mentioned in the above PR, Debian 8 out is out of support at the end of June, therefore we should probably look into our playbook supporting a newer version - Debian 10.
The 2 issues (that I'm aware of) that remain after this PR will be that `gcc-4.8` won't be installed, and neither will a version of `jdk7`, so this may not be able to build JDK8/HS out the box.

Apart from the Vagrantfile, the primary thing this PR is doing is just making sure all the repos that are meant for other versions of Debian, aren't added to a Debian 10 run.