### PR TITLE
UnixPB: Fix java alternatives for RHEL7 ppc64le/s390x

### DIFF
--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/tasks/RedHat.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/tasks/RedHat.yml
@@ -149,6 +149,7 @@
 - name: Set default java version - RHEL 6 x86_64
   alternatives:
     name: java
+    link: /usr/bin/java
     path: /usr/lib/jvm/jre-1.8.0-openjdk.x86_64/bin/java
   when:
     - ansible_distribution_major_version == "6"
@@ -158,6 +159,7 @@
 - name: Set default java version - RHEL 7 x86_64
   alternatives:
     name: java
+    link: /usr/bin/java
     path: java-1.8.0-openjdk.x86_64
   when:
     - ansible_distribution_major_version == "7"
@@ -167,6 +169,7 @@
 - name: Set default java version - RHEL 6 ppc64
   alternatives:
     name: java
+    link: /usr/bin/java
     path: /usr/lib/jvm/jre-1.8.0-ibm.ppc64/bin/java
   when:
     - ansible_distribution_major_version == "6"
@@ -176,42 +179,39 @@
 - name: Set default java version - RHEL 7 ppc64
   alternatives:
     name: java
+    link: /usr/bin/java
     path: /usr/lib/jvm/java-1.8.0-openjdk-1.8.0.161-0.b14.el7_4.ppc64/jre/bin/java
   when:
     - ansible_distribution_major_version == "7"
     - ansible_architecture == "ppc64"
   tags: default_java
 
-- name: Set default java version - RHEL 7 ppc64le
+# Both PPC64LE and S390X have the same 'java-1.8.0-openjdk' symlink.
+# See: https://github.com/AdoptOpenJDK/openjdk-infrastructure/issues/1467
+- name: Set default java version - RHEL 7 ppc64le / s390x
   alternatives:
     name: java
-    path: java-1.8.0-openjdk.ppc64le
+    link: /usr/bin/java
+    path: /usr/lib/jvm/java-1.8.0-openjdk/jre/bin/java
   when:
     - ansible_distribution_major_version == "7"
-    - ansible_architecture == "ppc64le"
+    - ansible_architecture == "ppc64le" or ansible_architecture == "s390x"
   tags: default_java
 
 - name: Set default java version - RHEL 7 aarch64
   alternatives:
     name: java
+    link: /usr/bin/java
     path: java-1.8.0-openjdk.aarch64
   when:
     - ansible_distribution_major_version == "7"
     - ansible_architecture == "aarch64"
   tags: default_java
 
-- name: Set default java version - RHEL 7 s390x
-  alternatives:
-    name: java
-    path: java-1.8.0-openjdk.s390x
-  when:
-    - ansible_distribution_major_version == "7"
-    - ansible_architecture == "s390x"
-  tags: default_java
-
 - name: Set default java version - RHEL 8
   alternatives:
     name: java
+    link: /usr/bin/java
     path: java-1.8.0-openjdk.{{ ansible_architecture }}
   when:
     - ansible_distribution_major_version == "8"


### PR DESCRIPTION
Fixes: #1467 

Changes include:
 - Adding the `link` option to all the ansible alternatives modules, as RHEL based systems require it. https://docs.ansible.com/ansible/latest/modules/alternatives_module.html#parameter-link
 - Changing the ppc64le / s390x `path` to use the `java-1.8.0-openjdk` symlink that is created, instead of the version specific version of the string- this also means we don't have to update this later on. 
- Remove the s390x task, and add `or ansible_architecture == "s390x"` to the ppc64le task as I've checked that these have the same path.

Note: This PR won't be able to run through either [vagrantPlaybookCheck](https://ci.adoptopenjdk.net/view/Tooling/job/VagrantPlaybookCheck/) or [qemuPlaybookCheck](https://ci.adoptopenjdk.net/job/QEMUPlaybookCheck/) as they aren't able to test the `common/tasks/redhat.yml` files.