### PR TITLE
Add gcc 7.5.0 install to arm32 Ubuntu16 machines (for build)

### DIFF
--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/gcc_7/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/gcc_7/tasks/main.yml
@@ -9,7 +9,7 @@
   ignore_errors: yes
   register: gcc7_installed
   tags: gcc-7
-  when: ansible_distribution == "RedHat" or ansible_distribution == "CentOS" or ansible_distribution == "openSUSE"
+  when: ansible_distribution == "RedHat" or ansible_distribution == "CentOS" or ansible_distribution == "openSUSE" or ( ansible_architecture == "armv7l" and ansible_distribution_major_version == "16" )
 
   # Unable to check the checksum of the binary as it'll be different for each architecture's tar.xz file
 
@@ -20,7 +20,7 @@
     force: no
     mode: 0644
   when:
-    - ansible_distribution == "RedHat" or ansible_distribution == "CentOS" or ansible_distribution == "openSUSE"
+    - ansible_distribution == "RedHat" or ansible_distribution == "CentOS" or ansible_distribution == "openSUSE" or ( ansible_architecture == "armv7l" and ansible_distribution_major_version == "16" )
     - gcc7_installed.rc != 0
   tags: gcc-7
 
@@ -30,7 +30,7 @@
     dest: /usr/local/
     copy: False
   when:
-    - ansible_distribution == "RedHat" or ansible_distribution == "CentOS" or ansible_distribution == "openSUSE"
+    - ansible_distribution == "RedHat" or ansible_distribution == "CentOS" or ansible_distribution == "openSUSE" or ( ansible_architecture == "armv7l" and ansible_distribution_major_version == "16" )
     - gcc7_installed.rc != 0
   tags: gcc-7
 
@@ -39,6 +39,6 @@
     path: '/tmp/ansible-adoptopenjdk-gcc-7.tar.xz'
     state: absent
   when:
-    - ansible_distribution == "RedHat" or ansible_distribution == "CentOS" or ansible_distribution == "openSUSE"
+    - ansible_distribution == "RedHat" or ansible_distribution == "CentOS" or ansible_distribution == "openSUSE" or ( ansible_architecture == "armv7l" and ansible_distribution_major_version == "16" )
     - gcc7_installed.rc != 0
   tags: gcc-7


### PR DESCRIPTION
Last nights builds with this change look good, so merging this which will bring arm32 builds up to the level of gcc used on other Linux platforms. NOTE that this will not install on raspbian at present, although I have tested with a tweaked version of this to ensure that it works

Fixes https://github.com/AdoptOpenJDK/openjdk-infrastructure/issues/487

Signed-off-by: Stewart Addison <sxa@uk.ibm.com>