### PR TITLE
Vagrant: Add warning in docs about starting Windows VM with too little memory

### DIFF
--- a/ansible/README.md
+++ b/ansible/README.md
@@ -276,6 +276,8 @@ ln -sf Vagrantfile.Win2012 Vagrantfile
 
 vagrant up
 ```
+Note: If the machine running this only has 8G of memory, the windows VM may go into an aborted state on bootup. This is due to assigning the VM too much memory.
+To stop this, halve the memory to the VM by changing the following line in the Windows vagrantfile: `v.memory = 5120`
 
 Several files will also need to be edited for Windows:
 

--- a/ansible/pbTestScripts/vagrantPlaybookCheck.sh
+++ b/ansible/pbTestScripts/vagrantPlaybookCheck.sh
@@ -146,6 +146,8 @@ checkVagrantOS()
                 echo $vagrantOSList
                 exit 1
         fi
+        # The Windows VM is setup to use 5GB of memory, which can be an issue on machines with only 8GB installed.
+        # See: https://github.com/AdoptOpenJDK/openjdk-infrastructure/pull/1532#issue-481189847
         if [[ "$vagrantOS" == "Win2012" && $(free | awk '/Mem:/ { print $2 }') -lt 8000000 ]]; then
                 echo "Warning: Windows VM requires 5Gb of free memory to run. On laptops with only 8Gb this can be an issue."
                 echo "Reducing the Windows VM memory requirement to 2560Mb."

--- a/ansible/pbTestScripts/vagrantPlaybookCheck.sh
+++ b/ansible/pbTestScripts/vagrantPlaybookCheck.sh
@@ -146,6 +146,11 @@ checkVagrantOS()
                 echo $vagrantOSList
                 exit 1
         fi
+        if [[ "$vagrantOS" == "Win2012" && $(free | awk '/Mem:/ { print $2 }') -lt 8000000 ]]; then
+                echo "Warning: Windows VM requires 5Gb of free memory to run. On laptops with only 8Gb this can be an issue."
+                echo "Reducing the Windows VM memory requirement to 2560Mb."
+                sed -i -e "s/5120/2560/g" Vagrantfile.Win2012
+        fi
 }
 
 splitURL()


### PR DESCRIPTION
This is a problem I came across when setting up a new laptop. I don't think we should reduce the memory of the Windows Vagrantfile, otherwise it can significantly increase the time taken to execute `VPC.sh` on it- but a warning should probably be put in to the docs, in case the user doesn't have enough available memory and is wondering why their VM is going to the aborted state straight away.