### PR TITLE
aixPB: download packages from yum instead

### DIFF
--- a/ansible/playbooks/aix.yml
+++ b/ansible/playbooks/aix.yml
@@ -191,6 +191,10 @@
             - grep
             - libXrender-devel
             - libffi-devel
+            - libiconv
+            - libunistring
+            - perl
+            - cmake
             - make
             - m4
             - pcre
@@ -206,23 +210,6 @@
             - zip
             - zsh
           tags: yum
-
-      ##############################################
-      # Additional Tools not available through yum #
-      ##############################################
-        - name: Install yum package support
-          yum: name={{ item }} state=present update_cache=yes
-          with_items:
-            - http://www.bullfreeware.com/download/bin/2328/libiconv-1.14-22.aix6.1.ppc.rpm
-            - http://www.bullfreeware.com/download/bin/2591/libunistring-0.9.6-2.aix6.1.ppc.rpm
-            - http://www.bullfreeware.com/download/bin/3944/perl-5.24.0-3.aix6.1.ppc.rpm
-            - http://www.oss4aix.org/download/RPMS/cmake/cmake-3.7.2-1.aix6.1.ppc.rpm
-          tags: rpm_install
-
-        - name: Ensure perl from /opt/freeware/bin is the default in /usr/bin
-          shell: mv /usr/bin/perl /usr/bin/perl.old && ln -s /opt/freeware/bin/perl /usr/bin/
-          ignore_errors: True
-          tags: rpm_install
 
       ##############
       # Boot JDK 7 #

--- a/ansible/playbooks/aix.yml
+++ b/ansible/playbooks/aix.yml
@@ -429,6 +429,7 @@
           shell: lslpp -l X11.adt.ext >/dev/null 2>&1
           register: does_X11_adt_ext_exist
           ignore_errors: yes
+          tags: x11
 
         - name: Check if X11.vfb is installed
           shell: lslpp -l X11.vfb >/dev/null 2>&1


### PR DESCRIPTION
Ref https://github.com/AdoptOpenJDK/openjdk-infrastructure/issues/1391

Ive replaced the bullfreeware download links for perl, cmake, libiconv and libunistring with the usual yum install. Besides the cmake link, the other 3 were not working so needed to be replaced.

The packages download, without error, on one aix 7.1 machine on which ive tested.