### PR TITLE
WinPB: Fix task to remove quotes from path after cygwin install

### DIFF
--- a/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/roles/MSVS_2010/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/roles/MSVS_2010/tasks/main.yml
@@ -29,6 +29,18 @@
     - c:\Program Files (x86)\Microsoft Visual Studio 10.0\DIA SDK\bin\amd64\msdia100.dll
   tags: MSVS_2010
 
+# NOTE: This construct is because an SQL Server entry is being added to
+# the path which has an erroneous quote in it, causing OpenSSL not to build
+# See: https://github.com/AdoptOpenJDK/openjdk-infrastructure/issues/1485
+- name: Remove double quote from %PATH%
+  win_shell: |
+    $NewPath=$env:path.Replace('"','')
+    [Environment]::SetEnvironmentVariable("Path", $NewPath, [System.EnvironmentVariableTarget]::Machine)
+  args:
+    executable: powershell
+  when: (not vs2010_installed.stat.exists)
+  tags: MSVS_2010
+
 - name: Reboot machine after Visual Studio 2010 installation
   win_reboot:
     reboot_timeout: 1800

--- a/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/roles/cygwin/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/roles/cygwin/tasks/main.yml
@@ -111,22 +111,15 @@
 
 # NOTE: This construct is because an SQL Server entry is being added to
 # the path which has an erroneous quote in it which causes problems for SETX
-# See https://github.com/AdoptOpenJDK/openjdk-infrastructure/issues/1401
-- name: Remove speech mark from the %PATH%
-  win_shell: 'setx /M PATH "%PATH:\"=%"'
+# See https://github.com/AdoptOpenJDK/openjdk-infrastructure/issues/1485
+- name: Remove double quote from %PATH% & Add C:\cygwin64\bin to the front
+  win_shell: |
+    $NewPath=$env:path.Replace('"','')
+    [Environment]::SetEnvironmentVariable("Path", "C:\cygwin64\bin;" + $NewPath, [System.EnvironmentVariableTarget]::Machine)
   args:
-    executable: cmd
+    executable: powershell
   when: (not cygwin_installed.stat.exists)
-  tags:
-    - cygwin
-
-- name: Add c:\cygwin64\bin to front of %PATH%
-  win_shell: 'setx /M PATH "C:\cygwin64\bin;%PATH%"'
-  args:
-    executable: cmd
-  when: (not cygwin_installed.stat.exists)
-  tags:
-    - cygwin
+  tags: cygwin
 
 - name: Reboot machine for PATH changes to take effect
   win_reboot:

--- a/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/roles/cygwin/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/roles/cygwin/tasks/main.yml
@@ -109,13 +109,9 @@
   when: (not cygwin_installed.stat.exists)
   tags: cygwin
 
-# NOTE: This construct is because an SQL Server entry is being added to
-# the path which has an erroneous quote in it which causes problems for SETX
-# See https://github.com/AdoptOpenJDK/openjdk-infrastructure/issues/1485
-- name: Remove double quote from %PATH% & Add C:\cygwin64\bin to the front
+- name: Add C:\cygwin64\bin to the front of the path
   win_shell: |
-    $NewPath=$env:path.Replace('"','')
-    [Environment]::SetEnvironmentVariable("Path", "C:\cygwin64\bin;" + $NewPath, [System.EnvironmentVariableTarget]::Machine)
+    [Environment]::SetEnvironmentVariable("Path", "C:\cygwin64\bin;" + $env:Path, [System.EnvironmentVariableTarget]::Machine)
   args:
     executable: powershell
   when: (not cygwin_installed.stat.exists)


### PR DESCRIPTION
Fixes: #1485 
ping @lumpfish 

Uses Powershell to remove the speech mark & put `C:/cygwin64/bin` to the beginning of the path, as the `setX /M` command didn't appear to work. When the speech mark was present in the Path, it also stopped building OpenSSL due to the speech mark causing the `./vcvarsall` script (or equivalent) to not work - however without producing an error message (otherwise this would've been spotted earlier).
