### PR TITLE
PBs: Update which JDKs to install

### DIFF
--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/main.yml
@@ -58,11 +58,12 @@
     - role: adoptopenjdk_install
       jdk_version: 11
       tags: build_tools
-    - role: adoptopenjdk_install  # JDK13 Build Bootstrap
-      jdk_version: 12
-      tags: build_tools
     - role: adoptopenjdk_install  # JDK14 Build Bootstrap
       jdk_version: 13
+      tags: build_tools
+    - role: adoptopenjdk_install  # JDK15 Build Bootstrap
+      jdk_version: 14
+      tags: build_tools
     - OpenSSL102                  # OpenJ9
     # - Nagios_Plugins              # AdoptOpenJDK Infrastructure
     # - Nagios_Master_Config        # AdoptOpenJDK Infrastructure

--- a/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/main.yml
@@ -52,10 +52,12 @@
     - Java8                       # JDK9 build bootstrap/ For Gradle
     - role: Java_install          # JDK11 build bootstrap
       jdk_version: 10
-    - role: Java_install          # JDK13 build bootstrap
-      jdk_version: 12
+    - role: Java_install          # For Gradle
+      jdk_version: 11
     - role: Java_install          # JDK14 build bootstrap
       jdk_version: 13
+    - role: Java_install          # JDK15 build bootstrap
+      jdk_version: 14
     - ANT                         # Testing
     - MSVS_2013
     - MSVS_2017                   # OpenJ9


### PR DESCRIPTION
Ref: #1001 

Stop install JDK12 on machines as we no longer build JDK13, start installing JDK14 for JDKNext. 