### PR TITLE
pbTests: Add Ubuntu2004 to vmDestroy.sh

### DIFF
--- a/ansible/pbTestScripts/vmDestroy.sh
+++ b/ansible/pbTestScripts/vmDestroy.sh
@@ -43,6 +43,8 @@ checkOS() {
 			osToDestroy="U16";;
                 "Ubuntu1804" | "U18" | "u18" )
                         osToDestroy="U18";;
+                "Ubuntu2004" | "U20" | "u20" )
+                        osToDestroy="U20";;
                 "CentOS6" | "centos6" | "C6" | "c6" )
                         osToDestroy="C6" ;;
                 "CentOS7" | "centos7" | "C7" | "c7" )
@@ -60,7 +62,7 @@ checkOS() {
 		"Windows2012" | "Win2012" | "W12" | "w12" )
                         osToDestroy="W2012";;
                 "all" )
-                        osToDestroy="U16 U18 C6 C7 D8 D10 FBSD12 S12 W2012" ;;
+                        osToDestroy="U16 U18 U20 C6 C7 D8 D10 FBSD12 S12 W2012" ;;
 		"")
 			echo "No OS detected. Did you miss the '-o' option?" ; usage; exit 1;;
 		*) echo "$OS is not a currently supported OS" ; listOS; exit 1;
@@ -72,6 +74,7 @@ listOS() {
 	echo "Currently supported OSs:
 		- Ubuntu1604
 		- Ubuntu1804
+		- Ubuntu2004
 		- CentOS6
 		- CentOS7
 		- CentOS8


### PR DESCRIPTION
Allow `vmDestroy.sh` to pickup Ubuntu2004 as a viable option, so it can be destroyed in the `VagrantPlaybookCheck` Jenkins job.