### PR TITLE
ansible: add which to centos packages

### DIFF
--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/vars/CentOS.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/vars/CentOS.yml
@@ -47,6 +47,7 @@ Build_Tool_Packages:
   - systemtap-sdt-devel
   - unzip
   - wget
+  - which
   - xz
   - zip
 


### PR DESCRIPTION
The centos7 dockerfile doesn't come with which by default