### PR TITLE
unixPB: don't try to install gcc 4.8 on any Debian 10 arch

### DIFF
--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/tasks/Debian.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/tasks/Debian.yml
@@ -116,7 +116,7 @@
   with_items: "{{ gcc_compiler }}"
   when:
     - (ansible_distribution_major_version != "9" and ansible_architecture != "armv7l")
-    - not (ansible_distribution_major_version == "10" and ansible_architecture == "x86_64")
+    - ansible_distribution_major_version != "10"
   tags: build_tools
 
 - name: Install GCC G++ on Raspian Buster


### PR DESCRIPTION
Signed-off-by: Stewart Addison <sxa@uk.ibm.com>