### PR TITLE
pbTests: Add option to build Hotspot; Add options to specify build repo

### DIFF
--- a/ansible/pbTestScripts/buildJDK.sh
+++ b/ansible/pbTestScripts/buildJDK.sh
@@ -168,6 +168,11 @@ if [[ "$ARCHITECTURE" == "aarch64" && "$JAVA_TO_BUILD" == "jdk8u" && $VARIANT ==
 	JDK_BOOT_DIR=/usr/lib/jvm/jdk10
 fi
 
+if [[ "$ARCHITECTURE" == "armv7l" && "$VARIANT" == "openj9" ]]; then
+	echo "Can't build an OpenJ9 JDK on ARMv7l, Defaulting to Hotspot"
+	export VARIANT=hotspot
+fi
+
 export FILENAME="${JAVA_TO_BUILD}_${VARIANT}_${ARCHITECTURE}"
 
 echo "DEBUG:


### PR DESCRIPTION
I realised that these options were missing from `QPC.sh`, despite `buildJDK.sh` having the functionality to do those things, so I thought I'd add them in.

Testing at : https://ci.adoptopenjdk.net/job/QEMUPlaybookCheck/92/ARCHITECTURE=arm32,label=vagrant/console

(I will make ready to review once I've ensured the above run will start a Hotspot JDK build)