### PR TITLE
Fix alternatives configuration on RHEL flavours

### DIFF
--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/tasks/CentOS.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/tasks/CentOS.yml
@@ -182,44 +182,49 @@
 ####################
 # Set Default Java #
 ####################
-- name: Create Java 8 Alternative
-  alternatives:
-    name: java
-    link: /usr/bin/java
-    path: /usr/lib/jvm/java-1.8.0-openjdk/bin/java
-    priority: 1
-  when:
-    - ansible_architecture == "x86_64"
-    - ansible_distribution_major_version != "6"
+
+- name: Find Default JRE
+  stat:
+    path: /usr/lib/jvm/jre-1.8.0
+  register: jre_path
   tags: default_java
 
-- name: Create Java 8 Alternative (for CentOS6)
+- name: Find Default JDK
+  stat:
+    path: /usr/lib/jvm/java-1.8.0
+  register: jdk_path
+  tags: default_java
+
+- name: Set Default JRE (CentOS 6)
   alternatives:
     name: java
-    link: /usr/bin/java
-    path: /usr/lib/jvm/java-1.8.0-openjdk.x86_64/bin/java
-    priority: 1
+    path: "/usr/lib/jvm/jre-1.8.0-openjdk.{{ ansible_architecture }}/bin/java"
   when:
-    - ansible_architecture == "x86_64"
     - ansible_distribution_major_version == "6"
   tags: default_java
 
-- name: Set Default Java Version
+- name: Set Default JRE (CentOS 7 and later)
   alternatives:
     name: java
-    path: /usr/lib/jvm/java-1.8.0-openjdk/bin/java
+    path: "{{ jre_path.stat.lnk_source }}/bin/java"
   when:
-    - ansible_architecture == "x86_64"
-    - ansible_distribution_major_version != "6"
+    - ansible_distribution_major_version > "6"
   tags: default_java
 
-- name: Set Default Java Version (for CentOS6)
+- name: Set Default JDK (CentOS 6)
   alternatives:
-    name: java
-    path: /usr/lib/jvm/java-1.8.0-openjdk.x86_64/bin/java
+    name: javac
+    path: "/usr/lib/jvm/java-1.8.0-openjdk.{{ ansible_architecture }}/bin/javac"
   when:
-    - ansible_architecture == "x86_64"
     - ansible_distribution_major_version == "6"
+  tags: default_java
+
+- name: Set Default JDK (CentOS 7 and later)
+  alternatives:
+    name: javac
+    path: "{{ jdk_path.stat.lnk_source }}/bin/javac"
+  when:
+    - ansible_distribution_major_version > "6"
   tags: default_java
 
 ###########

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/tasks/RedHat.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/tasks/RedHat.yml
@@ -146,75 +146,49 @@
 ####################
 # Set default Java #
 ####################
-- name: Set default java version - RHEL 6 x86_64
+
+- name: Find Default JRE
+  stat:
+    path: /usr/lib/jvm/jre-1.8.0
+  register: jre_path
+  tags: default_java
+
+- name: Find Default JDK
+  stat:
+    path: /usr/lib/jvm/java-1.8.0
+  register: jdk_path
+  tags: default_java
+
+- name: Set Default JRE (RHEL 6)
   alternatives:
     name: java
-    link: /usr/bin/java
-    path: /usr/lib/jvm/jre-1.8.0-openjdk.x86_64/bin/java
+    path: "/usr/lib/jvm/jre-1.8.0-openjdk.{{ ansible_architecture }}/bin/java"
   when:
     - ansible_distribution_major_version == "6"
-    - ansible_architecture == "x86_64"
   tags: default_java
 
-- name: Set default java version - RHEL 7 x86_64
+- name: Set Default JRE (RHEL 7 and later)
   alternatives:
     name: java
-    link: /usr/bin/java
-    path: java-1.8.0-openjdk.x86_64
+    path: "{{ jre_path.stat.lnk_source }}/bin/java"
   when:
-    - ansible_distribution_major_version == "7"
-    - ansible_architecture == "x86_64"
+    - ansible_distribution_major_version > "6"
   tags: default_java
 
-- name: Set default java version - RHEL 6 ppc64
+- name: Set Default JDK (RHEL 6)
   alternatives:
-    name: java
-    link: /usr/bin/java
-    path: /usr/lib/jvm/jre-1.8.0-ibm.ppc64/bin/java
+    name: javac
+    path: "/usr/lib/jvm/java-1.8.0-openjdk.{{ ansible_architecture }}/bin/javac"
   when:
     - ansible_distribution_major_version == "6"
-    - ansible_architecture == "ppc64"
   tags: default_java
 
-- name: Set default java version - RHEL 7 ppc64
+- name: Set Default JDK (RHEL 7 and later)
   alternatives:
-    name: java
-    link: /usr/bin/java
-    path: /usr/lib/jvm/java-1.8.0-openjdk-1.8.0.161-0.b14.el7_4.ppc64/jre/bin/java
+    name: javac
+    path: "{{ jdk_path.stat.lnk_source }}/bin/javac"
   when:
-    - ansible_distribution_major_version == "7"
-    - ansible_architecture == "ppc64"
-  tags: default_java
-
-# Both PPC64LE and S390X have the same 'java-1.8.0-openjdk' symlink.
-# See: https://github.com/AdoptOpenJDK/openjdk-infrastructure/issues/1467
-- name: Set default java version - RHEL 7 ppc64le / s390x
-  alternatives:
-    name: java
-    link: /usr/bin/java
-    path: /usr/lib/jvm/java-1.8.0-openjdk/jre/bin/java
-  when:
-    - ansible_distribution_major_version == "7"
-    - ansible_architecture == "ppc64le" or ansible_architecture == "s390x"
-  tags: default_java
-
-- name: Set default java version - RHEL 7 aarch64
-  alternatives:
-    name: java
-    link: /usr/bin/java
-    path: java-1.8.0-openjdk.aarch64
-  when:
-    - ansible_distribution_major_version == "7"
-    - ansible_architecture == "aarch64"
-  tags: default_java
-
-- name: Set default java version - RHEL 8
-  alternatives:
-    name: java
-    link: /usr/bin/java
-    path: java-1.8.0-openjdk.{{ ansible_architecture }}
-  when:
-    - ansible_distribution_major_version == "8"
+    - ansible_distribution_major_version > "6"
   tags: default_java
 
 ###########


### PR DESCRIPTION
Previously, a new alternative was created for java/javac that did not configure the slave commands (for example, keytool). This is not necessary, because the RHEL packages being used properly declare their alternatives. Futhermore, it made a lot of standard tools like keytool unavailable.

I'm unsure about the state of Debian/Ubuntu: Ubuntu has the same problematic configuration in https://github.com/AdoptOpenJDK/openjdk-infrastructure/blob/master/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/tasks/Ubuntu.yml#L137-L161. But the proper way there is to use `update-java-alternatives`, not `alternatives`. The Debian playbooks don't do this at all. Happy to address that in a separate PR if someone helps me understand the thinking there.