### PR TITLE
pbTests: Hardcode JDK_BOOT_DIR in buildJDK.sh

### DIFF
--- a/ansible/pbTestScripts/buildJDK.sh
+++ b/ansible/pbTestScripts/buildJDK.sh
@@ -84,6 +84,7 @@ checkJDKVersion() {
 setBootJDK() {
         local buildJDKNumber=$(echo ${JAVA_TO_BUILD//[!0-9]/})
         local bootJDKNumber=$(($buildJDKNumber - 1));
+        # Refer to 8 as 'jdk8'. Anything else is 'jdk-XX'
         [[ $bootJDKNumber != "8" ]] && bootJDKNumber="-$bootJDKNumber"
         if [[ $buildJDKNumber -eq 8 ]]; then
                 # CentOS JDK7
@@ -93,14 +94,14 @@ setBootJDK() {
                 # Zulu-7 for OSs without JDK7
                 [[ -z "$JDK_BOOT_DIR" ]] && export JDK_BOOT_DIR=$(find /usr/lib/jvm/ -maxdepth 1 -name zulu7)
         else
-                export JDK_BOOT_DIR=$(find /usr/lib/jvm -maxdepth 1 -name *jdk$bootJDKNumber*)
+                export JDK_BOOT_DIR=/usr/lib/jvm/jdk${bootJDKNumber}
         fi
         # If JDK (jdkToBuild - 1) can't be found, look for equal boot and build jdk
         if [ -z "${JDK_BOOT_DIR}" ]
         then
                 [[ $buildJDKNumber != "8" ]] && buildJDKNumber="-$buildJDKNumber"
                 echo "Can't find jdk$bootJDKNumber to build JDK, looking for jdk$buildJDKNumber"
-                export JDK_BOOT_DIR=$(find /usr/lib/jvm -maxdepth 1 -name *jdk$buildJDKNumber*)
+                export JDK_BOOT_DIR=/usr/lib/jvm/jdk${buildJDKNumber}
         fi
 }
 


### PR DESCRIPTION
Ref: #1387 

I didn't realise that as part of the above PR we now symlink the JDK versions to `/usr/lib/jvm/jdk-XX` ( or `/usr/lib/jvm/jdk8`), like we do with the Windows playbooks. Due to this, the `find` functions that are being replaced in this PR pick up multiple entries, which confuse the build-scripts. (see all the Ubuntu runs and C6 / C7 in this `VPC` run: https://ci.adoptopenjdk.net/view/Tooling/job/VagrantPlaybookCheck/692/ )
Hardcoding this fixes this :-) 