### PR TITLE
pbTests: Set JDK_BOOT_DIR correctly on QEMU aarch64

### DIFF
--- a/ansible/pbTestScripts/buildJDK.sh
+++ b/ansible/pbTestScripts/buildJDK.sh
@@ -165,6 +165,7 @@ fi
 if [[ "$ARCHITECTURE" == "aarch64" && "$JAVA_TO_BUILD" == "jdk8u" && $VARIANT == "openj9" ]]; then
 	echo "Can't build OpenJ9 JDK8 on AARCH64, Defaulting to jdk11"
 	JAVA_TO_BUILD=jdk11u
+	JDK_BOOT_DIR=/usr/lib/jvm/jdk10
 fi
 
 export FILENAME="${JAVA_TO_BUILD}_${VARIANT}_${ARCHITECTURE}"


### PR DESCRIPTION
Ref: https://ci.adoptopenjdk.net/job/QEMUPlaybookCheck/78/ARCHITECTURE=aarch64,label=vagrant/console

The script currently changes the `JDK_TO_BUILD`, but not the `JDK_BOOT_DIR` as its meant to.