### PR TITLE
pbTests: Add logging to QEMU builds/tests & Rename ARM64 to AARCH64

### DIFF
--- a/ansible/pbTestScripts/buildJDK.sh
+++ b/ansible/pbTestScripts/buildJDK.sh
@@ -165,7 +165,7 @@ if grep 'buster' /etc/*-release >/dev/null 2>&1; then
 	export CXX=/usr/bin/g++-7
 fi
 
-if [ "$ARCHITECTURE" == "aarch64" && "$JAVA_TO_BUILD" == "jdk8u" && $VARIANT == "openj9" ]; then
+if [[ "$ARCHITECTURE" == "aarch64" && "$JAVA_TO_BUILD" == "jdk8u" && $VARIANT == "openj9" ]]; then
 	echo "Can't build OpenJ9 JDK8 on AARCH64, Defaulting to jdk11"
 	JAVA_TO_BUILD=jdk11u
 fi

--- a/ansible/pbTestScripts/qemuPlaybookCheck.sh
+++ b/ansible/pbTestScripts/qemuPlaybookCheck.sh
@@ -71,7 +71,7 @@ defaultVars() {
 		"s390x" | "S390X" | "S390x" )
 			echo "s390x selected"; ARCHITECTURE=S390X;;
 		"aarch64" | "arm64" | "ARM64" )
-                        echo "arm64 selected"; ARCHITECTURE=ARM64;;
+                        echo "aarch64 selected"; ARCHITECTURE=AARCH64;;
 		"ppc64le" | "ppc64" | "PPC64LE" | "PPC64" )
 			echo "ppc64le selected"; ARCHITECTURE=PPC64LE;;
 		"" )
@@ -96,7 +96,7 @@ showArchList() {
 	echo "Currently supported architectures:
 	- ppc64le
 	- s390x
-	- arm64"
+	- aarch64"
 }
 
 # Setup the file system
@@ -136,17 +136,17 @@ done
 	case "$ARCHITECTURE" in
 		"S390X" )
 			export MACHINE="s390-ccw-virtio"
-			export DRIVE="-drive file=$workFolder/S390X.dsk,if=none,id=hd0 -device virtio-blk-ccw,drive=hd0,id=virtio-disk0"
+			export DRIVE="-drive file=$workFolder/${ARCHITECTURE}.dsk,if=none,id=hd0 -device virtio-blk-ccw,drive=hd0,id=virtio-disk0"
 			export QEMUARCH="s390x"
 			export SSH_CMD="-net user,hostfwd=tcp::$PORTNO-:22 -net nic";;
 		"PPC64LE" )
 			export MACHINE="pseries-2.12"
-			export DRIVE="-hda $workFolder/PPC64LE.dsk"
+			export DRIVE="-hda $workFolder/${ARCHITECTURE}.dsk"
 			export QEMUARCH="ppc64"
 			export SSH_CMD="-net user,hostfwd=tcp::$PORTNO-:22 -net nic";;
-		"ARM64" )
+		"AARCH64" )
 			export MACHINE="virt"
-			export DRIVE="-drive if=none,file=$workFolder/ARM64.dsk,id=hd -device virtio-blk-device,drive=hd"
+			export DRIVE="-drive if=none,file=$workFolder/${ARCHITECTURE}.dsk,id=hd -device virtio-blk-device,drive=hd"
 			export QEMUARCH="aarch64"
 			export SSH_CMD="-device e1000,netdev=net0 -netdev user,id=net0,hostfwd=tcp:127.0.0.1:$PORTNO-:22"
 			export EXTRA_ARGS="-cpu cortex-a57 -bios /usr/share/qemu-efi-aarch64/QEMU_EFI.fd";;
@@ -181,21 +181,37 @@ done
 
 runPlaybook() {
 	local workFolder="$WORKSPACE"/qemu_pbCheck
+	local pbLogPath="$workFolder/logFiles/$ARCHITECTURE.log"
 
 	[[ ! -d "$workFolder/openjdk-infrastructure"  ]] && git clone -b "$gitBranch" "$gitURL" "$workFolder"/openjdk-infrastructure
 	cd "$workFolder"/openjdk-infrastructure/ansible || exit 1;
 
-	ansible-playbook -i "localhost:$PORTNO," --private-key "$workFolder"/id_rsa -u linux -b --skip-tags adoptopenjdk,jenkins${skipFullSetup} playbooks/AdoptOpenJDK_Unix_Playbook/main.yml 2>&1 | tee "$workFolder"/logFiles/"$ARCHITECTURE".log
-	if grep -q 'failed=[1-9]\|unreachable=[1-9]' "$workFolder"/logFiles/"$ARCHITECTURE".log; then
+	ansible-playbook -i "localhost:$PORTNO," --private-key "$workFolder"/id_rsa -u linux -b --skip-tags adoptopenjdk,jenkins${skipFullSetup} playbooks/AdoptOpenJDK_Unix_Playbook/main.yml 2>&1 | tee "$pbLogPath"
+	if grep -q 'failed=[1-9]\|unreachable=[1-9]' "$pbLogPath"; then
 		echo "Playbook failed"
 		destroyVM
 		exit 1;
 	fi
 
 	if [[ "$buildJDK" == true ]]; then
-		ssh linux@localhost -p "$PORTNO" -i "$workFolder"/id_rsa "git clone https://github.com/adoptopenjdk/openjdk-infrastructure \$HOME/openjdk-infrastructure && \$HOME/openjdk-infrastructure/ansible/pbTestScripts/buildJDK.sh --version $jdkToBuild"
+		local buildLogPath="$workFolder/logFiles/$ARCHITECTURE.build_log"
+		
+		ssh linux@localhost -p "$PORTNO" -i "$workFolder"/id_rsa "git clone https://github.com/adoptopenjdk/openjdk-infrastructure \$HOME/openjdk-infrastructure && \$HOME/openjdk-infrastructure/ansible/pbTestScripts/buildJDK.sh --version $jdkToBuild" 2>&1 | tee "$buildLogPath"
+		if grep -q '] Error' "$buildLogPath"; then
+			echo BUILD FAILED
+			destroyVM
+			exit 127
+		fi
+
 		if [[ "$testJDK" == true ]]; then
-			ssh linux@localhost -p "$PORTNO" -i "$workFolder"/id_rsa "\$HOME/openjdk-infrastructure/ansible/pbTestScripts/testJDK.sh" 
+			local testLogPath="$workFolder/logFiles/$ARCHITECTURE.test_log"
+
+			ssh linux@localhost -p "$PORTNO" -i "$workFolder"/id_rsa "\$HOME/openjdk-infrastructure/ansible/pbTestScripts/testJDK.sh" 2>&1 | tee $testLogPath
+			if ! grep -q 'FAILED: 0' "$testLogPath"; then
+				echo TEST FAILED
+				destroyVM
+				exit 127
+			fi
 		fi	
 	fi
 	if [[ "$retainVM" == false ]]; then


### PR DESCRIPTION
Ref: #1465 #1452 #1444 

Add logging to the build and test branches in `qemuPlaybookCheck.sh` to stop false positives (as it stops running a test if a build fails).  
If a build or test fails, it exits with error code `127` - the Jenkins jobs have been configured to report `unstable` if the build or tests fails, but `failure` if the playbook fails.

Tested at:
https://ci.adoptopenjdk.net/job/QEMUPlaybookCheck/60/
https://ci.adoptopenjdk.net/job/QEMUPlaybookCheck/61/. (The Jenkins job has been configured to report unstable if `exit 127` since this job ran)