### PR TITLE
Fix URL for Docker GPG key

### DIFF
--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Docker/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Docker/tasks/main.yml
@@ -212,7 +212,7 @@
 
 - name: Add Docker GPG apt key for Raspbian
   apt_key:
-    url: htps://yum.dockerproject.org/gpg
+    url: https://download.docker.com/linux/debian/gpg
     state: present
   when:
     - docker_installed.rc != 0


### PR DESCRIPTION
Furthermore, I changed the URL to the one recommended in the Docker docs (see https://docs.docker.com/engine/install/debian/).