### PR TITLE
winPB: convert 'raw' modules to 'win_shell' when making symlinks

### DIFF
--- a/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/roles/Clang_32bit/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/roles/Clang_32bit/tasks/main.yml
@@ -37,7 +37,9 @@
   tags: clang_32bit
 
 - name: Create symlink to C:\openjdk\LLVM32
-  raw: cmd /c mklink /D "C:\openjdk\LLVM32" "C:\Program Files (x86)\LLVM"
+  win_shell: mklink /D "C:\openjdk\LLVM32" "C:\Program Files (x86)\LLVM"
+  args:
+    executable: cmd
   when: (not llvm32_symlink.stat.exists)
   tags: clang_32bit
 

--- a/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/roles/Clang_64bit/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/roles/Clang_64bit/tasks/main.yml
@@ -36,7 +36,9 @@
   tags: clang_64bit
 
 - name: Create symlink to C:\openjdk\LLVM64
-  raw: cmd /c mklink /D "C:\openjdk\LLVM64" "C:\Program Files\LLVM"
+  win_shell: mklink /D "C:\openjdk\LLVM64" "C:\Program Files\LLVM"
+  args:
+    executable: cmd
   when: not llvm64_symlink.stat.exists
   tags: clang_64bit
 

--- a/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/roles/Java7/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/roles/Java7/tasks/main.yml
@@ -39,6 +39,8 @@
   tags: Java7
 
 - name: Create symlink to Java 7
-  raw: cmd /c mklink /D "C:\openjdk\jdk7" "C:\Program Files\Java\java-se-7u75-ri"
+  win_shell: mklink /D "C:\openjdk\jdk7" "C:\Program Files\Java\java-se-7u75-ri"
+  args:
+    executable: cmd
   when: (not java7_symlink.stat.exists)
   tags: Java7


### PR DESCRIPTION
Use `win_shell` instead of the `raw` module when creating symlinks in the Windows Playbook. This was prompted by getting an error message whilst investigating #1485 : 
```
An exception occurred during task execution. To see the full traceback, use -vvv. The error was: winrm.exceptions.WinRMError: Access is denied.  (extended fault data: {'transport_message': 'Bad HTTP response returned from server. Code 500', 'http_status_code': 500, 'wsmanfault_code': '2147942405', 'fault_code': 's:Receiver', 'fault_subcode': 'w:InternalError'})
fatal: [9.20.194.40]: FAILED! => {"msg": "Unexpected failure during module execution.", "stdout":
```
This seems to only be specific to the Windows machines I was provisioning (@lumpfish didn't get this issue when using machines from the same provider), however I found the `win_shell` module didn't cause this error message. In addition, the `raw` module isn't meant to be used when it can be avoided: https://docs.ansible.com/ansible/latest/modules/raw_module.html#synopsis. (It's main use seems to be communicating with a guest that doesn't have `python` installed). Due to this, I thought I'd just change them anyway :-)