### PR TITLE
UnixPB: Don't validate certs for wget-ting the git source

### DIFF
--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/GIT_Source/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/GIT_Source/tasks/main.yml
@@ -32,6 +32,7 @@
     dest: /tmp/git-2.15.0.tar.xz
     mode: 0440
     checksum: sha256:107116489f10b758b51af1c5dbdb9a274917b0fb67dc8eaefcdabc7bc3eb3e6a
+    validate_certs: no
   retries: 3
   delay: 5
   register: git_download


### PR DESCRIPTION
ref: https://ci.adoptopenjdk.net/view/Tooling/job/VagrantPlaybookCheck/OS=SUSE12,label=vagrant/658/console

SUSE has been consistently failing due to the SSL cert not being able to be validated. Unfortunately, attempting to install the python modules suggested failed due to not being able to find them, therefore I opted for not `validating_certs` - as we have the checksum in place, (AFAIK) there's no added security risk of this. 