### PR TITLE
UnixPB: Added missing dependancies

### DIFF
--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/vars/SLES.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/vars/SLES.yml
@@ -64,6 +64,10 @@ Additional_Build_Tools_SLES_x86:
   - glibc-32bit                   # a dependency required for executing a 32-bit C binary
   - glibc-devel-32bit             # a dependency required for executing a 32-bit C binary
   - libstdc++6-32bit              # a dependency required for executing a 32-bit C binary
+  - libelf0-32bit                 # a dependency required for executing a 32-bit C binary
+  - libelf0-debuginfo-32bit       # a dependency required for executing a 32-bit C binary
+  - libstdc++-devel-32bit         # a dependency required for executing a 32-bit C binary
+  - libXtst6-32bit                # a dependency required for executing a 32-bit C binary
 
 Test_Tool_Packages:
   - gcc


### PR DESCRIPTION
Added missing dependancies for SLES that can be installed with zypper.

- libelf0-32bit
- libelf0-debuginfo-32bit
- libstdc++-devel-32bit
- libXtst6-32bit

Signed off by Pav.Salimon@ibm.com