### PR TITLE
pbTests: Force 'JAVA_HOME' to /usr/lib/jvm/jdk8

### DIFF
--- a/ansible/pbTestScripts/buildJDK.sh
+++ b/ansible/pbTestScripts/buildJDK.sh
@@ -145,7 +145,7 @@ if [[ ${unameOutput} != "x86_64" ]]; then
 fi
 
 # Use the JDK8 installed with the adoptopenjdk_install role to run Gradle with.
-export JAVA_HOME=$(find /usr/lib/jvm -maxdepth 1 -name *jdk8*)
+export JAVA_HOME=/usr/lib/jvm/jdk8
 
 # Only build Hotspot on FreeBSD
 if [[ $(uname) == "FreeBSD" ]]; then


### PR DESCRIPTION
Recently the `VPC` job has been issues finding a JDK to run Gradle. 
I think this may be due to the `find` function in `buildJDK.sh` picking up multiple JDK8s - i.e. `/usr/lib/jvm/jdk8` and `/usr/lib/jvm/jdk8u242-b09`.
Hardcoding `JAVA_HOME` to `/usr/lib/jvm/jdk8` should be okay as the `adoptopenjdk_install` task ensures it's at that path. 