### PR TITLE
UnixPB: apt_cache update on Ubuntu s390x Install

### DIFF
--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/tasks/Ubuntu.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/tasks/Ubuntu.yml
@@ -10,6 +10,7 @@
   apt:
     name: gnupg2
     state: present
+    update_cache: yes
   when: ansible_architecture == "s390x"
   tags: patch_update
 


### PR DESCRIPTION
Ref: #1444 

WIP PR to keep a track of all changes needed to fix the S390x run of `QEMUPlaybookCheck` ( https://ci.adoptopenjdk.net/job/QEMUPlaybookCheck/ARCHITECTURE=s390x,label=vagrant/ )