### PR TITLE
winPB: Separate remove speech mark & add cygwin to front of %PATH% task

### DIFF
--- a/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/roles/cygwin/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/roles/cygwin/tasks/main.yml
@@ -106,20 +106,30 @@
       - 'C:\cygwin64\bin'
     scope: machine
     state: absent
+  when: (not cygwin_installed.stat.exists)
   tags: cygwin
 
 # NOTE: This construct is because an SQL Server entry is being added to
 # the path which has an erroneous quote in it which causes problems for SETX
-- name: Add c:\cygwin64\bin to front of %PATH%
-  win_shell: 'setx /M PATH "C:\cygwin64\bin;%PATH:\"=%"'
+# See https://github.com/AdoptOpenJDK/openjdk-infrastructure/issues/1401
+- name: Remove speech mark from the %PATH%
+  win_shell: 'setx /M PATH "%PATH:\"=%"'
   args:
     executable: cmd
+  when: (not cygwin_installed.stat.exists)
   tags:
     - cygwin
-    # TODO: write a condition when NOT to run this step
-    - skip_ansible_lint
+
+- name: Add c:\cygwin64\bin to front of %PATH%
+  win_shell: 'setx /M PATH "C:\cygwin64\bin;%PATH%"'
+  args:
+    executable: cmd
+  when: (not cygwin_installed.stat.exists)
+  tags:
+    - cygwin
 
 - name: Reboot machine for PATH changes to take effect
   win_reboot:
     reboot_timeout: 1800
+  when: (not cygwin_installed.stat.exists)
   tags: cygwin


### PR DESCRIPTION
Fixes: #1401 

FYI @lumpfish 

Separates the task `Add c:\cygwin64\bin to front of %PATH%` and `Remove speech marks from %PATH%`,  as it makes it clearer how each task is being done, for people who don't know `cmd` / Windows.
As well as this, making sure that these changes are made only as we install cygwin, as the path changes are only needed directly after it's installed, and rerunning the current `Add c:\cygwin64\bin to front of %PATH%` task causes an error.