### PR TITLE
WinPB: Add VS2019 support for Windows JDK15 builds

### DIFF
--- a/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/main.yml
@@ -61,6 +61,7 @@
     - ANT                         # Testing
     - MSVS_2013
     - MSVS_2017                   # OpenJ9
+    - MSVS_2019                   # OpenJ9
     - NVidia_Cuda_Toolkit         # OpenJ9
     - NTP_TIME
     - Clang_64bit                 # OpenJ9

--- a/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/roles/MSVS_2019/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/roles/MSVS_2019/tasks/main.yml
@@ -1,0 +1,43 @@
+---
+################################
+# Visual Studio Community 2019 #
+################################
+
+- name: Test if VS 2019 is installed
+  win_stat:
+    path: 'C:\Program Files (x86)\Microsoft Visual Studio\2019'
+  register: vs2019_installed
+  tags: MSVS_2019
+
+- name: Download Visual Studio Community 2019
+  win_get_url:
+    url: 'https://aka.ms/vs/16/release/vs_community.exe'
+    dest: 'C:\temp\vs_community19.exe'
+    force: no
+    checksum: 03f1768299410a2c359f61c88abbe038c5bcfd51d71854cf6437e633ebdefa06
+    checksum_algorithm: sha256
+  when: (not vs2019_installed.stat.exists)
+  tags: MSVS_2019
+
+- name: Install Visual Studio Community 2019
+  win_shell: 'C:\temp\vs_community19.exe --wait --add Microsoft.VisualStudio.Workload.NativeDesktop;includeRecommended;includeOptional --quiet --norestart'
+  args:
+    executable: cmd
+  when: (not vs2019_installed.stat.exists)
+  register: vs2019_error
+  failed_when: vs2019_error.rc != 1 and vs2019_error.rc != 0
+  tags: MSVS_2019
+
+- name: Register Visual Studio Community 2019 DIA SDK shared libraries
+  win_command: 'regsvr32 /s "{{ item }}"'
+  with_items:
+    - C:\Program Files (x86)\Microsoft Visual Studio\2019\Community\DIA SDK\bin\msdia140.dll
+    - C:\Program Files (x86)\Microsoft Visual Studio\2019\Community\DIA SDK\bin\amd64\msdia140.dll
+  tags: MSVS_2019
+
+- name: Reboot machine after Visual Studio installation
+  win_reboot:
+    reboot_timeout: 1800
+    shutdown_timeout: 1800
+  when: (not vs2019_installed.stat.exists)
+  tags: MSVS_2019

--- a/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/roles/OpenSSL/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/roles/OpenSSL/tasks/main.yml
@@ -20,13 +20,19 @@
   register: openssl64_vs2017_installed
   tags: openssl
 
+- name: Check if OpenSSL 64bit VS2019 installed
+  win_stat:
+    path: C:\openjdk\OpenSSL-1.1.1g-x86_64-VS2019
+  register: openssl64_vs2019_installed
+  tags: openssl
+
 - name: Download OpenSSL-1.1.1g
   win_get_url:
     url: https://www.openssl.org/source/openssl-1.1.1g.tar.gz
     dest: C:\temp\OpenSSL-1.1.1g.tar.gz
     checksum: ddb04774f1e32f0c49751e21b67216ac87852ceb056b75209af2443400636d46
     checksum_algorithm: sha256
-  when: (not openssl32_installed.stat.exists) or (not openssl64_vs2013_installed.stat.exists) or (not openssl64_vs2017_installed.stat.exists)
+  when: (not openssl32_installed.stat.exists) or (not openssl64_vs2013_installed.stat.exists) or (not openssl64_vs2017_installed.stat.exists) or (not openssl64_vs2019_installed.stat.exists)
   tags: openssl
 
 - name: Unpack OpenSSL-1.1.1g for installation
@@ -34,7 +40,7 @@
     cd C:\temp
     C:\7-Zip\7z.exe x C:\temp\OpenSSL-1.1.1g.tar.gz
     C:\7-Zip\7z.exe x C:\temp\OpenSSL-1.1.1g.tar
-  when: (not openssl32_installed.stat.exists) or (not openssl64_vs2013_installed.stat.exists) or (not openssl64_vs2017_installed.stat.exists)
+  when: (not openssl32_installed.stat.exists) or (not openssl64_vs2013_installed.stat.exists) or (not openssl64_vs2017_installed.stat.exists) or (not openssl64_vs2019_installed.stat.exists)
   tags: openssl
 
 - name: Install OpenSSL-1.1.1g 32-bit (VS2013)
@@ -66,6 +72,16 @@
   tags:
     - openssl
     - MSVS_2017
+
+- name: Install OpenSSL-1.1.1g 64-bit (VS2019)
+  win_shell: set PATH=C:\Strawberry\perl\bin;C:\openjdk\nasm-2.13.03;%PATH% && .\vcvarsall.bat AMD64 && cd C:\temp\OpenSSL-1.1.1g && perl C:\temp\OpenSSL-1.1.1g\Configure VC-WIN64A --prefix=C:\openjdk\OpenSSL-1.1.1g-x86_64-VS2019 && nmake install > C:\temp\openssl64-VS2019.log && nmake -f makefile clean
+  args:
+    chdir: 'C:\Program Files (x86)\Microsoft Visual Studio\2019\Community\VC\Auxiliary\Build'
+    executable: cmd
+  when: (not openssl64_vs2019_installed.stat.exists)
+  tags:
+    - openssl
+    - MSVS_2019
 
 - name: Cleanup OpenSSL source files
   win_file:


### PR DESCRIPTION
* eclipse/openj9#9805
* add top level main.yml, MSVS_2019 role and add openssl 1.1.1g built with VS2019

Signed-off-by: Joe deKoning <joe_dekoning@ca.ibm.com>