### PR TITLE
UnixPB: Exclude make from updating when gmake is built

### DIFF
--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/gmake/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/gmake/tasks/main.yml
@@ -86,6 +86,9 @@
   ignore_errors: yes
   tags: goodmake_source
 
+
+# Disabiling updates to system 'make' to ensure the symlink above doesn't break.
+# See https://github.com/AdoptOpenJDK/openjdk-infrastructure/issues/1106
 - name: Check if /etc/yum.conf exists
   stat:
     path: /etc/yum.conf

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/gmake/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/gmake/tasks/main.yml
@@ -85,3 +85,37 @@
     - /tmp/make-{{ makeVersion }}.tar.gz
   ignore_errors: yes
   tags: goodmake_source
+
+- name: Check if /etc/yum.conf exists
+  stat:
+    path: /etc/yum.conf
+  register: yumconf
+  when:
+    - ((ansible_distribution == "RedHat" or ansible_distribution == "CentOS") and ansible_distribution_major_version|int < 8)
+  tags: goodmake_source
+
+- name: Create /etc/yum.conf and exclude make from updates
+  lineinfile:
+    path: /etc/yum.conf
+    create: yes
+    line: [main]
+  when:
+    - ((ansible_distribution == "RedHat" or ansible_distribution == "CentOS") and ansible_distribution_major_version|int < 8)
+    - not yumconf.stat.exists
+  tags: goodmake_source
+
+- name: Exclude make from updates if /etc/yum.conf does exist
+  lineinfile:
+    path: /etc/yum.conf
+    line: exclude=make
+  when:
+    - ((ansible_distribution == "RedHat" or ansible_distribution == "CentOS") and ansible_distribution_major_version|int < 8)
+  tags: goodmake_source
+
+- name: Configure Apt to exclude make from updating
+  dpkg_selections:
+    name: make
+    state: hold
+  when:
+    - (ansible_distribution == "Ubuntu" and ansible_distribution_major_version == "14")
+  tags: goodmake_source


### PR DESCRIPTION
Fixes: #1106 

This change will exclude `make` from auto-updating after creating the symlink to `gmake`. With the CentOS / RedHat system, the `yum` package of `make` is a dependency of `yum` itself and therefore can't be uninstalled, however if the updates are stopped, the symlink created won't be broken. 
This should stop machines reverting back to using an older version of `make`.