### PR TITLE
UnixPD: Skip failing NTP_TIME task for FreeBSD

### DIFF
--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/NTP_TIME/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/NTP_TIME/tasks/main.yml
@@ -13,7 +13,9 @@
   service:
     name: systemd-timesyncd
     enabled: no
-  when: ansible_distribution != "CentOS" and ansible_distribution != "RedHat"
+  when: 
+    - ansible_distribution != "CentOS" and ansible_distribution != "RedHat"
+    - ansible_distribution != "FreeBSD"
   tags: ntp_time
 
 - name: Configure NTP server pools

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/NTP_TIME/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/NTP_TIME/tasks/main.yml
@@ -13,7 +13,7 @@
   service:
     name: systemd-timesyncd
     enabled: no
-  when: 
+  when:
     - ansible_distribution != "CentOS" and ansible_distribution != "RedHat"
     - ansible_distribution != "FreeBSD"
   tags: ntp_time


### PR DESCRIPTION
Ref https://github.com/AdoptOpenJDK/openjdk-infrastructure/issues/1364

Currently the `Ensure systemd-timesyncd service is disabled` fails on FreeBSD. However since this task is a "duplicate" of the `Set timedatectl set-ntp no` task which is skipped for FreeBSD it seem logical to skip this failing task too