### PR TITLE
VF: Remove whitespace from generated U20 host file

### DIFF
--- a/ansible/Vagrantfile.Ubuntu2004
+++ b/ansible/Vagrantfile.Ubuntu2004
@@ -3,7 +3,7 @@
 
 $script = <<SCRIPT
 # Get IPs of the VM, and output to shared folder
-ip address show | grep -w inet | cut -d/ -f 1 | sed 's/inet//g' >> /vagrant/playbooks/AdoptOpenJDK_Unix_Playbook/hosts.tmp
+ip address show | grep -w inet | cut -d/ -f 1 | sed 's/inet//g' | tr -d '[:blank:]' >> /vagrant/playbooks/AdoptOpenJDK_Unix_Playbook/hosts.tmp
 # Put the host machine's IP into the authorised_keys file on the VM
 if [ -r /vagrant/id_rsa.pub ]; then
         mkdir -p $HOME/.ssh && cat /vagrant/id_rsa.pub >> $HOME/.ssh/authorized_keys


### PR DESCRIPTION
Remove the whitespace from the generated host file when running the Ubuntu2004 provisioning shell. 
Currently, the host file will be generated to spaces before the IP address. Whereas Ansible can deal with this, the ssh command used to start running builds in `VPC` cannot (https://github.com/AdoptOpenJDK/openjdk-infrastructure/blob/9a8939be81093e4d91784cfe42dc2008204b9fda/ansible/pbTestScripts/vagrantPlaybookCheck.sh#L235)
E.g. : https://ci.adoptopenjdk.net/view/Tooling/job/VagrantPlaybookCheck/681/OS=Ubuntu2004,label=infra-softlayer-ubuntu1804-x64-1/console
It's trying to execute on the host `vagrant@ 172.28.128.25`