### PR TITLE
UnixPB: Ensure locales package is installed for locales tasks

### DIFF
--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/tasks/Debian.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/tasks/Debian.yml
@@ -176,6 +176,13 @@
 ##################
 # Enable Locales #
 ##################
+
+- name: Install 'locales' package
+  package:
+    name: locales
+    state: present
+  tags: locales
+
 - name: Enable ja_JP locale
   locale_gen:
     name: ja_JP.UTF-8

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/tasks/RedHat.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/tasks/RedHat.yml
@@ -220,6 +220,13 @@
 ###########
 # Locales #
 ###########
+
+- name: Install 'locales' package
+  package:
+    name: locales
+    state: present
+  tags: locales
+
 # Skipping linting as no alternative to shell can be used (lint error 305)
 - name: Get locale list
   shell: locale -a

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/tasks/Ubuntu.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/tasks/Ubuntu.yml
@@ -163,6 +163,12 @@
 ##################
 # Enable Locales #
 ##################
+- name: Install 'locales' package
+  package:
+    name: locales
+    state: present
+  tags: locales
+
 - name: Enable ja_JP locale
   locale_gen:
     name: ja_JP.UTF-8


### PR DESCRIPTION
Fixes: #1502 

Tested at: 
https://ci.adoptopenjdk.net/view/Tooling/job/VagrantPlaybookCheck/834/
https://ci.adoptopenjdk.net/job/QEMUPlaybookCheck/77/

I ran both of the above tests as this is across several architectures. All of them got through the new playbook task (though s390x Ubuntu and x64 CentOS8 failed the run due to other reasons). The problem that this is fixing, however, wasn't found with `VPC` so I can't reproduce the environment that it was found- I'll need @sxa to confirm its fixed.