### PR TITLE
VFs: Add Ubuntu20.04

### DIFF
--- a/ansible/Vagrantfile.Ubuntu2004
+++ b/ansible/Vagrantfile.Ubuntu2004
@@ -1,0 +1,28 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+$script = <<SCRIPT
+# Get IPs of the VM, and output to shared folder
+ip address show | grep -w inet | cut -d/ -f 1 | sed 's/inet//g' >> /vagrant/playbooks/AdoptOpenJDK_Unix_Playbook/hosts.tmp
+# Put the host machine's IP into the authorised_keys file on the VM
+if [ -r /vagrant/id_rsa.pub ]; then
+        mkdir -p $HOME/.ssh && cat /vagrant/id_rsa.pub >> $HOME/.ssh/authorized_keys
+fi
+SCRIPT
+
+# 2 = version of configuration file for Vagrant 1.1+ leading up to 2.0.x
+Vagrant.configure("2") do |config|
+
+  config.vm.define :adoptopenjdkU20 do |adoptopenjdkU20|
+    adoptopenjdkU20.vm.box = "generic/ubuntu2004"
+    adoptopenjdkU20.vm.synced_folder ".", "/vagrant"
+    adoptopenjdkU20.vm.hostname = "adoptopenjdkU20"
+    adoptopenjdkU20.vm.network :private_network, type: "dhcp"
+    adoptopenjdkU20.vm.provision "shell", inline: $script, privileged: false
+  end
+  config.vm.provider "virtualbox" do |v|
+    v.gui = false
+    v.memory = 2560
+    v.customize ["modifyvm", :id, "--cpuexecutioncap", "50"]
+  end
+end


### PR DESCRIPTION
Ref: #1226 #1340 

As the two above PRs are in and merged and `generic` recently releasing an Ubuntu20.04 vagrant box, I've added it so we can start testing it with `VPC`, when it eventually works. 
This is effectively the same as the other Ubuntu VFs, though I've stripped out the unnecessary code in the script session. I've also redone the command required to get the IP address as thats changed between U18 and U20.