### PR TITLE
UnixPB: Fix libstdc++ for Redhat vars on ppc64le

### DIFF
--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/vars/RedHat.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/vars/RedHat.yml
@@ -59,7 +59,7 @@ Additional_Build_Tools_RHEL7:
   - libstdc++-static
 
 Additional_Build_Tools_RHEL7_PPC64LE:
-  - libstdc++.so.5
+  - libstdc++
 
 Additional_Build_Tools_RHEL_x86:
   - glibc.i686                    # a dependency required for executing a 32-bit C binary


### PR DESCRIPTION
- Changed `libstdc++.so.5` to `libstdc++`

libstdc++.so.5 fails due to no valid package name, which is a blocker when running the Common task for Adopt_Unix_playbook on RHEL7 ppc64le.
```
TASK [Common : Install additional build tools for RHEL 7 on ppc64le] ***********
failed: [rhel7lert-11.fyre.ibm.com] (item=libstdc++.so.5) => {"ansible_loop_var": "item", "changed": false, "item": "libstdc++.so.5", "msg": "No package matching 'libstdc++.so.5' found available, installed or updated", "rc": 126, "results": ["No package matching 'libstdc++.so.5' found available, installed or updated"]}
```
This is fixed when changing the var in roles/Common/vars/RedHat.yml from libstdc++.so.5 to libstdc++

Signed-off-by: kevin-bonilla <kevin.bonilla@ibm.com>