### PR TITLE
pbTests: Add better checkJDK logic to buildJDK*.sh

### DIFF
--- a/ansible/pbTestScripts/buildJDKWin.sh
+++ b/ansible/pbTestScripts/buildJDKWin.sh
@@ -1,13 +1,26 @@
 #!/bin/bash
 set -eu
 
+setJDKVars() {
+	wget -q https://api.adoptopenjdk.net/v3/info/available_releases
+	JDK_MAX=$(awk -F: '/tip_version/{gsub("[, ]","",$2); print$2}' < available_releases)
+	JDK_GA=$(awk -F: '/most_recent_feature_release/{gsub("[, ]","",$2); print$2}' < available_releases)
+	rm available_releases
+}
+
 processArgs() {
 	while [[ $# -gt 0 ]] && [[ ."$1" = .-* ]] ; do
 		local opt="$1";
 		shift;
 		case "$opt" in
 			"--version" | "-v" )
-				JAVA_TO_BUILD="$1"; shift;;
+				if [ $1 == "jdk" ]; then
+					JAVA_TO_BUILD=$JDK_MAX
+				else
+					JAVA_TO_BUILD=$(echo $1 | tr -d [:alpha:])
+				fi
+				checkJDK
+				shift;;
 			"--URL" | "-u" )
 				GIT_URL="$1"; shift;;
 			"--hotspot" | "-hs" )
@@ -19,8 +32,10 @@ processArgs() {
 			*) echo >&2 "Invalid option: ${opt}"; echo "This option was unrecognised."; usage; exit 1;;
 		esac
 	done
-
-	checkJDKVersion $JAVA_TO_BUILD
+	if [ -z "$JAVA_TO_BUILD:-}" ]; then
+		echo "You must use the '-v' option"
+		exit 1
+	fi
 	if [ -z "${WORKSPACE:-}" ]; then
         	echo "WORKSPACE not found, setting it to /tmp"
         	WORKSPACE=/tmp/
@@ -32,10 +47,10 @@ processArgs() {
 }
 
 usage() {
-	echo "Usage: ./buildJDK.sh <options>
+	echo "Usage: ./buildJDK.sh <options> (-v <JDK>)
 
 	Options:
-		--version | -v		Specify the JDK version to build
+		--version | -v	<JDK>	Specify the JDK version to build
 		--URL | -u		Specify the github URL to clone openjdk-build from
 		--hotspot | -hs		Builds hotspot, instead of openj9 (openj9 by default)
 		--clean-workspace | -c 	Removes old openjdk-build folder before cloning
@@ -43,48 +58,28 @@ usage() {
 
 	If not specified, JDK8-J9 will be built with the standard openjdk-build repo"
 	echo
-	showJDKVersions
 }
 
-showJDKVersions() {
-	echo "Currently supported JDK versions:
-		- JDK8
-		- JDK9
-		- JDK10
-		- JDK11
-		- JDK12
-		- JDK13
-		- JDK14"
-	echo
-}
-
-checkJDKVersion() {
-        local jdk=$1
-        case "$jdk" in
-                "jdk8u" | "jdk8" | "8" | "8u" )
-                        JAVA_TO_BUILD="jdk8u";
-                        export JDK_BOOT_DIR=/cygdrive/c/openjdk/jdk7;;
-                "jdk9u" | "jdk9" | "9" | "9u" )
-                        JAVA_TO_BUILD="jdk9u";
-                        export JDK_BOOT_DIR=/cygdrive/c/openjdk/jdk-8;;
-                "jdk10u" | "jdk10" | "10" | "10u" )
-                        JAVA_TO_BUILD="jdk10u";
-                        export JDK_BOOT_DIR=/cygdrive/c/openjdk/jdk-10;;
-                "jdk11u" | "jdk11" | "11" | "11u" )
-                        JAVA_TO_BUILD="jdk11u";
-                        export JDK_BOOT_DIR=/cygdrive/c/openjdk/jdk-10;;
-                "jdk12u" | "jdk12" | "12" | "12u" )
-                        JAVA_TO_BUILD="jdk12u";
-                        export JDK_BOOT_DIR=/cygdrive/c/openjdk/jdk-12;;
-                "jdk13u" | "jdk13" | "13" | "13u" )
-                        JAVA_TO_BUILD="jdk13u";
-                        export JDK_BOOT_DIR=/cygdrive/c/openjdk/jdk-12;;
-                "jdk14u" | "jdk14" | "14" | "14u" )
-                        JAVA_TO_BUILD="jdk14";
-                        export JDK_BOOT_DIR=/cygdrive/c/openjdk/jdk-13;;
-                *)
-                        echo "Not a valid JDK Version" ; showJDKVersions; exit 1;;
-        esac
+checkJDK() {
+	if ! ((JAVA_TO_BUILD >= 8 && JAVA_TO_BUILD <= JDK_MAX)); then
+		echo "Please input a JDK between 8 & ${JDK_MAX}, or 'jdk'"
+		echo "i.e. The following formats will work for jdk8: 'jdk8u', 'jdk8' , '8'"
+		exit 1
+	fi
+	if ((JAVA_TO_BUILD == 8)); then
+		export JDK_BOOT_DIR=/cygdrive/c/openjdk/jdk7
+		export JAVA_TO_BUILD="jdk8u"
+	elif ((JAVA_TO_BUILD > JDK_GA)); then
+		export JDK_BOOT_DIR=/cygdrive/c/openjdk/jdk-${JDK_GA}
+		if ((JAVA_TO_BUILD == JDK_MAX)); then
+			export JAVA_TO_BUILD="jdk"
+		else
+			export JAVA_TO_BUILD="jdk${JAVA_TO_BUILD}"
+		fi
+	else
+		export JDK_BOOT_DIR=/cygdrive/c/openjdk/jdk-$((JAVA_TO_BUILD - 1))
+		export JAVA_TO_BUILD="jdk${JAVA_TO_BUILD}u"
+	fi
 }
 
 cloneRepo() {
@@ -111,16 +106,22 @@ cloneRepo() {
 }
 # Set defaults
 export JAVA_TO_BUILD=jdk8
+export JDK_BOOT_DIR=/cygdrive/c/openjdk/jdk7
 export VARIANT=openj9
 export PATH=/usr/bin/:$PATH
 export TARGET_OS=windows
 export ARCHITECTURE=x64
 export JAVA_HOME=/cygdrive/c/openjdk/jdk-8
+
 GIT_URL=https://github.com/adoptopenjdk/openjdk-build
 CLEAN_WORKSPACE=false
+JDK_GA=
+JDK_MAX=
 
+setJDKVars
 processArgs $*
 cloneRepo
+
 export FILENAME="${JAVA_TO_BUILD}_${VARIANT}_${ARCHITECTURE}"
 echo "DEBUG:
 	TARGET_OS=$TARGET_OS


### PR DESCRIPTION
Ref: https://github.com/AdoptOpenJDK/openjdk-build/blob/master/docker/buildDocker.sh , https://github.com/AdoptOpenJDK/openjdk-build/pull/1982

Recently, I changed the above script to use the API to set the JDK versions as this will automatically update with every major release without having to alter `buildDocker.sh`- as the functionality changed there is also in the `buildJDK*.sh` scripts, I've copied what I needed from that and altered it to make it work. With #1481 , `VPC` is currently unable to test this PR as `buildJDKWin.sh` doesn't recognise `JDK15` as a valid JDK. As they'll need to be updated to include JDK15 anyway, I thought it'd be silly not to automate it considering I've done it before :-P

I've pre-tested the changes for both Windows and CentOS here: 
https://ci.adoptopenjdk.net/view/Tooling/job/VagrantPlaybookCheck/787/
https://ci.adoptopenjdk.net/view/Tooling/job/VagrantPlaybookCheck/786/