### PR TITLE
WinPB: Install Win-sdk-10.1 manually, not w/ chocolatey

### DIFF
--- a/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/roles/WiX/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/roles/WiX/tasks/main.yml
@@ -39,9 +39,20 @@
   register: win10_sdk_installed
   tags: Wix
 
-- name: Install windows-sdk-10.0 version 10.1.17763.1
-  win_chocolatey:
-    name: windows-sdk-10.1
-    version: '10.1.17763.1'
-  when: (not win10_sdk_installed.stat.exists)
+- name: Download Windows-SDK-10.1.17763.1
+  win_get_url:
+    url: https://download.microsoft.com/download/9/3/9/939441D4-6FBA-48EE-9EF7-402C1AA8B8A7/windowssdk/winsdksetup.exe
+    dest: C:/temp/winSDK10.exe
+  when: not win10_sdk_installed.stat.exists
+  tags: Wix
+
+- name: Install Windows-SDK-10.1.17763.1
+  win_shell: C:/temp/winSDK10.exe /q /norestart
+  when: not win10_sdk_installed.stat.exists
+  tags: Wix
+
+- name: Reboot to complete installation
+  win_reboot:
+    reboot_timeout: 1800
+  when: not win10_sdk_installed.stat.exists
   tags: Wix


### PR DESCRIPTION
This is what I believe is the best alternative to #1322 and #1323 (and so I'm going to close those PRs).

In it's current state, `windows-sdk-10.1.1776.1` is installed using chocolatey. I have also noticed that when running `VagrantPlaybookCheck`, the task is only ran when you _don't_ install `MSVS_2017`. When you do, the task does run but errors when attempting to install it (see https://github.com/AdoptOpenJDK/openjdk-infrastructure/pull/1322#issue-416660288 for logs / proof of this). 
I'm not sure what the cause of this is, but either way, the `win_chocolatey` task is broken in it's current form- whether it is skipped in `VPC` or not, the task should work. The other downside of skipping the `Wix` tag means that the installation of WiX isn't tested, which isn't ideal.

According to @gdams , this exact version of `Windows-SDK` needs to be installed for WiX. As I'm unable to test on any machine other than the windows vagrant boxes, I can't guarantee that completely removing the installation task won't break things when it comes to running the playbook on actual machines. In addition, this will ensure consistency in the `Windows SDK` version amongst machines.

So, I've changed the installation task to install it without using `chocolatey`- The rest of the Windows playbook doesn't use `chocolatey`, so it stays consistent. As can be seen [here](https://github.com/AdoptOpenJDK/openjdk-infrastructure/pull/1322#issue-416660288), the installation task is able to run without error-ing in `VPC` (when MSVS_2017 installation is skipped), and, it allows the WiX installation to be tested as well. 