### PR TITLE
ansible: remove adoptopenjdk tag from riscv task

### DIFF
--- a/ansible/pbTestScripts/vagrantPlaybookCheck.sh
+++ b/ansible/pbTestScripts/vagrantPlaybookCheck.sh
@@ -230,7 +230,7 @@ startVMPlaybook()
 	sed -i -e "s/.*hosts:.*/- hosts: all/g" playbooks/AdoptOpenJDK_Unix_Playbook/main.yml
 	awk '{print}/^\[defaults\]$/{print "private_key_file = id_rsa"; print "timeout = 30"}' < ansible.cfg > ansible.cfg.tmp && mv ansible.cfg.tmp ansible.cfg
 	
-	ansible-playbook -i playbooks/AdoptOpenJDK_Unix_Playbook/hosts.unx -u vagrant -b --skip-tags adoptopenjdk,jenkins${skipFullSetup} playbooks/AdoptOpenJDK_Unix_Playbook/main.yml 2>&1 | tee $WORKSPACE/adoptopenjdkPBTests/logFiles/$folderName.$branchName.$OS.log
+	ansible-playbook -i playbooks/AdoptOpenJDK_Unix_Playbook/hosts.unx -u vagrant -b --skip-tags adoptopenjdk,riscv,jenkins${skipFullSetup} playbooks/AdoptOpenJDK_Unix_Playbook/main.yml 2>&1 | tee $WORKSPACE/adoptopenjdkPBTests/logFiles/$folderName.$branchName.$OS.log
 	echo The playbook finished at : `date +%T`
 	if ! grep -q 'unreachable=0.*failed=0' $pbLogPath; then
 		echo PLAYBOOK FAILED 

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/riscv_cross_compiler/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/riscv_cross_compiler/tasks/main.yml
@@ -14,7 +14,6 @@
     - ansible_architecture == "x86_64"
   tags:
     - riscv
-    - adoptopenjdk
 
 - name: Check if the fedora sysroot folder is in place
   stat:
@@ -25,7 +24,6 @@
     - ansible_architecture == "x86_64"
   tags:
     - riscv
-    - adoptopenjdk
 
 - name: Yum install libmpc-devel
   yum:
@@ -36,7 +34,6 @@
     - ansible_architecture == "x86_64"
   tags:
     - riscv
-    - adoptopenjdk
 
 - name: Retrieve and unpack the riscv toolchain
   unarchive:
@@ -49,7 +46,6 @@
     - not riscv_toolchain_installed.stat.exists
   tags:
     - riscv
-    - adoptopenjdk
 
 - name: Retrieve and Unpack the fedora sysroot folder
   unarchive:
@@ -62,4 +58,3 @@
     - not fedora_folder.stat.exists
   tags:
     - riscv
-    - adoptopenjdk


### PR DESCRIPTION
It doesn't seem to be an adoptopenjdk setup specific task and it's currently getting skipped in the dockerfile builds