### PR TITLE
UnixPB: Failing NTP_TIME role for Ubuntu 20

### DIFF
--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/NTP_TIME/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/NTP_TIME/tasks/main.yml
@@ -6,6 +6,14 @@
   command: timedatectl set-ntp no
   when:
     - (ansible_distribution == "RedHat" and ansible_distribution_major_version == "7") or (ansible_distribution == "Ubuntu") or ((ansible_distribution == "SLES" or ansible_distribution == "openSUSE") and ansible_distribution_major_version == "12") or (ansible_distribution == "centos" and ansible_distribution_major_version == "7" )
+    - not (ansible_distribution == "Ubuntu" and ansible_distribution_major_version == "20")
+  tags: ntp_time
+
+- name: Ensure systemd-timesyncd service is disabled
+  service:
+    name: systemd-timesyncd
+    enabled: no
+  when: ansible_distribution != "CentOS" and ansible_distribution != "RedHat"
   tags: ntp_time
 
 - name: Configure NTP server pools


### PR DESCRIPTION
Ref https://github.com/AdoptOpenJDK/openjdk-infrastructure/issues/1226

Skips the `Set timedatectl set-ntp no` task for Ubuntu 20 as it causes the playbook to break, but instead runs an alternative, but equivalent, task of disabling the `systemd-timesyncd` service. This alternative task can also be run on distros that are not Ubuntu 20, since, after some inspection, our machines have the `systemd-timesyncd` service disabled by default.

However this service is not available on Centos or Redhat, hence the alternative task is skipped for those distros.