### PR TITLE
UnixPB: Add provider specfic role & godaddy host tasks in it

### DIFF
--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/main.yml
@@ -22,6 +22,7 @@
     - Debug
     - Version
     - Common
+    - Providers                   # AdoptOpenJDK Infrastructure
     - autoconf
     - curl
     - Jenkins_User                # AdoptOpenJDK Infrastructure

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Providers/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Providers/tasks/main.yml
@@ -5,6 +5,7 @@
 #
 # Certain providers of machines have idiosyncrasies that should be addressed here
 
+# Skipping linting as no situation where this can't run (lint error 301)
 - name: Determine the provider by the hostname
   shell: set -o pipefail | hostname | cut -d- -f2
   ignore_errors: yes
@@ -12,38 +13,39 @@
   tags:
     - providers
     - adoptopenjdk
+    - skip_ansible_lint
 
 - debug:
     msg: "No provider could be found"
-  when: provider_name.stdout == ""
+  when: provider_name.stdout | length == 0
   tags:
     - providers
     - adoptopenjdk
  
-- debug: 
+- debug:
     msg: "The provider found is: {{ provider_name.stdout }}"
-  when: 
-    - (provider_name.rc == 0) and (provider_name.stdout != "")
+  when:
+    - (provider_name.rc == 0) and (provider_name.stdout | length > 0)
   tags:
-   - providers
-   - adoptopenjdk
+    - providers
+    - adoptopenjdk
 
 ###########
 # GoDaddy #
 ###########
 
-# GoDaddy machines need their host template updated for changes to /etc/hosts to persist 
+# GoDaddy machines need their host template updated for changes to /etc/hosts to persist
 - name: Update /etc/cloud/templates/hosts.debian.tmpl file- IP FQDN hostname (GoDaddy)
   lineinfile:
     dest: /etc/cloud/templates/hosts.debian.tmpl
     regexp: "^(.*){{ ansible_hostname }}(.*)$"
     line: "{{ ansible_default_ipv4.address }} {{ inventory_hostname }}.{{ Domain }} {{ inventory_hostname }}"
     state: present
-  when: 
+  when:
     - provider_name.rc == 0
     - provider_name.stdout == "godaddy"
     - Domain == "adoptopenjdk.net"
-  tags: 
+  tags:
     - providers
     - adoptopenjdk
 

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Providers/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Providers/tasks/main.yml
@@ -1,0 +1,62 @@
+---
+###########################
+# Provider Specific Tasks #
+###########################
+#
+# Certain providers of machines have idiosyncrasies that should be addressed here
+
+- name: Determine the provider by the hostname
+  shell: set -o pipefail | hostname | cut -d- -f2
+  ignore_errors: yes
+  register: provider_name
+  tags:
+    - providers
+    - adoptopenjdk
+
+- debug:
+    msg: "No provider could be found"
+  when: provider_name.stdout == ""
+  tags:
+    - providers
+    - adoptopenjdk
+ 
+- debug: 
+    msg: "The provider found is: {{ provider_name.stdout }}"
+  when: 
+    - (provider_name.rc == 0) and (provider_name.stdout != "")
+  tags:
+   - providers
+   - adoptopenjdk
+
+###########
+# GoDaddy #
+###########
+
+# GoDaddy machines need their host template updated for changes to /etc/hosts to persist 
+- name: Update /etc/cloud/templates/hosts.debian.tmpl file- IP FQDN hostname (GoDaddy)
+  lineinfile:
+    dest: /etc/cloud/templates/hosts.debian.tmpl
+    regexp: "^(.*){{ ansible_hostname }}(.*)$"
+    line: "{{ ansible_default_ipv4.address }} {{ inventory_hostname }}.{{ Domain }} {{ inventory_hostname }}"
+    state: present
+  when: 
+    - provider_name.rc == 0
+    - provider_name.stdout == "godaddy"
+    - Domain == "adoptopenjdk.net"
+  tags: 
+    - providers
+    - adoptopenjdk
+
+- name: Update /etc/cloud/templates/hosts.debian.tmpl file- IP FQDN hostname (Domian != "adoptopenjdk.net") (GoDaddy)
+  lineinfile:
+    dest: /etc/cloud/templates/hosts.debian.tmpl
+    regexp: "^(.*){{ ansible_hostname }}(.*)$"
+    line: "{{ ansible_default_ipv4.address }} {{ ansible_fqdn }} {{ ansible_hostname }}"
+    state: present
+  when:
+    - provider_name.rc == 0
+    - provider_name.stdout == "godaddy"
+    - Domain != "adoptopenjdk.net"
+  tags:
+    - providers
+    - adoptopenjdk

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Providers/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Providers/tasks/main.yml
@@ -21,7 +21,7 @@
   tags:
     - providers
     - adoptopenjdk
- 
+
 - debug:
     msg: "The provider found is: {{ provider_name.stdout }}"
   when:


### PR DESCRIPTION
Fixes: #1427 

Add a role for tasks that are provider specific to go, along with finding the provider from the hostname on the machine- as most machines I tested had their hostnames the same as their name according to `inventory.yml` and ci.adoptopenjdk.net/computer.

I also added the tasks that were specific to GoDaddy machines (ref: #1145 #1423 ), in which to update `/etc/hosts` and make it persist through reboots, the template file must also be updated.

I've made sure that the tasks all have `adoptopenjdk` as a tag, as this is very specific to setting up machines for AdoptOpenJDK. (Note: Due to this tag, this PR won't be able to be tested through `VPC`)

This was tested on a CentOS6 vagrant VM, whose hostname was set to `test-godaddy-ubuntu1604-x64-1` for testing purposes. To test that roles were skipped when they were meant to, I just removed the `hostname` command from the path, which caused `provider_name.stdout` to be empty (although curiously it didn't throw an error).