### PR TITLE
pbTest: Add RISC-V support to QEMUPlaybookCheck

### DIFF
--- a/ansible/pbTestScripts/qemuPlaybookCheck.sh
+++ b/ansible/pbTestScripts/qemuPlaybookCheck.sh
@@ -91,6 +91,12 @@ defaultVars() {
 		echo "Unable to test an unbuilt JDK. Please specify both '--build' and '--test'."
 		exit 1;
 	fi
+	if [[ "$buildJDK" == true && "$ARCHITECTURE" == "RISCV" ]]; then
+		echo "Currently unable to build a JDK on RISC-V natively"
+		echo "Skipping build/test"
+		buildJDK=false
+		testJDK=false
+	fi
 
 }
 


### PR DESCRIPTION
Fixes: #1520 

- [X] Alter `QPC.sh` to accept `riscv`, start the VM and start running the playbook
- [ ] Alter `buildJDK.sh` to set correct variables to start a build
- [ ] Alter `testJDK.sh` to set correct variables to test the built JDK (As we currently don't test riscv JDKs, this may be skipped)