### PR TITLE
pbTests: Increase timeout for QEMUPlaybookCheck

### DIFF
--- a/ansible/pbTestScripts/qemuPlaybookCheck.sh
+++ b/ansible/pbTestScripts/qemuPlaybookCheck.sh
@@ -185,6 +185,10 @@ runPlaybook() {
 
 	[[ ! -d "$workFolder/openjdk-infrastructure"  ]] && git clone -b "$gitBranch" "$gitURL" "$workFolder"/openjdk-infrastructure
 	cd "$workFolder"/openjdk-infrastructure/ansible || exit 1;
+	
+	# Increase timeout as to stop privilege timeout issues
+	# See: https://github.com/AdoptOpenJDK/openjdk-infrastructure/pull/1516#issue-470063061
+	awk '{print}/^\[defaults\]$/{print "timeout = 30"}' < ansible.cfg > ansible.cfg.tmp && mv ansible.cfg.tmp ansible.cfg
 
 	ansible-playbook -i "localhost:$PORTNO," --private-key "$workFolder"/id_rsa -u linux -b --skip-tags adoptopenjdk,jenkins${skipFullSetup} playbooks/AdoptOpenJDK_Unix_Playbook/main.yml 2>&1 | tee "$pbLogPath"
 	if grep -q 'failed=[1-9]\|unreachable=[1-9]' "$pbLogPath"; then


### PR DESCRIPTION
This is due to the latest `s390x` run showing the error message ( https://ci.adoptopenjdk.net/job/QEMUPlaybookCheck/77/ARCHITECTURE=s390x,label=vagrant/console ) : 
```
TASK [Docker : Install Docker prerequisites for Ubuntu] ************************
fatal: [localhost]: FAILED! => {"msg": "Timeout (12s) waiting for privilege escalation prompt: "}
```
I've seen this before on `VPC`, awhile ago. The QEMUPlaybookCheck has a history of being very slow, due to the fact that QEMU has to virtualise different architectures to the main host, so I don't think increasing the timeout from 12s to 30s is unreasonable. 