### PR TITLE
UnixPB: Symlink ccache to stop building from source

### DIFF
--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/gcc_7/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/gcc_7/tasks/main.yml
@@ -7,8 +7,8 @@
   shell: /usr/local/gcc/bin/gcc-7.5 --version 2>&1 > /dev/null
   ignore_errors: yes
   register: gcc7_installed
-  tags: gcc-7
   when: ansible_distribution == "RedHat" or ansible_distribution == "CentOS" or ansible_distribution == "openSUSE"
+  tags: gcc_7
 
 # Unable to check the checksum of the binary as it'll be different for each architecture's tar.xz file
 - name: Download AdoptOpenJDK gcc-7.5.0 binary
@@ -20,7 +20,7 @@
   when:
     - ansible_distribution == "RedHat" or ansible_distribution == "CentOS" or ansible_distribution == "openSUSE"
     - gcc7_installed.rc != 0
-  tags: gcc-7
+  tags: gcc_7
 
 - name: Extract AdoptOpenJDK gcc-7 binary to /usr/local/gcc
   unarchive:
@@ -30,7 +30,7 @@
   when:
     - ansible_distribution == "RedHat" or ansible_distribution == "CentOS" or ansible_distribution == "openSUSE"
     - gcc7_installed.rc != 0
-  tags: gcc-7
+  tags: gcc_7
 
 - name: Remove downloaded gcc 7 binary tarball
   file:
@@ -39,10 +39,18 @@
   when:
     - ansible_distribution == "RedHat" or ansible_distribution == "CentOS" or ansible_distribution == "openSUSE"
     - gcc7_installed.rc != 0
-  tags: gcc-7
+  tags: gcc_7
 
 # Stops buildng ccache from source when unnecessary
 # See: https://github.com/AdoptOpenJDK/openjdk-infrastructure/issues/1472
+- name: Check if ccache is at /usr/local/bin/ccache
+  stat:
+    path: /usr/local/bin/ccache
+  register: ccache_symlink
+  when:
+    - ansible_distribution == "RedHat" or ansible_distribution == "CentOS" or ansible_distribution == "openSUSE"
+  tags: gcc_7
+
 - name: Create symlink for ccache
   file:
     src: /usr/local/gcc/bin/ccache
@@ -50,5 +58,5 @@
     state: link
   when:
     - ansible_distribution == "RedHat" or ansible_distribution == "CentOS" or ansible_distribution == "openSUSE"
-    - gcc7_installed.rc != 0
-  tags: gcc-7
+    - not ccache_symlink.stat.exists
+  tags: gcc_7

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/gcc_7/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/gcc_7/tasks/main.yml
@@ -3,7 +3,6 @@
 # gcc_7 #
 #########
 
-
 - name: Check if gcc 7.5 is installed on RHEL/CentOS
   shell: /usr/local/gcc/bin/gcc-7.5 --version 2>&1 > /dev/null
   ignore_errors: yes
@@ -11,8 +10,7 @@
   tags: gcc-7
   when: ansible_distribution == "RedHat" or ansible_distribution == "CentOS" or ansible_distribution == "openSUSE"
 
-  # Unable to check the checksum of the binary as it'll be different for each architecture's tar.xz file
-
+# Unable to check the checksum of the binary as it'll be different for each architecture's tar.xz file
 - name: Download AdoptOpenJDK gcc-7.5.0 binary
   get_url:
     url: https://ci.adoptopenjdk.net/userContent/gcc/gcc750+ccache.{{ ansible_architecture }}.tar.xz
@@ -38,6 +36,18 @@
   file:
     path: '/tmp/ansible-adoptopenjdk-gcc-7.tar.xz'
     state: absent
+  when:
+    - ansible_distribution == "RedHat" or ansible_distribution == "CentOS" or ansible_distribution == "openSUSE"
+    - gcc7_installed.rc != 0
+  tags: gcc-7
+
+# Stops buildng ccache from source when unnecessary
+# See: https://github.com/AdoptOpenJDK/openjdk-infrastructure/issues/1472
+- name: Create symlink for ccache
+  file:
+    src: /usr/local/gcc/bin/ccache
+    dest: /usr/local/bin/ccache
+    state: link
   when:
     - ansible_distribution == "RedHat" or ansible_distribution == "CentOS" or ansible_distribution == "openSUSE"
     - gcc7_installed.rc != 0


### PR DESCRIPTION
Fixes: #1472

Stops `ccache` being built from source when it is extracted from the binary retrieved in the `gcc_7` task. 

VPC Run: https://ci.adoptopenjdk.net/view/Tooling/job/VagrantPlaybookCheck/773/
(Only CentOS VMs are ran as they're the only ones that have the `gcc_7` task ran on them)