### PR TITLE
UnixPB: Add RH7 to EPEL and add Docker repository for RH7 ppc64le

### DIFF
--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/tasks/RedHat.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/tasks/RedHat.yml
@@ -17,12 +17,12 @@
   tags: patch_update
 
 
-- name: Enable EPEL release for RHEL8 or RHEL6
+- name: Enable EPEL release for RHEL8 or RHEL6 or RHEL7
   yum: name=https://dl.fedoraproject.org/pub/epel/epel-release-latest-{{ ansible_distribution_major_version }}.noarch.rpm
   ignore_errors: yes
   when:
     - ansible_architecture != "s390x"
-    - (ansible_distribution_major_version == "8") or (ansible_distribution_major_version == "6")
+    - (ansible_distribution_major_version == "8") or (ansible_distribution_major_version == "6") or (ansible_distribution_major_version == "7")
   tags: patch_update
 
 - name: YUM upgrade all packages

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Docker/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Docker/tasks/main.yml
@@ -113,7 +113,7 @@
     - ansible_architecture == "x86_64"
   tags: docker
 
-- name: Add Docker Repo for RedHat 7
+- name: Add Docker Repo for RedHat 7 x86_64
   get_url:
     url: https://download.docker.com/linux/centos/docker-ce.repo
     dest: /etc/yum.repos.d/docker-ce.repo
@@ -127,6 +127,20 @@
     - ansible_distribution == "RedHat"
     - ansible_distribution_major_version == "7"
     - ansible_architecture == "x86_64"
+  tags: docker
+
+- name: Add Docker repo for RedHat 7 ppc64le
+  yum_repository:
+    name: docker
+    description: docker YUM repo ppc64le
+    baseurl: http://ftp.unicamp.br/pub/ppc64el/rhel/7/docker-ppc64el/
+    enabled: yes
+    gpgcheck: no
+  when:
+    - docker_installed.rc != 0
+    - ansible_distribution == "RedHat"
+    - ansible_distribution_major_version == "7"
+    - ansible_architecture == "ppc64le"
   tags: docker
 
 - name: Import Docker Repo key for RedHat

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Docker/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Docker/tasks/main.yml
@@ -292,7 +292,7 @@
   when:
     - docker_installed.rc != 0
     - (ansible_distribution == "RedHat" and ansible_distribution_major_version == "7") or (ansible_distribution == "CentOS" and ansible_distribution_major_version == "7")
-    - ansible_architecture == "x86_64"
+    - (ansible_architecture == "x86_64") or (ansible_architecture == "ppc64le")
   tags:
     - docker
     # TODO: Package installs should not use latest
@@ -355,5 +355,5 @@
   when:
     - docker_installed.rc != 0
     - (ansible_distribution == "SLES" and ansible_distribution_major_version == "12") or (ansible_distribution == "RedHat" and ansible_distribution_major_version == "7") or (ansible_distribution == "CentOS" and ansible_distribution_major_version == "7")
-    - ansible_architecture == "x86_64"
+    - (ansible_architecture == "x86_64") or (ansible_architecture == "ppc64le")
   tags: docker


### PR DESCRIPTION
- Found a different approach (thanks @Willsparker for the help), for installing `docker-ce` on RH7 ppc64le. 
- Requires EPEL repo, modified `Common/RedHat.yml` to add RH7 to EPEL repo list
- Also following this [IBM documentation ](https://developer.ibm.com/linuxonpower/docker-on-power/), and using the `yum_repository` module, I had to add the correct docker.repo in order for RH7 ppc64le to install `docker-ce` 

Fyi: previous PR #1460

Signed-off-by: kevin-bonilla <kevin.bonilla@ibm.com>