### PR TITLE
UnixPB: Alter Deb Common file & pb script to build JDK8/HS on Deb10

### DIFF
--- a/ansible/pbTestScripts/buildJDK.sh
+++ b/ansible/pbTestScripts/buildJDK.sh
@@ -150,8 +150,7 @@ if [ -z "$JAVA_HOME" ]; then
 	export JAVA_HOME=$(ls -1d /usr/lib/jvm/adoptopenjdk-8-* | head -1)
 fi
 
-if grep 'openSUSE' /etc/os-release >/dev/null 2>&1; then
-	echo "Running on openSUSE"
+if grep 'openSUSE' /etc/os-release || grep 'buster' /etc/os-release >/dev/null 2>&1; then
 	JAVA_HOME=$(find /usr/lib/jvm/ -name jdk8u*)
 fi
 
@@ -163,6 +162,13 @@ if [[ $(uname) == "FreeBSD" ]]; then
         export JAVA_TO_BUILD=jdk11u
         export JDK_BOOT_DIR=/usr/local/openjdk11
         export JAVA_HOME=/usr/local/openjdk8
+fi
+
+# Required as Debian Buster doesn't have gcc-4.8 available
+# See https://github.com/AdoptOpenJDK/openjdk-infrastructure/pull/1321#discussion_r426625178
+if grep 'buster' /etc/*-release >/dev/null 2>&1; then
+	export CC=/usr/bin/gcc-7
+	export CXX=/usr/bin/g++-7
 fi
 
 echo "DEBUG:

--- a/ansible/pbTestScripts/vmDestroy.sh
+++ b/ansible/pbTestScripts/vmDestroy.sh
@@ -51,6 +51,8 @@ checkOS() {
                         osToDestroy="C8" ;;
                 "Debian8" | "debian8" | "D7" | "d7" )
                         osToDestroy="D8" ;;
+                "Debian10" | "debian10" | "D10" | "d10" )
+                        osToDestroy="D10" ;;
 		"FreeBSD12" | "freebsd12" | "F12" | "f12" )
 			osToDestroy="FBSD12" ;;
 		"SUSE12" | "suse12" | "S12" | "s12" )
@@ -58,7 +60,7 @@ checkOS() {
 		"Windows2012" | "Win2012" | "W12" | "w12" )
                         osToDestroy="W2012";;
                 "all" )
-                        osToDestroy="U16 U18 C6 C7 D8 FBSD12 S12 W2012" ;;
+                        osToDestroy="U16 U18 C6 C7 D8 D10 FBSD12 S12 W2012" ;;
 		"")
 			echo "No OS detected. Did you miss the '-o' option?" ; usage; exit 1;;
 		*) echo "$OS is not a currently supported OS" ; listOS; exit 1;
@@ -74,6 +76,7 @@ listOS() {
 		- CentOS7
 		- CentOS8
 		- Debian8
+		- Debian10
 		- FreeBSD12
 		- SUSE12
 		- Win2012"

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/tasks/Debian.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/tasks/Debian.yml
@@ -116,6 +116,7 @@
   with_items: "{{ gcc_compiler }}"
   when:
     - (ansible_distribution_major_version != "9" and ansible_architecture != "armv7l")
+    - not (ansible_distribution_major_version == "10" and ansible_architecture == "x86_64")
   tags: build_tools
 
 - name: Install GCC G++ on Raspian Buster


### PR DESCRIPTION
Several changes to allow building JDK8 / HS on Debian10:
1) Change `buildJDK.sh` to detect `JAVA_HOME`. correctly for Debian Buster
2) Add a condition to ensure it doesn't attempt to install gcc-4.8 (as this is unavailable for Debian 10's repos)
3) Symlink `/usr/bin/gcc-7` and `/usr/bin/gcc` and the same for `g++`. As `gcc-4.8` is unavailable to Debian 10, the gcc to use to build JDK8/HS should be the lowest version available - `gcc-7.4`. Tested and it does build JDK8/HS now.
