### PR TITLE
pbTests: Refactor searchLogFile functionality; Add logging for builds and tests

### DIFF
--- a/ansible/Vagrantfile.Win2012
+++ b/ansible/Vagrantfile.Win2012
@@ -5,7 +5,10 @@
 $script = <<SCRIPT
 Start-Process powershell -Verb runAs
 wget https://raw.githubusercontent.com/ansible/ansible/devel/examples/scripts/ConfigureRemotingForAnsible.ps1 -OutFile .\\ConfigureRemotingForAnsible.ps1
+.\\ConfigureRemotingForAnsible.ps1 -CertValidityDays 9999
 .\\ConfigureRemotingForAnsible.ps1 -EnableCredSSP
+.\\ConfigureRemotingForAnsible.ps1 -ForceNewSSLCert
+.\\ConfigureRemotingForAnsible.ps1 -SkipNetworkProfileCheck
 $IPArray=(Get-NetIPAddress -InterfaceAlias "Ethernet*" -AddressFamily ipv4 | select -ExpandProperty IPAddress)
 echo $IPArray | Out-file -Encoding ASCII -FilePath C:/vagrant/playbooks/AdoptOpenJDK_Windows_Playbook/hosts.tmp
 # Retrieving disk's current size

--- a/ansible/pbTestScripts/vagrantPlaybookCheck.sh
+++ b/ansible/pbTestScripts/vagrantPlaybookCheck.sh
@@ -203,6 +203,7 @@ startVMPlaybook()
 {
 	local OS=$1
 	local vagrantPORT=""
+	local pbLogPath="$WORKSPACE/adoptopenjdkPBTests/logFiles/$folderName.$branchName.$OS.log"
 
 	cd $WORKSPACE/adoptopenjdkPBTests/$folderName-$branchName/ansible
 	if [ "$newVagrantFiles" = "true" ]; then
@@ -226,17 +227,21 @@ startVMPlaybook()
 	sed -i -e "s/.*hosts:.*/- hosts: all/g" playbooks/AdoptOpenJDK_Unix_Playbook/main.yml
 	# Alter ansible.cfg to increase timeout and to specify which private key to use
 	# NOTE! Only works with GNU sed
-	! grep -q "timeout" ansible.cfg && sed -i -e 's/\[defaults\]/&\ntimeout = 30/g' ansible.cfg
-	! grep -q "private_key_file" ansible.cfg && sed -i -e 's/\[defaults\]/&\nprivate_key_file = id_rsa/g' ansible.cfg
+	#! grep -q "timeout" ansible.cfg && sed -i -e 's/\[defaults\]/&\ntimeout = 30/g' ansible.cfg
+	#! grep -q "private_key_file" ansible.cfg && sed -i -e 's/\[defaults\]/&\nprivate_key_file = id_rsa/g' ansible.cfg
+
+	awk '{print}/^\[defaults\]$/{print "private_key_file = id_rsa"; print "timeout = 30"}' < ansible.cfg > ansible.cfg.tmp && mv ansible.cfg.tmp ansible.cfg
+	
 	ansible-playbook -i playbooks/AdoptOpenJDK_Unix_Playbook/hosts.unx -u vagrant -b --skip-tags adoptopenjdk,jenkins${skipFullSetup} playbooks/AdoptOpenJDK_Unix_Playbook/main.yml 2>&1 | tee $WORKSPACE/adoptopenjdkPBTests/logFiles/$folderName.$branchName.$OS.log
 	echo The playbook finished at : `date +%T`
-	searchLogFiles $OS
-	local pb_failed=$?
-	cd $WORKSPACE/adoptopenjdkPBTests/$folderName-$branchName/ansible
+	! grep -q 'unreachable=0.*failed=0' $pbLogPath && echo PLAYBOOK FAILED && exit 1
 
-	if [[ "$testNativeBuild" = true && "$pb_failed" == 0 ]]; then
-		ssh -p ${vagrantPORT} -i $PWD/id_rsa vagrant@127.0.0.1 "cd /vagrant/pbTestScripts && ./buildJDK.sh $buildURL $jdkToBuild $buildHotspot"
+	if [[ "$testNativeBuild" = true ]]; then
+		local buildLogPath="$WORKSPACE/adoptopenjdkPBTests/logFiles/$folderName.$branchName.$OS.build_log"
+		ssh -p ${vagrantPORT} -i $PWD/id_rsa vagrant@127.0.0.1 "cd /vagrant/pbTestScripts && ./buildJDK.sh $buildURL $jdkToBuild $buildHotspot" 2>&1 | tee $buildLogPath
 		echo The build finished at : `date +%T`
+		grep -q '] Error' $buildLogPath && echo BUILD FAILED && exit 127
+
 		if [[ "$runTest" = true ]]; then
 			ssh -p ${vagrantPORT} -i $PWD/id_rsa vagrant@127.0.0.1 "cd /vagrant/pbTestScripts && ./testJDK.sh"
 			echo The test finished at : `date +%T`
@@ -247,6 +252,8 @@ startVMPlaybook()
 startVMPlaybookWin()
 {
 	local OS=$1
+	local pbLogPath="$WORKSPACE/adoptopenjdkPBTests/logFiles/$folderName.$branchName.$OS.log"
+
 	cd $WORKSPACE/adoptopenjdkPBTests/$folderName-$branchName/ansible
 	if [ "$newVagrantFiles" = "true" ]; then
 	  ln -sf Vagrantfile.$OS Vagrantfile
@@ -271,18 +278,20 @@ startVMPlaybookWin()
 		echo -e "\nansible_winrm_transport: credssp" >> playbooks/AdoptOpenJDK_Windows_Playbook/group_vars/all/adoptopenjdk_variables.yml
 	fi
 	# Run the ansible playbook on the VM & logs the output.
-	ansible-playbook -i playbooks/AdoptOpenJDK_Windows_Playbook/hosts.win -u vagrant --skip-tags jenkins,adoptopenjdk${skipFullSetup} playbooks/AdoptOpenJDK_Windows_Playbook/main.yml 2>&1 | tee $WORKSPACE/adoptopenjdkPBTests/logFiles/$folderName.$branchName.$OS.log
+	ansible-playbook -i playbooks/AdoptOpenJDK_Windows_Playbook/hosts.win -u vagrant --skip-tags jenkins,adoptopenjdk${skipFullSetup} playbooks/AdoptOpenJDK_Windows_Playbook/main.yml 2>&1 | tee $pbLogPath
 	echo The playbook finished at : `date +%T`
-	searchLogFiles $OS
-	local pbFailed=$?
-	cd $WORKSPACE/adoptopenjdkPBTests/$folderName-$branchName/ansible
-        if [[ "$testNativeBuild" = true && "$pbFailed" == 0 ]]; then
+	! grep -q 'unreachable=0.*failed=0' $pbLogPath && echo PLAYBOOK FAILED && exit 1
+        
+	if [[ "$testNativeBuild" = true ]]; then
+		local buildLogPath="$WORKSPACE/adoptopenjdkPBTests/logFiles/$folderName.$branchName.$OS.build_log"
 		# Restarting the VM as the shared folder disappears after the playbook runs. (Possibly due to the restarts in the playbook)
 		vagrant halt && vagrant up
 		# Run a python script to start the build on the Windows VM to give live stdout/stderr
 		# See: https://github.com/AdoptOpenJDK/openjdk-infrastructure/issues/1296
-		python pbTestScripts/startScriptWin.py -i $(cat playbooks/AdoptOpenJDK_Windows_Playbook/hosts.win) -a "$buildURL $jdkToBuild $buildHotspot" -b
+		python pbTestScripts/startScriptWin.py -i $(cat playbooks/AdoptOpenJDK_Windows_Playbook/hosts.win) -a "$buildURL $jdkToBuild $buildHotspot" -b  2>&1 | tee $buildLogPath
 		echo The build finished at : `date +%T`
+		grep -q '] Error' $buildLogPath && echo BUILD FAILED && exit 127
+	
 		if [[ "$runTest" = true ]]; then
 			vagrant halt && vagrant up
 			# Run a python script to start a test for the built JDK on the Windows VM
@@ -290,18 +299,6 @@ startVMPlaybookWin()
 			echo The test finished at : `date +%T`
 		fi
 	fi
-}
-
-searchLogFiles()
-{
-        local OS=$1
-        cd $WORKSPACE/adoptopenjdkPBTests/logFiles
-        if grep -q 'failed=0' *$folderName.$branchName.$OS.log && grep -q 'unreachable=0' *$folderName.$branchName.$OS.log
-        then
-                return 0;
-        else
-                return 1;
-        fi
 }
 
 destroyVM()


### PR DESCRIPTION
Start to log builds and tests in a `VPC` run. This allows those logs to be searched as well, thereby stopping a `VPC` run from going onto testing if a build failed. This also stops false positives in Jenkins.
In additional, some other changes have been made:
- Adding the additional `.\ConfigureRemotingForAnsible.ps1` script calls into the Windows Vagrantfile. Previously, only the one to enable `Credssp` was ran, which did seem to suffice- however I've added these as it is required when setting up machines, and also seems to make connecting to the Windows VM via Ansible more stable.
- Change the `sed` commands that were used to add lines to the `ansible.cfg` file to an `awk` command, as this stops the requirement of `GNU sed`. (Thanks @sxa , for figuring that one out)