### PR TITLE
UnixPB: docker and gcc4.8 changes

### DIFF
--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/tasks/Ubuntu.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/tasks/Ubuntu.yml
@@ -77,6 +77,7 @@
   with_items: "{{ gcc_compiler }}"
   when:
     - (ansible_distribution_major_version != "9" and ansible_architecture != "armv7l")
+    - ansible_distribution_major_version != "20"
   tags: build_tools
 
 - name: Install additional build tools for x86

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Docker/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Docker/tasks/main.yml
@@ -262,7 +262,7 @@
   tags: docker
 
 - name: Install Docker for Ubuntu
-  package: "name=docker-ce state=latest"
+  package: "name=docker.io state=latest"
   when:
     - docker_installed.rc != 0
     - ansible_distribution == "Ubuntu"


### PR DESCRIPTION
Ref https://github.com/AdoptOpenJDK/openjdk-infrastructure/issues/1226

Made changes to the `Docker` and `Common` role to accommodate for Ubuntu 20.
Skips installing `gcc-4.8` and `g++-4.8`. Installs `docker.io` instead of `docker-ce`

Still have yet to find a fix for the failing NTP_TIME role, but I thought id push these changes in the meantime