### PR TITLE
UnixPB: Install docker.io for Debian, Add gcc-7 to Common role for aarch64 

### DIFF
--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/vars/Debian.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/vars/Debian.yml
@@ -11,9 +11,11 @@ Build_Tool_Packages:
   - build-essential
   - cpio
   - curl
-  - flex                          # Openj9
+  - flex                          # OpenJ9
   - g++
+  - g++-7                         # OpenJ9
   - gcc
+  - gcc-7                         # OpenJ9
   - gettext
   - libasound2-dev
   - libcups2-dev
@@ -74,18 +76,12 @@ Additional_Packages_Debian8:
 Additional_Build_Tools_x86_64:
   - libnuma-dev
   - numactl
-  - gcc-7
-  - g++-7
 
 Additional_Build_Tools_ppc64le:
   - libnuma-dev
   - numactl
-  - gcc-7                         # OpenJ9
-  - g++-7                         # OpenJ9
 
 Additional_Build_Tools_s390x:
-  - gcc-7                         # OpenJ9
-  - g++-7                         # OpenJ9
   - numactl
   - libfreetype6-dev              # Needed by test state=installed
 

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Docker/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Docker/tasks/main.yml
@@ -283,7 +283,7 @@
     - skip_ansible_lint
 
 - name: Install Docker for Debian
-  package: "name=docker-ce state=latest"
+  package: "name=docker.io state=latest"
   when:
     - docker_installed.rc != 0
     - ansible_distribution == "Debian"

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Docker/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Docker/tasks/main.yml
@@ -200,13 +200,14 @@
 
 # Debian
 
-- name: Add Docker GPG apt Key for Debian
+- name: Add Docker GPG apt Key for Debian ( < 10 )
   apt_key:
     url: https://download.docker.com/linux/debian/gpg
     state: present
   when:
     - docker_installed.rc != 0
     - ansible_distribution == "Debian"
+    - ansible_distribution_major_version|int <10
   tags: docker
 
 - name: Add Docker GPG apt key for Raspbian
@@ -240,6 +241,7 @@
   when:
     - docker_installed.rc != 0
     - ansible_distribution == "Debian"
+    - ansible_distribution_major_version|int <10
     - ansible_architecture == "x86_64"
   tags: docker
 

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Docker/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Docker/tasks/main.yml
@@ -284,11 +284,21 @@
     # TODO: Package installs should not use latest
     - skip_ansible_lint
 
-- name: Install Docker for Debian
+- name: Install Docker for Debian <10
+  package: "name=docker-ce state=latest"
+  when:
+    - docker_installed.rc != 0
+    - (ansible_distribution == "Debian" and ansible_distribution_major_version|int <10)
+  tags:
+    - docker
+    # TODO: Package installs should not use latest
+    - skip_ansible_lint
+
+- name: Install Docker for Debian >=10
   package: "name=docker.io state=latest"
   when:
     - docker_installed.rc != 0
-    - ansible_distribution == "Debian"
+    - (ansible_distribution == "Debian" and ansible_distribution_major_version|int >=10)
   tags:
     - docker
     # TODO: Package installs should not use latest


### PR DESCRIPTION
ref: #1444  ; https://ci.adoptopenjdk.net/job/QEMUPlaybookCheck/46/ARCHITECTURE=arm64,label=vagrant/

For Debian10/aarch64 , `docker-ce` isn't an available package, however `docker.io` is : https://packages.debian.org/buster/arm64/docker.io/download

Running through QEMUPlaybookCheck here: https://ci.adoptopenjdk.net/job/QEMUPlaybookCheck/47/ 
