### PR TITLE
WinPB: Update MSVS_2017 checksum

### DIFF
--- a/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/roles/MSVS_2017/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/roles/MSVS_2017/tasks/main.yml
@@ -14,7 +14,7 @@
     url: 'https://aka.ms/vs/15/release/vs_community.exe'
     dest: 'C:\TEMP\vs_community.exe'
     force: no
-    checksum: cc9556137c66a373670376d6db2fc5c5c937b2b0bf7b3d3cac11c69e33615511
+    checksum: a4bfd3d43684963707877f8ef5108b5f9bc5ee986f7009bfaea9602c0c3a7e16
     checksum_algorithm: sha256
   when: (not vs2017_installed.stat.exists)
   tags: MSVS_2017


### PR DESCRIPTION
Found in `VPC`: https://ci.adoptopenjdk.net/view/Tooling/job/VagrantPlaybookCheck/728/OS=Win2012,label=vagrant/console