### PR TITLE
pbTests: Remove `--force` flag when using vagrant halt

### DIFF
--- a/ansible/pbTestScripts/vagrantPlaybookCheck.sh
+++ b/ansible/pbTestScripts/vagrantPlaybookCheck.sh
@@ -276,13 +276,13 @@ startVMPlaybookWin()
 	cd $WORKSPACE/adoptopenjdkPBTests/$folderName-$branchName/ansible
         if [[ "$testNativeBuild" = true && "$pbFailed" == 0 ]]; then
 		# Restarting the VM as the shared folder disappears after the playbook runs. (Possibly due to the restarts in the playbook)
-		vagrant halt --force && vagrant up
+		vagrant halt && vagrant up
 		# Runs the build script via ansible, as vagrant powershell gives error messages that ansible doesn't. 
         	# See: https://github.com/AdoptOpenJDK/openjdk-infrastructure/pull/942#issuecomment-539946564
 		python pbTestScripts/startScriptWin.py -i $(cat playbooks/AdoptOpenJDK_Windows_Playbook/hosts.win) -a "$buildURL $jdkToBuild $buildHotspot" -b
 		echo The build finished at : `date +%T`
 		if [[ "$runTest" = true ]]; then
-			vagrant halt --force && vagrant up
+			vagrant halt && vagrant up
 			# Runs a script on the VM to test the built JDK
 			python pbTestScripts/startScriptWin.py -i $(cat playbooks/AdoptOpenJDK_Windows_Playbook/hosts.win) -t
 			echo The test finished at : `date +%T`
@@ -324,7 +324,7 @@ do
 		startVMPlaybook $OS
 	fi
   	if [[ "$vmHalt" == true ]]; then
-                vagrant halt --force
+                vagrant halt 
 	fi
 	if [[ "$retainVM" == false ]]; then
 		destroyVM $OS


### PR DESCRIPTION
Fixes #1281 

Previous issue encountered where Windows VMs would hang if `vagrant halt` was ran without a `--force` flag. I've been unable to recreate the issue, so I'll remove the flags. If it recurrs we can re-open the above issue