### PR TITLE
travis: fix arm64 build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 arch:
   - amd64
-  - arm64
+  - arm64-graviton2
   - ppc64le
 
 env: 


### PR DESCRIPTION
the arm64 builds kept crashing, travis support advised me to switch to graviton2