### PR TITLE
aixPB: Do not move openjdk7 into IBM java7 location

### DIFF
--- a/ansible/playbooks/aix.yml
+++ b/ansible/playbooks/aix.yml
@@ -229,7 +229,7 @@
       ##############
         - name: Check for Java7 availability
           stat:
-            path: /usr/java7_64
+            path: /usr/j2sdk-image
           register: java7
           tags: java7
 
@@ -238,11 +238,6 @@
             src: /Vendor_Files/aix/openjdk-7u-aix.tar
             dest: /usr
             remote_src: no
-          when: java7.stat.isdir is not defined
-          tags: java7
-
-        - name: Rename j2sdk_image to java7_64
-          command: mv /usr/j2sdk_image /usr/java7_64
           when: java7.stat.isdir is not defined
           tags: java7
 


### PR DESCRIPTION
Currently playbooks are trying to place the openjdk7 required for bootstrapping JDK8 into `/usr/java7_64` which is the location that the IBM Java uses. If an IBM Java7 is installed then this will cause confusion.

To prevent ambiguity I want to leave this in it's original location of `/usr/j2sdk_image` and this can be set in the jenkins definition for the machine as `JDK7_BOOT_DIR`

Resolves https://github.com/AdoptOpenJDK/openjdk-infrastructure/issues/1319

Signed-off-by: Stewart Addison <sxa@uk.ibm.com>