### PR TITLE
VF: Force no-prompt upgrade to grub-pc on U18

### DIFF
--- a/ansible/Vagrantfile.Ubuntu1804
+++ b/ansible/Vagrantfile.Ubuntu1804
@@ -6,6 +6,7 @@ sudo apt-get install tree -y
 sudo apt-get install software-properties-common
 sudo apt-add-repository ppa:ansible/ansible
 sudo apt-get update
+sudo DEBIAN_FRONTEND=noninteractive apt-get -y -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" install --only-upgrade grub-pc
 sudo apt-get install ansible -y
 sudo mkdir /ansible
 sudo cp /etc/ansible/ansible.cfg /ansible


### PR DESCRIPTION
Fixes: #1344 

Fixes an issue specific to the Vagrant box that we use, where `grub-pc` needs to be upgraded with the `DEBIAN_FRONTEND=noninteractive` variable, to stop a prompt coming up on the `apt-get upgrade` task in the playbook. 

In draft until I can run it through `VPC` properly.

