### PR TITLE
UnixPB: Fix path variable for cmake on rhel6

### DIFF
--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/cmake/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/cmake/tasks/main.yml
@@ -48,7 +48,7 @@
 
 # NOTE: PATH setting is for RHEL6/CentOS6 since gcc 4.4.7 is not C++11 compliant
 - name: Running ./configure & make for cmake
-  shell: cd /tmp/cmake-{{ cmakeVersion }} && ./configure && PATH=/opt/gcc-4.8.5/bin:$PATH make -j {{ ansible_processor_vcpus }} && make install
+  shell: cd /tmp/cmake-{{ cmakeVersion }} && PATH=/opt/gcc-4.8.5/bin:$PATH && ./configure && make -j {{ ansible_processor_vcpus }} && make install
   when:
     - (cmake_installed.rc != 0 ) or (cmake_installed.rc == 0 and cmake_version.stdout is version_compare(cmakeVersion, operator='lt') )
     - ansible_architecture != "armv7l"


### PR DESCRIPTION
Despite it being there from the gcc_48 role in the playbook, the system cannot detect gcc-4.8.5 on the machine when building cmake during the `cmake` role, resulting in the error:
```
        "C compiler on this system is: gcc       ",
        "---------------------------------------------",
        "Error when bootstrapping CMake:",
        "Cannot find a C++ compiler supporting C++11 on this system.",
```
Placing the included PATH variable before ./configure seems to have fixed this.

I received this error on two different rhel 6 machines, and this fix worked for both of them.