### PR TITLE
winPB: Update MSVS_2017 download checksum

### DIFF
--- a/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/roles/MSVS_2017/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/roles/MSVS_2017/tasks/main.yml
@@ -14,7 +14,7 @@
     url: 'https://aka.ms/vs/15/release/vs_community.exe'
     dest: 'C:\TEMP\vs_community.exe'
     force: no
-    checksum: e7405c4f1c66af1b7d6458d3162a79295fa1c4e52b74744632dcdbb266b422b3
+    checksum: cc9556137c66a373670376d6db2fc5c5c937b2b0bf7b3d3cac11c69e33615511
     checksum_algorithm: sha256
   when: (not vs2017_installed.stat.exists)
   tags: MSVS_2017


### PR DESCRIPTION
Update MSVS_2017 chcksum as it's out of date again: 
https://ci.adoptopenjdk.net/view/Tooling/job/VagrantPlaybookCheck/OS=Win2012,label=infra-softlayer-ubuntu1804-x64-1/691/console

I double checked the checksum that the above log says it was by running `sha256sum vs_community.exe` and I got the same result.