### PR TITLE
WinPB: Correct MSVS_2017 checksum

### DIFF
--- a/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/roles/MSVS_2017/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/roles/MSVS_2017/tasks/main.yml
@@ -14,7 +14,7 @@
     url: 'https://aka.ms/vs/15/release/vs_community.exe'
     dest: 'C:\TEMP\vs_community.exe'
     force: no
-    checksum: 789aa74d8838804c37e2d0ea484e5d9a4958bc5cc5d2f6132542f2b637b9c17d
+    checksum: e7405c4f1c66af1b7d6458d3162a79295fa1c4e52b74744632dcdbb266b422b3
     checksum_algorithm: sha256
   when: (not vs2017_installed.stat.exists)
   tags: MSVS_2017


### PR DESCRIPTION
Ref: 
https://ci.adoptopenjdk.net/view/Tooling/job/VagrantPlaybookCheck/593/OS=Win2012,label=infra-softlayer-ubuntu1804-x64-1/console

They've changed it again..