### PR TITLE
pbTests: Add missing '-' char so aarch64 QPC uses correct boot jdk

### DIFF
--- a/ansible/pbTestScripts/buildJDK.sh
+++ b/ansible/pbTestScripts/buildJDK.sh
@@ -165,7 +165,7 @@ fi
 if [[ "$ARCHITECTURE" == "aarch64" && "$JAVA_TO_BUILD" == "jdk8u" && $VARIANT == "openj9" ]]; then
 	echo "Can't build OpenJ9 JDK8 on AARCH64, Defaulting to jdk11"
 	JAVA_TO_BUILD=jdk11u
-	JDK_BOOT_DIR=/usr/lib/jvm/jdk10
+	JDK_BOOT_DIR=/usr/lib/jvm/jdk-10
 fi
 
 export FILENAME="${JAVA_TO_BUILD}_${VARIANT}_${ARCHITECTURE}"


### PR DESCRIPTION
The aarch64 QPC runs keep failing the build portion as it keeps trying to use jdk8 as the boot dir. This is due to `JDK_BOOT_DIR` being set to `/usr/lib/jvm/jdk10`, which doesn't exist, so it defaults to setting the boot dir to be what `JAVA_HOME` is, which is jdk8. 

