### PR TITLE
Unix_PB: Add RHEL7 ppc64le support for Docker role

### DIFF
--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Docker/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Docker/tasks/main.yml
@@ -271,12 +271,23 @@
     # TODO: Package installs should not use latest
     - skip_ansible_lint
 
-- name: Install Docker for Cent/Rhel 7
+- name: Install Docker for Cent/Rhel 7 x86
   package: "name=docker-ce state=latest"
   when:
     - docker_installed.rc != 0
     - (ansible_distribution == "RedHat" and ansible_distribution_major_version == "7") or (ansible_distribution == "CentOS" and ansible_distribution_major_version == "7")
     - ansible_architecture == "x86_64"
+  tags:
+    - docker
+    # TODO: Package installs should not use latest
+    - skip_ansible_lint
+
+- name: Install Docker for Cent/Rhel 7 ppc64le
+  package: "name=docker state=latest"
+  when:
+    - docker_installed.rc != 0
+    - (ansible_distribution == "RedHat" and ansible_distribution_major_version == "7") or (ansible_distribution == "CentOS" and ansible_distribution_major_version == "7")
+    - ansible_architecture == "ppc64le"
   tags:
     - docker
     # TODO: Package installs should not use latest


### PR DESCRIPTION
- Added task to install `docker` on RHEL/CENT 7 ppc64le
- Other tasks look for `docker-ce` which is not a valid package for RedHat ppc64le

Signed-off-by: kevin-bonilla <kevin.bonilla@ibm.com>