### PR TITLE
UnixPB: Add numactl-devel for Redhat vars on ppc64le

### DIFF
--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/tasks/CentOS.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/tasks/CentOS.yml
@@ -73,6 +73,13 @@
     - ansible_distribution_major_version != "8"
   tags: build_tools
 
+- name: Install numactl-devel excluding CENT 7 on s390x
+  package: "name=numactl-devel state=latest"
+  when:
+    - ! (ansible_os_family == "CentOS" and ansible_distribution_major_version == "7")
+    - ansible_architecture != "s390x"
+  tags: build_tools
+
 - name: Add devtools-2 to yum repo list for gcc 4.8
   get_url:
     url: https://people.centos.org/tru/devtools-2/devtools-2.repo

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/tasks/RedHat.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/tasks/RedHat.yml
@@ -78,7 +78,8 @@
 - name: Install numactl-devel excluding RHEL 7 on s390x
   package: "name=numactl-devel state=latest"
   when:
-    - (ansible_distribution_major_version != "7" and ansible_architecture != "s390x")
+    - ! (ansible_os_family == "RedHat" and ansible_distribution_major_version == "7")
+    - ansible_architecture != "s390x"
   tags: build_tools
 
 - name: Install additional build tools for RHEL on x86

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/vars/RedHat.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/vars/RedHat.yml
@@ -60,7 +60,6 @@ Additional_Build_Tools_RHEL7:
 
 Additional_Build_Tools_RHEL7_PPC64LE:
   - libstdc++
-  - numactl-devel
 
 Additional_Build_Tools_RHEL_x86:
   - glibc.i686                    # a dependency required for executing a 32-bit C binary

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/vars/RedHat.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/vars/RedHat.yml
@@ -60,6 +60,7 @@ Additional_Build_Tools_RHEL7:
 
 Additional_Build_Tools_RHEL7_PPC64LE:
   - libstdc++
+  - numactl-devel
 
 Additional_Build_Tools_RHEL_x86:
   - glibc.i686                    # a dependency required for executing a 32-bit C binary


### PR DESCRIPTION
- Added `numactl-devel` to `Additional_Build_Tools_RHEL7_PPC64LE`

numactl-devel is a required package for running builds. During my testing I ran into blocker due to missing numactl dependancies on Redhat 7 ppc64le
```
configure: error: Could not find numa!
```
This is fixed when adding `numactl-devel` to vars in roles/Common/vars/RedHat.yml, more specifically under `Additional_Build_Tools_RHEL7_PPC64LE`

Signed-off-by: kevin-bonilla <kevin.bonilla@ibm.com>