### PR TITLE
Enable EPEL repo for rhel 6

### DIFF
--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/main.yml
@@ -5,7 +5,7 @@
 # Groups can be passed in as a command-line variable in Ansible playbook.
 # It can be defined as 'all' or a specific group which the host belongs to.
 # For example, it can be 'all' or 'x86' for when a host is in the group 'x86'.
-- hosts: "{{ Groups | default('localhost:build:test:!*zos*:!*win*:!*aix*') }}"
+- hosts: all
   gather_facts: yes
   tasks:
     - block:

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/main.yml
@@ -5,7 +5,7 @@
 # Groups can be passed in as a command-line variable in Ansible playbook.
 # It can be defined as 'all' or a specific group which the host belongs to.
 # For example, it can be 'all' or 'x86' for when a host is in the group 'x86'.
-- hosts: all
+- hosts: "{{ Groups | default('localhost:build:test:!*zos*:!*win*:!*aix*') }}"
   gather_facts: yes
   tasks:
     - block:

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/tasks/RedHat.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/tasks/RedHat.yml
@@ -27,7 +27,7 @@
 
 - name: Enable EPEL release for RHEL6
   yum: name=http://dl.fedoraproject.org/pub/epel/epel-release-latest-{{ ansible_distribution_major_version }}.noarch.rpm
-  when: 
+  when:
     - ansible_distribution_major_version == "6"
     - ansible_architecture == "x86_64"
   tags: patch_update

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/tasks/RedHat.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/tasks/RedHat.yml
@@ -17,19 +17,12 @@
   tags: patch_update
 
 
-- name: Enable EPEL release for RHEL8
+- name: Enable EPEL release for RHEL8 or RHEL6
   yum: name=https://dl.fedoraproject.org/pub/epel/epel-release-latest-{{ ansible_distribution_major_version }}.noarch.rpm
   ignore_errors: yes
   when:
     - ansible_architecture != "s390x"
-    - ansible_distribution_major_version == "8"
-  tags: patch_update
-
-- name: Enable EPEL release for RHEL6
-  yum: name=http://dl.fedoraproject.org/pub/epel/epel-release-latest-{{ ansible_distribution_major_version }}.noarch.rpm
-  when:
-    - ansible_distribution_major_version == "6"
-    - ansible_architecture == "x86_64"
+    - (ansible_distribution_major_version == "8") or (ansible_distribution_major_version == "6")
   tags: patch_update
 
 - name: YUM upgrade all packages

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/tasks/RedHat.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/tasks/RedHat.yml
@@ -25,6 +25,13 @@
     - ansible_distribution_major_version == "8"
   tags: patch_update
 
+- name: Enable EPEL release for RHEL6
+  yum: name=http://dl.fedoraproject.org/pub/epel/epel-release-latest-{{ ansible_distribution_major_version }}.noarch.rpm
+  when: 
+    - ansible_distribution_major_version == "6"
+    - ansible_architecture == "x86_64"
+  tags: patch_update
+
 - name: YUM upgrade all packages
   yum:
     name: '*'


### PR DESCRIPTION
Ref https://github.com/AdoptOpenJDK/openjdk-infrastructure/issues/1470

Added a task into `Redhat.yml` which adds the EPEL repo for rhel 6.

Tested on a rhel 6 x86 machine. EPEL repo and `libdwarf-devel` are both installed without error. Im unable to test this on other architectures as only x86 rhel 6 machines are available to me through fyre. However, according to https://fedoraproject.org/wiki/EPEL#What_packages_and_versions_are_available_in_EPEL.3F, for rhel 6, EPEL is only available on x86 and i386. Hence I have added a condition which only installs the EPEL repo on x86