### PR TITLE
unixPB: Installer jobs need access to a full JDK

### DIFF
--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/linux_installer/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/linux_installer/tasks/main.yml
@@ -10,6 +10,7 @@
     state: present
     update_cache: yes
   with_items:
+    - openjdk-8-jdk-headless
     - make
     - gcc
     - git


### PR DESCRIPTION
Without this (e.g. if you only have a JRE) the installer job can fail with:


```gradle
Starting a Gradle Daemon (subsequent builds will be faster)
> Task :buildSrc:compileJava FAILED

FAILURE: Build failed with an exception.

* What went wrong:
Execution failed for task ':buildSrc:compileJava'.
> Could not find tools.jar. Please check that /usr/lib/jvm/java-8-openjdk-amd64 contains a valid JDK installation.
```

Signed-off-by: Stewart Addison <sxa@uk.ibm.com>