### PR TITLE
winPB: Ignore errors on win_update reboot task

### DIFF
--- a/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/roles/Windows_Updates/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/roles/Windows_Updates/tasks/main.yml
@@ -11,5 +11,6 @@
 - name: Reboot machine if necessary
   win_reboot:
     reboot_timeout: 3600
+  ignore_errors: yes
   when: update_result.reboot_required
   tags: Windows_Updates

--- a/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/roles/Windows_Updates/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/roles/Windows_Updates/tasks/main.yml
@@ -2,6 +2,9 @@
 ###################
 # Windows Updates #
 ###################
+
+# The following tasks have ignore_errors enabled as some Windows Providers can have issues updating due to the Administrator managed updates
+# See https://github.com/AdoptOpenJDK/openjdk-infrastructure/issues/1469
 - name: Download and Install Windows Updates
   win_updates:
   register: update_result


### PR DESCRIPTION
Ref: #1469 

While the above seems to be an isolated issue for those particular machines, it's shown that there's no point having `ignore_error: yes` on the first task, if it doesn't have it on the second task, as the `update_result` variable is undefined if the first task fails. This also allows for workarounds to be done for the group of machines that the referenced issue affects without the playbook failing or having to add `Windows_Updates` to the `ansible-playbook` `--skip-tags` option.

ping @lumpfish 