### PR TITLE
winPB: Remove MSVS_2019 checksum

### DIFF
--- a/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/roles/MSVS_2019/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/roles/MSVS_2019/tasks/main.yml
@@ -14,8 +14,6 @@
     url: 'https://aka.ms/vs/16/release/vs_community.exe'
     dest: 'C:\temp\vs_community19.exe'
     force: no
-    checksum: 03f1768299410a2c359f61c88abbe038c5bcfd51d71854cf6437e633ebdefa06
-    checksum_algorithm: sha256
   when: (not vs2019_installed.stat.exists)
   tags: MSVS_2019
 


### PR DESCRIPTION
Removing the checksum as it's changed twice in the span of a few days!
ref: 
https://ci.adoptopenjdk.net/view/Tooling/job/VagrantPlaybookCheck/835/OS=Win2012,label=vagrant/console
https://github.com/AdoptOpenJDK/openjdk-infrastructure/pull/1481#discussion_r472075910

Removing the checksum all together should save on PRs that just change the checksum.