### PR TITLE
UnixPB: Remove unnecessary distro checks in distro specific common files

### DIFF
--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/tasks/CentOS.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/tasks/CentOS.yml
@@ -76,8 +76,7 @@
 - name: Install numactl-devel excluding CENT 7 on s390x
   package: "name=numactl-devel state=latest"
   when:
-    - ! (ansible_os_family == "CentOS" and ansible_distribution_major_version == "7")
-    - ansible_architecture != "s390x"
+    - ! (ansible_distribution_major_version == "7" and ansible_architecture == "s390x")
   tags: build_tools
 
 - name: Add devtools-2 to yum repo list for gcc 4.8

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/tasks/RedHat.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/tasks/RedHat.yml
@@ -78,8 +78,7 @@
 - name: Install numactl-devel excluding RHEL 7 on s390x
   package: "name=numactl-devel state=latest"
   when:
-    - ! (ansible_os_family == "RedHat" and ansible_distribution_major_version == "7")
-    - ansible_architecture != "s390x"
+    - ! (ansible_distribution_major_version == "7" and ansible_architecture == "s390x")
   tags: build_tools
 
 - name: Install additional build tools for RHEL on x86


### PR DESCRIPTION
Fixes: #452 

From what I can see, the linked issue is pretty much done, however this PR removes some of the unnecessary distribution checks that are already in the distribution specific common files.
