### PR TITLE
UnixPB: Add Zulu7 for JDK8 Build bootstrap, make buildJDK.sh use JDK7

### DIFF
--- a/ansible/pbTestScripts/buildJDK.sh
+++ b/ansible/pbTestScripts/buildJDK.sh
@@ -82,21 +82,26 @@ checkJDKVersion() {
 }
 
 setBootJDK() {
-	local buildJDKNumber=$(echo ${JAVA_TO_BUILD//[!0-9]/})
-	local bootJDKNumber=$(($buildJDKNumber - 1));
-        # if building JDK8/9 look for 'jdk8u', not 'jdk-x'
-	if [[ $buildJDKNumber -eq 8 || $buildJDKNumber -eq 9 ]]; then
-		export JDK_BOOT_DIR=$(find /usr/lib/jvm -maxdepth 1 -name *jdk8*)	
-		return
-	else
-		export JDK_BOOT_DIR=$(find /usr/lib/jvm -maxdepth 1 -name *jdk-$bootJDKNumber*)
-	fi
-
-	if [ -z "${JDK_BOOT_DIR}" ]
-	then
-		echo "Can't find jdk$bootJDKNumber to build JDK, looking for jdk$buildJDKNumber"
-		export JDK_BOOT_DIR=$(find /usr/lib/jvm -maxdepth 1 -name *jdk-$buildJDKNumber*)
-	fi
+        local buildJDKNumber=$(echo ${JAVA_TO_BUILD//[!0-9]/})
+        local bootJDKNumber=$(($buildJDKNumber - 1));
+        [[ $bootJDKNumber != "8" ]] && bootJDKNumber="-$bootJDKNumber"
+        if [[ $buildJDKNumber -eq 8 ]]; then
+                # CentOS JDK7
+                export JDK_BOOT_DIR=$(find /usr/lib/jvm -maxdepth 1 -name java-1.7.0-openjdk.x86_64)
+                # Ubuntu JDK7
+                [[ -z "$JDK_BOOT_DIR" ]] && export JDK_BOOT_DIR=$(find /usr/lib/jvm/ -maxdepth 1 -name java-1.7.0-openjdk-\*)
+                # Zulu-7 for OSs without JDK7
+                [[ -z "$JDK_BOOT_DIR" ]] && export JDK_BOOT_DIR=$(find /usr/lib/jvm/ -maxdepth 1 -name zulu7)
+        else
+                export JDK_BOOT_DIR=$(find /usr/lib/jvm -maxdepth 1 -name *jdk$bootJDKNumber*)
+        fi
+        # If JDK (jdkToBuild - 1) can't be found, look for equal boot and build jdk
+        if [ -z "${JDK_BOOT_DIR}" ]
+        then
+                [[ $buildJDKNumber != "8" ]] && buildJDKNumber="-$buildJDKNumber"
+                echo "Can't find jdk$bootJDKNumber to build JDK, looking for jdk$buildJDKNumber"
+                export JDK_BOOT_DIR=$(find /usr/lib/jvm -maxdepth 1 -name *jdk$buildJDKNumber*)
+        fi
 }
 
 cloneRepo() {
@@ -139,21 +144,8 @@ if [[ ${unameOutput} != "x86_64" ]]; then
        export ARCHITECTURE=${unameOutput}
 fi
 
-# Differences in openJDK7 name between OSs. Search for CentOS one
-export JDK7_BOOT_DIR=$(find /usr/lib/jvm/ -name java-1.7.0-openjdk.x86_64)
-# If the CentOS JDK7 can't be found, search for the Ubuntu one
-[[ -z "$JDK7_BOOT_DIR" ]] && export JDK7_BOOT_DIR=$(find /usr/lib/jvm/ -name java-1.7.0-openjdk-\*)
-
-# Differences in openJDK8 name between Ubuntu and CentOS
-export JAVA_HOME=$(find /usr/lib/jvm/ -name java-1.8.0-openjdk-\*)
-if [ -z "$JAVA_HOME" ]; then
-	export JAVA_HOME=$(ls -1d /usr/lib/jvm/adoptopenjdk-8-* | head -1)
-fi
-
-if grep 'openSUSE' /etc/os-release >/dev/null 2>&1; then
-	echo "Running on openSUSE"
-	JAVA_HOME=$(find /usr/lib/jvm/ -name jdk8u*)
-fi
+# Use the JDK8 installed with the adoptopenjdk_install role to run Gradle with.
+export JAVA_HOME=$(find /usr/lib/jvm -maxdepth 1 -name *jdk8*)
 
 # Only build Hotspot on FreeBSD
 if [[ $(uname) == "FreeBSD" ]]; then

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/main.yml
@@ -48,6 +48,7 @@
     - role: nasm                  # OpenJ9
       when: ansible_architecture == 'x86_64'
       tags: [build_tools, build_tools_openj9]
+    - zulu7                       # JDK8 Build Bootstrap
     - role: adoptopenjdk_install
       jdk_version: 8
       tags: build_tools

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/zulu7/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/zulu7/tasks/main.yml
@@ -32,7 +32,6 @@
     - ansible_os_family != "Darwin"
     - ansible_architecture == "x86_64"
     - ((ansible_distribution == "Redhat" or ansible_distribution == "CentOS") and (ansible_distribution_major_version|int >= 8)) or
-      ((ansible_distribution == "SLES" or ansible_distribution == "openSUSE") and (ansible_distribution_major_version|int >= 12)) or
       (ansible_distribution == "Ubuntu" and ansible_distribution_major_version|int >= 18) or
       (ansible_distribution == "Debian" and ansible_distribution_major_version|int >= 10)
   tags: zulu7
@@ -46,7 +45,6 @@
     - ansible_os_family != "Darwin"
     - ansible_architecture == "x86_64"
     - ((ansible_distribution == "Redhat" or ansible_distribution == "CentOS") and (ansible_distribution_major_version|int >= 8)) or
-      ((ansible_distribution == "SLES" or ansible_distribution == "openSUSE") and (ansible_distribution_major_version|int >= 12)) or
       (ansible_distribution == "Ubuntu" and ansible_distribution_major_version|int >= 18) or
       (ansible_distribution == "Debian" and ansible_distribution_major_version|int >= 10)
     - zulu7_installed.rc != 0
@@ -61,7 +59,6 @@
     - ansible_os_family != "Darwin"
     - ansible_architecture == "x86_64"
     - ((ansible_distribution == "Redhat" or ansible_distribution == "CentOS") and (ansible_distribution_major_version|int >= 8)) or
-      ((ansible_distribution == "SLES" or ansible_distribution == "openSUSE") and (ansible_distribution_major_version|int >= 12)) or
       (ansible_distribution == "Ubuntu" and ansible_distribution_major_version|int >= 18) or
       (ansible_distribution == "Debian" and ansible_distribution_major_version|int >= 10)
     - zulu7_installed.rc != 0

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/zulu7/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/zulu7/tasks/main.yml
@@ -6,6 +6,24 @@
 # Install zulu-7 for OSs that don't have openjdk-7 available in their package manager:
 #  CentOS/RHEL 8, Debian 10, Ubuntu1804, openSUSE/SLES 12 (only tested for x86_64)
 
+- name: Checking for /usr/lib/jvm
+  stat: path=/usr/lib/jvm
+  register: usr_lib_jvm_exists
+  when:
+    - ansible_os_family != "Darwin"
+  tags: zulu7
+
+- name: Creating /usr/lib/jvm if not found
+  file:
+    path: /usr/lib/jvm
+    state: directory
+    owner: root
+    mode: 0755
+  when:
+    - not usr_lib_jvm_exists.stat.exists
+    - ansible_os_family != "Darwin"
+  tags: zulu7
+
 - name: Check if Zulu-7 is already installed in the target location
   shell: ls -ld /usr/lib/jvm/zulu7 2>&1
   ignore_errors: yes
@@ -13,10 +31,10 @@
   when:
     - ansible_os_family != "Darwin"
     - ansible_architecture == "x86_64"
-    - ((ansible_distribution == "Redhat" or ansible_distribution == "CentOS") and (ansible_distribution_major_version|int >= "8")) or
-      ((ansible_distribution == "SLES" or ansible_distribution == "openSUSE") and (ansible_distribution_major_version|int >= "12")) or
-      (ansible_distribution == "Ubuntu" and ansible_distribution_major_version|int >= "18") or
-      (ansible_distribution == "Debian" and ansible_distribution_major_version|int >= "10")
+    - ((ansible_distribution == "Redhat" or ansible_distribution == "CentOS") and (ansible_distribution_major_version|int >= 8)) or
+      ((ansible_distribution == "SLES" or ansible_distribution == "openSUSE") and (ansible_distribution_major_version|int >= 12)) or
+      (ansible_distribution == "Ubuntu" and ansible_distribution_major_version|int >= 18) or
+      (ansible_distribution == "Debian" and ansible_distribution_major_version|int >= 10)
   tags: zulu7
 
 - name: Install latest release if not already installed
@@ -27,10 +45,10 @@
   when:
     - ansible_os_family != "Darwin"
     - ansible_architecture == "x86_64"
-    - ((ansible_distribution == "Redhat" or ansible_distribution == "CentOS") and (ansible_distribution_major_version|int >= "8")) or
-      ((ansible_distribution == "SLES" or ansible_distribution == "openSUSE") and (ansible_distribution_major_version|int >= "12")) or
-      (ansible_distribution == "Ubuntu" and ansible_distribution_major_version|int >= "18") or
-      (ansible_distribution == "Debian" and ansible_distribution_major_version|int >= "10")
+    - ((ansible_distribution == "Redhat" or ansible_distribution == "CentOS") and (ansible_distribution_major_version|int >= 8)) or
+      ((ansible_distribution == "SLES" or ansible_distribution == "openSUSE") and (ansible_distribution_major_version|int >= 12)) or
+      (ansible_distribution == "Ubuntu" and ansible_distribution_major_version|int >= 18) or
+      (ansible_distribution == "Debian" and ansible_distribution_major_version|int >= 10)
     - zulu7_installed.rc != 0
   tags: zulu7
 
@@ -42,9 +60,9 @@
   when:
     - ansible_os_family != "Darwin"
     - ansible_architecture == "x86_64"
-    - ((ansible_distribution == "Redhat" or ansible_distribution == "CentOS") and (ansible_distribution_major_version|int >= "8")) or
-      ((ansible_distribution == "SLES" or ansible_distribution == "openSUSE") and (ansible_distribution_major_version|int >= "12")) or
-      (ansible_distribution == "Ubuntu" and ansible_distribution_major_version|int >= "18") or
-      (ansible_distribution == "Debian" and ansible_distribution_major_version|int >= "10")
+    - ((ansible_distribution == "Redhat" or ansible_distribution == "CentOS") and (ansible_distribution_major_version|int >= 8)) or
+      ((ansible_distribution == "SLES" or ansible_distribution == "openSUSE") and (ansible_distribution_major_version|int >= 12)) or
+      (ansible_distribution == "Ubuntu" and ansible_distribution_major_version|int >= 18) or
+      (ansible_distribution == "Debian" and ansible_distribution_major_version|int >= 10)
     - zulu7_installed.rc != 0
   tags: zulu7

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/zulu7/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/zulu7/tasks/main.yml
@@ -16,12 +16,14 @@
     - ((ansible_distribution == "Redhat" or ansible_distribution == "CentOS") and (ansible_distribution_major_version|int >= "8")) or
       ((ansible_distribution == "SLES" or ansible_distribution == "openSUSE") and (ansible_distribution_major_version|int >= "12")) or
       (ansible_distribution == "Ubuntu" and ansible_distribution_major_version|int >= "18") or
-      (ansible_distributiob == "Debian" and ansible_distribution_major_version|int >= "10")
+      (ansible_distribution == "Debian" and ansible_distribution_major_version|int >= "10")
   tags: zulu7
 
-  # See here for reason to skip_ansible_lint: https://github.com/AdoptOpenJDK/openjdk-infrastructure/pull/1325#issuecomment-627374329
 - name: Install latest release if not already installed
-  shell: mkdir -p /usr/lib/jvm/zulu7 && wget https://cdn.azul.com/zulu/bin/zulu7.38.0.11-ca-jdk7.0.262-linux_x64.tar.gz  -O - | tar xzf - -C /usr/lib/jvm/zulu7 --strip-components=1
+  unarchive:
+    src: https://cdn.azul.com/zulu/bin/zulu7.38.0.11-ca-jdk7.0.262-linux_x64.tar.gz
+    dest: /usr/lib/jvm/
+    remote_src: yes
   when:
     - ansible_os_family != "Darwin"
     - ansible_architecture == "x86_64"
@@ -29,6 +31,20 @@
       ((ansible_distribution == "SLES" or ansible_distribution == "openSUSE") and (ansible_distribution_major_version|int >= "12")) or
       (ansible_distribution == "Ubuntu" and ansible_distribution_major_version|int >= "18") or
       (ansible_distribution == "Debian" and ansible_distribution_major_version|int >= "10")
-  tags:
-    - skip_ansible_lint
-    - zulu7
+    - zulu7_installed.rc != 0
+  tags: zulu7
+
+- name: Create symlink to point at zulu-7
+  file:
+    src: /usr/lib/jvm/zulu7.38.0.11-ca-jdk7.0.262-linux_x64
+    dest: /usr/lib/jvm/zulu7
+    state: link
+  when:
+    - ansible_os_family != "Darwin"
+    - ansible_architecture == "x86_64"
+    - ((ansible_distribution == "Redhat" or ansible_distribution == "CentOS") and (ansible_distribution_major_version|int >= "8")) or
+      ((ansible_distribution == "SLES" or ansible_distribution == "openSUSE") and (ansible_distribution_major_version|int >= "12")) or
+      (ansible_distribution == "Ubuntu" and ansible_distribution_major_version|int >= "18") or
+      (ansible_distribution == "Debian" and ansible_distribution_major_version|int >= "10")
+    - zulu7_installed.rc != 0
+  tags: zulu7

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/zulu7/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/zulu7/tasks/main.yml
@@ -3,12 +3,20 @@
 # ZULU-7 #
 ##########
 
+# Install zulu-7 for OSs that don't have openjdk-7 available in their package manager:
+#  CentOS/RHEL 8, Debian 10, Ubuntu1804, openSUSE/SLES 12 (only tested for x86_64)
+
 - name: Check if Zulu-7 is already installed in the target location
   shell: ls -ld /usr/lib/jvm/zulu7 2>&1
   ignore_errors: yes
   register: zulu7_installed
   when:
     - ansible_os_family != "Darwin"
+    - ansible_architecture == "x86_64"
+    - ((ansible_distribution == "Redhat" or ansible_distribution == "CentOS") and (ansible_distribution_major_version == "8")) or
+      ((ansible_distribution == "SLES" or ansible_distribution == "openSUSE") and (ansible_distribution_major_version == "12")) or
+      (ansible_distribution == "Ubuntu" and ansible_distribution_major_version == "18") or
+      (ansible_distributiob == "Debian" and ansible_distribution_major_version == "10")
   tags: zulu7
 
   # See here for reason to skip_ansible_lint: https://github.com/AdoptOpenJDK/openjdk-infrastructure/pull/1325#issuecomment-627374329
@@ -16,7 +24,11 @@
   shell: mkdir -p /usr/lib/jvm/zulu7 && wget https://cdn.azul.com/zulu/bin/zulu7.38.0.11-ca-jdk7.0.262-linux_x64.tar.gz  -O - | tar xzf - -C /usr/lib/jvm/zulu7 --strip-components=1
   when:
     - ansible_os_family != "Darwin"
-    - zulu7_installed.rc != 0
+    - ansible_architecture == "x86_64"
+    - ((ansible_distribution == "Redhat" or ansible_distribution == "CentOS") and (ansible_distribution_major_version == "8")) or
+      ((ansible_distribution == "SLES" or ansible_distribution == "openSUSE") and (ansible_distribution_major_version == "12")) or
+      (ansible_distribution == "Ubuntu" and ansible_distribution_major_version == "18") or
+      (ansible_distributiob == "Debian" and ansible_distribution_major_version == "10")
   tags:
     - skip_ansible_lint
     - zulu7

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/zulu7/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/zulu7/tasks/main.yml
@@ -1,0 +1,40 @@
+---
+##########
+# ZULU-7 #
+##########
+
+- name: Check if /usr/lib/jvm exists
+  stat: path=/usr/lib/jvm
+  register: usr_lib_jvm_exists
+  when:
+    - ansible_os_family != "Darwin"
+  tags: zulu7
+
+- name: Create /usr/lib/jvm if not found
+  file:
+    path: /usr/lib/jvm
+    state: directory
+    owner: root
+    mode: 0755
+  when:
+    - not usr_lib_jvm_exists.stat.exists
+    - ansible_os_family != "Darwin"
+  tags: zulu7
+
+- name: Check if Zulu-7 is already installed in the target location
+  shell: ls -ld /usr/lib/jvm/zulu7 2>&1
+  ignore_errors: yes
+  register: zulu7_installed
+  when:
+    - ansible_os_family != "Darwin"
+  tags: zulu7
+
+  # See here for reason to skip_ansible_lint: https://github.com/AdoptOpenJDK/openjdk-infrastructure/pull/1325#issuecomment-627374329
+- name: Install latest release if not already installed
+  shell: mkdir -p /usr/lib/jvm/zulu7 && wget https://cdn.azul.com/zulu/bin/zulu7.38.0.11-ca-jdk7.0.262-linux_x64.tar.gz  -O - | tar xzf - -C /usr/lib/jvm/zulu7 --strip-components=1
+  when:
+    - ansible_os_family != "Darwin"
+    - zulu7_installed.rc != 0
+  tags:
+    - skip_ansible_lint
+    - zulu7

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/zulu7/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/zulu7/tasks/main.yml
@@ -3,24 +3,6 @@
 # ZULU-7 #
 ##########
 
-- name: Check if /usr/lib/jvm exists
-  stat: path=/usr/lib/jvm
-  register: usr_lib_jvm_exists
-  when:
-    - ansible_os_family != "Darwin"
-  tags: zulu7
-
-- name: Create /usr/lib/jvm if not found
-  file:
-    path: /usr/lib/jvm
-    state: directory
-    owner: root
-    mode: 0755
-  when:
-    - not usr_lib_jvm_exists.stat.exists
-    - ansible_os_family != "Darwin"
-  tags: zulu7
-
 - name: Check if Zulu-7 is already installed in the target location
   shell: ls -ld /usr/lib/jvm/zulu7 2>&1
   ignore_errors: yes

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/zulu7/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/zulu7/tasks/main.yml
@@ -13,10 +13,10 @@
   when:
     - ansible_os_family != "Darwin"
     - ansible_architecture == "x86_64"
-    - ((ansible_distribution == "Redhat" or ansible_distribution == "CentOS") and (ansible_distribution_major_version == "8")) or
-      ((ansible_distribution == "SLES" or ansible_distribution == "openSUSE") and (ansible_distribution_major_version == "12")) or
-      (ansible_distribution == "Ubuntu" and ansible_distribution_major_version == "18") or
-      (ansible_distributiob == "Debian" and ansible_distribution_major_version == "10")
+    - ((ansible_distribution == "Redhat" or ansible_distribution == "CentOS") and (ansible_distribution_major_version|int >= "8")) or
+      ((ansible_distribution == "SLES" or ansible_distribution == "openSUSE") and (ansible_distribution_major_version|int >= "12")) or
+      (ansible_distribution == "Ubuntu" and ansible_distribution_major_version|int >= "18") or
+      (ansible_distributiob == "Debian" and ansible_distribution_major_version|int >= "10")
   tags: zulu7
 
   # See here for reason to skip_ansible_lint: https://github.com/AdoptOpenJDK/openjdk-infrastructure/pull/1325#issuecomment-627374329
@@ -25,10 +25,10 @@
   when:
     - ansible_os_family != "Darwin"
     - ansible_architecture == "x86_64"
-    - ((ansible_distribution == "Redhat" or ansible_distribution == "CentOS") and (ansible_distribution_major_version == "8")) or
-      ((ansible_distribution == "SLES" or ansible_distribution == "openSUSE") and (ansible_distribution_major_version == "12")) or
-      (ansible_distribution == "Ubuntu" and ansible_distribution_major_version == "18") or
-      (ansible_distributiob == "Debian" and ansible_distribution_major_version == "10")
+    - ((ansible_distribution == "Redhat" or ansible_distribution == "CentOS") and (ansible_distribution_major_version|int >= "8")) or
+      ((ansible_distribution == "SLES" or ansible_distribution == "openSUSE") and (ansible_distribution_major_version|int >= "12")) or
+      (ansible_distribution == "Ubuntu" and ansible_distribution_major_version|int >= "18") or
+      (ansible_distribution == "Debian" and ansible_distribution_major_version|int >= "10")
   tags:
     - skip_ansible_lint
     - zulu7


### PR DESCRIPTION
ref: https://github.com/AdoptOpenJDK/openjdk-build/issues/1732

Add in Zulu-7 to Unix playbook, as it can be a consistent JDK-7 amongst all the distributions, as some new linux distros are unable to install `openjdk-7` with their package manager.