### PR TITLE
winPB: Stop MSVS_2019 installation failing on rc=3010

### DIFF
--- a/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/roles/MSVS_2019/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/roles/MSVS_2019/tasks/main.yml
@@ -23,7 +23,7 @@
     executable: cmd
   when: (not vs2019_installed.stat.exists)
   register: vs2019_error
-  failed_when: vs2019_error.rc != 1 and vs2019_error.rc != 0
+  failed_when: vs2019_error.rc != 0 and vs2019_error.rc != 3010
   tags: MSVS_2019
 
 - name: Register Visual Studio Community 2019 DIA SDK shared libraries


### PR DESCRIPTION
fixes: #1526 

Ensure that the MSVS_2019 task won't fail when it returns error code 3010 as that states that the installation was successful but the machine needs rebooting to fully install. As a reboot task is scheduled afterwards, this should be fine.
I've also removed the exception for error code 1, as according to https://docs.microsoft.com/en-us/visualstudio/install/use-command-line-parameters-to-install-visual-studio?view=vs-2019 , `1` does indeed mean that an error has occured.

Looking at MSVS_2017, it appears that the [documentation](https://docs.microsoft.com/en-us/visualstudio/install/use-command-line-parameters-to-install-visual-studio?view=vs-2017#error-codes) says 1 is an error code too, but according to #671 , it should be ignored as well. For the sake of testing, I'll run this through `VPC`, to determine if a working installation of `MSVS_2019` can still report an error code of 1. If it is, I'll put `1` back in.

VPC Run: https://ci.adoptopenjdk.net/job/VagrantPlaybookCheck/863/

