### PR TITLE
WinPB: Remove Windows-SDK-10.0 installation

### DIFF
--- a/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/roles/WiX/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/roles/WiX/tasks/main.yml
@@ -32,16 +32,3 @@
     state: absent
   ignore_errors: yes
   tags: Wix
-
-- name: Test if Windows 10 SDK is already installed
-  win_stat:
-    path: 'C:\Program Files (x86)\Windows Kits\10\bin\10.0.17763.0\x64\signtool.exe'
-  register: win10_sdk_installed
-  tags: Wix
-
-- name: Install windows-sdk-10.0 version 10.1.17763.1
-  win_chocolatey:
-    name: windows-sdk-10.1
-    version: '10.1.17763.1'
-  when: (not win10_sdk_installed.stat.exists)
-  tags: Wix


### PR DESCRIPTION
I've removed this as this should be installed with MSVS_2017, so it would always skip, unless `VagrantPlaybookCheck` is being ran to build JDK8/J9 with 'fastmode' on.
e.g.:
https://ci.adoptopenjdk.net/view/Tooling/job/VagrantPlaybookCheck/571/OS=Win2012,label=infra-vagrant-1/console     (Failed at the WiX role)
https://ci.adoptopenjdk.net/view/Tooling/job/VagrantPlaybookCheck/572/OS=Win2012,label=infra-vagrant-1/console    (Got past the WiX role)

They ran with the same parameters, however the second one didn't run with `fastmode` on.
In current normal use, this wouldn't have been noticed as the Windows machines that run the installer jobs are also build machines ( I assume ), that will have MSVS_2017 installed anyway, so unless we have/get Windows machines specifically for making the installer, this is unnecessary.

