### PR TITLE
inv: Update Test/infra machine sections

### DIFF
--- a/ansible/inventory.yml
+++ b/ansible/inventory.yml
@@ -18,7 +18,7 @@ hosts:
 
       - softlayer:
           ubuntu1604-x64-3: {ip: 158.176.72.83, description: jckservices.adoptopenjdk.net}
-          vagrant-x64-1: {ip: 52.117.150.132, description: Bare metal machien to run VM playbook testing}
+          ubuntu1804-x64-1: {ip: 52.117.150.132, description: Bare metal machine to run VM playbook testing}
 
       - godaddy:
           ubuntu1604-x64-1: {ip: 160.153.247.225, description: git-hg/load relief for jenkins master}
@@ -106,14 +106,23 @@ hosts:
           win2012r2-x64-3: {ip: 13.68.219.237, user: adoptopenjdk}
 
       - aws:
+          rhel76-armv8-1: {ip: 18.202.36.216, user: ec2-user}
+          rhel76-armv8-2: {ip: 34.245.159.35, user: ec2-user}
+          rhel76-armv8-3: {ip: 34.246.191.41, user: ec2-user}
+          rhel76-armv8-4: {ip: 54.154.138.147, user: ec2-user}
+          rhel76-armv8-5: {ip: 52.209.17.37, user: ec2-user}
+          rhel76-armv8-6: {ip: 54.229.245.232, user: ec2-user}
+          rhel8-x64-1: {ip: 54.246.216.49}
+          ubuntu1804-armv8-1: {ip: 34.243.202.254}
+          ubuntu2004-x64-1: {ip: 34.241.242.10}
           win2019-x64-1: {ip: 34.244.74.139, user: Administrator}
           win2019-x64-2: {ip: 34.245.29.235, user: Administrator}
 
       - godaddy:
-          win2016-x64-1: {ip: 160.153.234.27, user: adoptopenjdk}
-          win2016-x64-2: {ip: 160.153.234.5, user: adoptopenjdk}
-          win2016-x64-3: {ip: 160.153.234.8, user: adoptopenjdk}
-          win2016-x64-4: {ip: 160.153.234.22, user: adoptopenjdk}
+          centos7-x64-1: {ip: 160.153.244.82, user: adoptopenjdk}
+          centos7-x64-2: {ip: 160.153.246.204, user: adoptopenjdk}
+          centos7-x64-3: {ip: 160.153.246.194, user: adoptopenjdk}
+          centos7-x64-4: {ip: 160.153.244.42, user: adoptopenjdk}
           debian8-x64-1: {ip: 160.153.246.223, user: adoptopenjdk}
           debian8-x64-2: {ip: 160.153.246.42, user: adoptopenjdk}
           debian8-x64-3: {ip: 160.153.246.234, user: adoptopenjdk}
@@ -122,24 +131,21 @@ hosts:
           ubuntu1604-x64-2: {ip: 160.153.246.176, user: adoptopenjdk}
           ubuntu1604-x64-3: {ip: 160.153.246.222, user: adoptopenjdk}
           ubuntu1604-x64-4: {ip: 160.153.246.214, user: adoptopenjdk}
-          centos7-x64-1: {ip: 160.153.244.82, user: adoptopenjdk}
-          centos7-x64-2: {ip: 160.153.246.204, user: adoptopenjdk}
-          centos7-x64-3: {ip: 160.153.246.194, user: adoptopenjdk}
-          centos7-x64-4: {ip: 160.153.244.42, user: adoptopenjdk}
-
-      - aws:
-          rhel76-armv8-1: {ip: 18.202.36.216, user: ec2-user}
-          rhel76-armv8-2: {ip: 34.245.159.35, user: ec2-user}
-          rhel76-armv8-3: {ip: 34.246.191.41, user: ec2-user}
-          rhel76-armv8-4: {ip: 54.154.138.147, user: ec2-user}
-          rhel76-armv8-5: {ip: 52.209.17.37, user: ec2-user}
-          rhel76-armv8-6: {ip: 54.229.245.232, user: ec2-user}
+          win2016-x64-1: {ip: 160.153.234.27, user: adoptopenjdk}
+          win2016-x64-2: {ip: 160.153.234.5, user: adoptopenjdk}
+          win2016-x64-3: {ip: 160.153.234.8, user: adoptopenjdk}
+          win2016-x64-4: {ip: 160.153.234.22, user: adoptopenjdk}
 
       - ibm:
           aix71-ppc64-1: {ip: 129.33.196.209, user: b9s010a}
           aix71-ppc64-2: {ip: 129.33.196.210, user: b9s010a}
 
+#     - inspira:
+#         solaris10u11-sparcv9-1: {ip: }
+
       - osuosl:
+          aix72-ppc64-1: {ip: 140.211.9.28}
+          aix72-ppc64-2: {ip: 140.211.9.36}
           centos74-ppc64le-1: {ip: 140.211.168.228, user: centos}
           centos74-ppc64le-2: {ip: 140.211.168.217, user: centos}
           centos74-ppc64le-3: {ip: 140.211.168.225, user: centos}
@@ -151,8 +157,6 @@ hosts:
           ubuntu1804-ppc64le-1: {ip: 140.211.168.5, user: ubuntu}
           ubuntu1804-ppc64le-2: {ip: 140.211.168.8, user: ubuntu}
           ubuntu1804-ppc64le-3: {ip: 140.211.168.4, user: ubuntu}
-          aix72-ppc64-1: {ip: 140.211.9.28}
-          aix72-ppc64-2: {ip: 140.211.9.36}
 
       - packet:
           ubuntu1604-armv8-1: {ip: 147.75.74.50}
@@ -183,8 +187,7 @@ hosts:
           ubuntu1604-x64-1: {ip: 51.15.76.107}
 
       - softlayer:
-          ubuntu1604-x64-1: {ip: 169.55.150.155}
           rhel74-x64-1: {ip: 169.55.170.70}
           rhel69-x64-1: {ip: 169.55.150.147}
-          win2012r2-x64-1: {ip: 169.55.170.72, user: admin}
+          ubuntu1604-x64-1: {ip: 169.55.150.155}
           win2012r2-x64-2: {ip: 52.117.29.13, user: Administrator}


### PR DESCRIPTION
Fixes: #634 

This should get the `inventory.yml` more accurately reflecting Jenkins. This PR is primarily ensuring `inventory.yml` is in alphabetical order and adds in a couple machines that are on Jenkins but not here.
I have omitted from `inventory.yml` the machines with the `-sxa` prefix, on request of @sxa, as they're only meant to be temporary machines.
Currently `test-inspira-solaris10u11-sparcv9-1` is commented out as I'm unable to find the IP address for the machine (ping @gdams )