### PR TITLE
QEMU: Add support to qpc script for multiple os

### DIFF
--- a/ansible/pbTestScripts/qemuPlaybookCheck.sh
+++ b/ansible/pbTestScripts/qemuPlaybookCheck.sh
@@ -226,14 +226,14 @@ done
 	esac
 	
 	# Run the command, mask output and send to background
-	qemu-system-$QEMUARCH \
+	(qemu-system-$QEMUARCH \
 	  -smp 4 \
 	  -m 3072 \
      	  -M $MACHINE \
 	  $SSH_CMD \
 	  $DRIVE \
      	  $EXTRA_ARGS \
-	  -nographic
+	  -nographic) > /dev/null 2>&1 &
 
 	echo "Machine is booting; Please be patient"
 	sleep 120

--- a/ansible/pbTestScripts/qemuPlaybookCheck.sh
+++ b/ansible/pbTestScripts/qemuPlaybookCheck.sh
@@ -135,16 +135,16 @@ defaultVars() {
 showArchList() {
 	echo "Currently supported architectures and operating systems:
 	- ppc64le
-		- ubuntu18
+		- Ubuntu18
 	- s390x
-		- ubuntu18
+		- Ubuntu18
 	- arm32
-		- debian8
+		- Debian8
 	- aarch64
-		- debian10
-		- ubuntu18
+		- Debian10
+		- Ubuntu18
 	- riscv
-		- debian11"
+		- Debian11"
 }
 
 # Setup the file system

--- a/ansible/pbTestScripts/qemuPlaybookCheck.sh
+++ b/ansible/pbTestScripts/qemuPlaybookCheck.sh
@@ -154,7 +154,7 @@ setupWorkspace() {
 	# Images are in this consistent place on the 'vagrant' jenkins machines
 	local imageLocation="/home/jenkins/qemu_base_images"
 
-	if [[ ! -d "$imageLocation/${OS}.${ARCHITECTURE}" ]]; then
+	if [[ ! -f "$imageLocation/${OS}.${ARCHITECTURE}/${OS}.${ARCHITECTURE}.dsk.xz" ]]; then
 		echo "Either this script does not support ${OS} on ${ARCHITECTURE}, or the disk image is not in $imageLocation"
 		exit 1;
 	fi

--- a/ansible/pbTestScripts/qemuPlaybookCheck.sh
+++ b/ansible/pbTestScripts/qemuPlaybookCheck.sh
@@ -166,7 +166,7 @@ setupWorkspace() {
 		find "$workFolder" -type f | xargs rm -f
 		rm -rf "$workFolder"/openjdk-infrastructure "$workFolder"/openjdk-build
 	fi
-	if [[ ! -f "$workFolder/${OS}.${ARCHITECTURE}.dsk" ]]; then 
+	if [[ ! -f "${workFolder}/${OS}.${ARCHITECTURE}.dsk" ]]; then 
 		echo "Copying new disk image"
 		# Copy disk image and tools from imageLocation to workFolder
 		cp -r $imageLocation/$OS.$ARCHITECTURE/. $workFolder

--- a/ansible/pbTestScripts/qemuPlaybookCheck.sh
+++ b/ansible/pbTestScripts/qemuPlaybookCheck.sh
@@ -106,6 +106,8 @@ defaultVars() {
 			echo "DEBIAN10 selected for $ARCHITECTURE"; OS=DEBIAN10;;
 		"ubuntu18" | "u18" | "Ubuntu18" )
 			echo "UBUNTU18 selected for $ARCHITECTURE"; OS=UBUNTU18;;
+		"debian11" | "deb11" | "Debian11" )
+			echo "DEBIAN11 selected for $ARCHITECTURE"; OS=DEBIAN11;;
 		* )
 			echo "Please use the -o flag to select a supported OS"; showArchList; exit 1;;
 	esac
@@ -141,7 +143,8 @@ showArchList() {
 	- aarch64
 		- debian10
 		- ubuntu18
-	- riscv"
+	- riscv
+		- debian11"
 }
 
 # Setup the file system
@@ -163,9 +166,9 @@ setupWorkspace() {
 		find "$workFolder" -type f | xargs rm -f
 		rm -rf "$workFolder"/openjdk-infrastructure "$workFolder"/openjdk-build
 	fi
-	if [[ ! -f "${workFolder}/$OS.${ARCHITECTURE}.dsk" ]]; then 
+	if [[ ! -f "$workFolder/$OS.$ARCHITECTURE.dsk" ]]; then 
 		echo "Copying new disk image"
-		xz -cd "$imageLocation"/"$OS.{$ARCHITECTURE}".dsk.xz > "$workFolder"/"$OS.$ARCHITECTURE".dsk
+		xz -cd "$imageLocation"/"$OS.$ARCHITECTURE".dsk.xz > "$workFolder"/"$OS.$ARCHITECTURE".dsk
 	else
 		echo "Using old disk image"
 	fi

--- a/ansible/pbTestScripts/qemuPlaybookCheck.sh
+++ b/ansible/pbTestScripts/qemuPlaybookCheck.sh
@@ -62,7 +62,7 @@ processArgs() {
 }
 
 usage() {
-	echo "Usage: ./qemu_test_script.sh (<options>) -a <architecture>
+	echo "Usage: ./qemu_test_script.sh (<options>) -a <architecture> -o <os>
 		--architecture | -a		Specifies the architecture to build the OS on
 		--build | -b			Build a JDK on the qemu VM
 		--build-repo | -br		Which openjdk-build to retrieve the build scripts from

--- a/ansible/pbTestScripts/qemuPlaybookCheck.sh
+++ b/ansible/pbTestScripts/qemuPlaybookCheck.sh
@@ -226,14 +226,14 @@ done
 	esac
 	
 	# Run the command, mask output and send to background
-	(qemu-system-$QEMUARCH \
+	qemu-system-$QEMUARCH \
 	  -smp 4 \
 	  -m 3072 \
      	  -M $MACHINE \
 	  $SSH_CMD \
 	  $DRIVE \
      	  $EXTRA_ARGS \
-	  -nographic) > /dev/null 2>&1 &
+	  -nographic
 
 	echo "Machine is booting; Please be patient"
 	sleep 120

--- a/ansible/pbTestScripts/qemuPlaybookCheck.sh
+++ b/ansible/pbTestScripts/qemuPlaybookCheck.sh
@@ -196,7 +196,7 @@ done
 					export MACHINE="virt,gic-version=max"
 					export DRIVE="-drive file=$workFolder/$OS.$ARCHITECTURE.dsk,if=none,id=drive0,cache=writeback -device virtio-blk,drive=drive0,bootindex=0"
 					export SSH_CMD="-netdev user,id=vnet,hostfwd=:127.0.0.1:$PORTNO-:22 -device virtio-net-pci,netdev=vnet"
-					export EXTRA_ARGS="-drive file=$workFolder/QEMU_EFI-flash.img,format=raw,if=pflash -drive file=$workFolder/flash1.img,format=raw,if=pflash -cpu max";;
+					export EXTRA_ARGS="-drive file=/qemu_base_images/arm64_tools/QEMU_EFI-flash.img,format=raw,if=pflash -drive file=/qemu_base_images/arm64_tools/flash1.img,format=raw,if=pflash -cpu max";;
 				"DEBIAN10" )
 					export MACHINE="virt"
 					export DRIVE="-drive if=none,file=$workFolder/$OS.${ARCHITECTURE}.dsk,id=hd -device virtio-blk-device,drive=hd"

--- a/ansible/pbTestScripts/qemuPlaybookCheck.sh
+++ b/ansible/pbTestScripts/qemuPlaybookCheck.sh
@@ -152,7 +152,7 @@ showArchList() {
 setupWorkspace() {
 	local workFolder=$WORKSPACE/qemu_pbCheck
 	# Images are in this consistent place on the 'vagrant' jenkins machines
-	local imageLocation="/qemu_base_images"
+	local imageLocation="/home/jenkins/qemu_base_images"
 
 	if [[ ! -f "$imageLocation/${OS}.${ARCHITECTURE}.dsk.xz" ]]; then
 		echo "Either this script does not support ${OS} on ${ARCHITECTURE}, or the disk image is not in $imageLocation"
@@ -178,6 +178,7 @@ runImage() {
 
 local EXTRA_ARGS=""
 local workFolder="$WORKSPACE/qemu_pbCheck"
+local imageLocation="/home/jenkins/qemu_base_images"
 
 # Find/stop port collisions
 while netstat -lp 2>/dev/null | grep "tcp.*:$PORTNO " > /dev/null; do
@@ -204,7 +205,7 @@ done
 					export MACHINE="virt,gic-version=max"
 					export DRIVE="-drive file=$workFolder/${OS}.${ARCHITECTURE}.dsk,if=none,id=drive0,cache=writeback -device virtio-blk,drive=drive0,bootindex=0"
 					export SSH_CMD="-netdev user,id=vnet,hostfwd=:127.0.0.1:$PORTNO-:22 -device virtio-net-pci,netdev=vnet"
-					export EXTRA_ARGS="-drive file=/qemu_base_images/arm64_tools/QEMU_EFI-flash.img,format=raw,if=pflash -drive file=/qemu_base_images/arm64_tools/flash1.img,format=raw,if=pflash -cpu max";;
+					export EXTRA_ARGS="-drive file=$imageLocation/arm64_tools/QEMU_EFI-flash.img,format=raw,if=pflash -drive file=$imageLocation/arm64_tools/flash1.img,format=raw,if=pflash -cpu max";;
 				"DEBIAN10" )
 					export MACHINE="virt"
 					export DRIVE="-drive if=none,file=$workFolder/${OS}.${ARCHITECTURE}.dsk,id=hd -device virtio-blk-device,drive=hd"
@@ -216,7 +217,7 @@ done
 			export QEMUARCH="arm"
 			export SSH_CMD="-device virtio-net-device,netdev=mynet -netdev user,id=mynet,hostfwd=tcp::$PORTNO-:22"
 			export DRIVE="-drive if=none,file=$workFolder/${OS}.${ARCHITECTURE}.dsk,format=qcow2,id=hd -device virtio-blk-device,drive=hd"
-			export EXTRA_ARGS="-kernel /qemu_base_images/arm32_tools/kernel.arm32 -initrd /qemu_base_images/arm32_tools/initrd.arm32 -append root=/dev/vda2";;
+			export EXTRA_ARGS="-kernel $imageLocation/arm32_tools/kernel.arm32 -initrd $imageLocation/arm32_tools/initrd.arm32 -append root=/dev/vda2";;
 		"RISCV" )
 			export QEMUARCH="riscv64"
 			export MACHINE="virt"

--- a/ansible/pbTestScripts/qemuPlaybookCheck.sh
+++ b/ansible/pbTestScripts/qemuPlaybookCheck.sh
@@ -166,7 +166,7 @@ setupWorkspace() {
 		find "$workFolder" -type f | xargs rm -f
 		rm -rf "$workFolder"/openjdk-infrastructure "$workFolder"/openjdk-build
 	fi
-	if [[ ! -f "$workFolder/$OS.$ARCHITECTURE.dsk" ]]; then 
+	if [[ ! -f "$workFolder/${OS}.${ARCHITECTURE}.dsk" ]]; then 
 		echo "Copying new disk image"
 		# Copy disk image and tools from imageLocation to workFolder
 		cp -r $imageLocation/$OS.$ARCHITECTURE/. $workFolder

--- a/ansible/pbTestScripts/qemuPlaybookCheck.sh
+++ b/ansible/pbTestScripts/qemuPlaybookCheck.sh
@@ -169,7 +169,7 @@ setupWorkspace() {
 	if [[ ! -f "$workFolder/$OS.$ARCHITECTURE.dsk" ]]; then 
 		echo "Copying new disk image"
 		# Copy disk image and tools from imageLocation to workFolder
-		cp "$imageLocation"/"$OS.$ARCHITECTURE" "$workFolder"
+		cp "$imageLocation"/"$OS.$ARCHITECTURE/*" "$workFolder"
 		xz -cd "$workFolder"/"$OS.$ARCHITECTURE".dsk.xz > "$workFolder"/"$OS.$ARCHITECTURE".dsk
 	else
 		echo "Using old disk image"

--- a/ansible/pbTestScripts/qemuPlaybookCheck.sh
+++ b/ansible/pbTestScripts/qemuPlaybookCheck.sh
@@ -218,7 +218,7 @@ done
 			export QEMUARCH="arm"
 			export SSH_CMD="-device virtio-net-device,netdev=mynet -netdev user,id=mynet,hostfwd=tcp::$PORTNO-:22"
 			export DRIVE="-drive if=none,file=$workFolder/${OS}.${ARCHITECTURE}.dsk,format=qcow2,id=hd -device virtio-blk-device,drive=hd"
-			export EXTRA_ARGS="-kernel $imageLocation/arm32_tools/kernel.arm32 -initrd $imageLocation/arm32_tools/initrd.arm32 -append root=/dev/vda2";;
+			export EXTRA_ARGS="-kernel $workFolder/kernel.arm32 -initrd $workFolder/initrd.arm32 -append root=/dev/vda2";;
 		"RISCV" )
 			export QEMUARCH="riscv64"
 			export MACHINE="virt"
@@ -228,14 +228,14 @@ done
 	esac
 	
 	# Run the command, mask output and send to background
-	qemu-system-$QEMUARCH \
+	(qemu-system-$QEMUARCH \
 	  -smp 4 \
 	  -m 3072 \
      	  -M $MACHINE \
 	  $SSH_CMD \
 	  $DRIVE \
      	  $EXTRA_ARGS \
-	  -nographic
+	  -nographic) > /dev/null 2>&1 &
 
 	echo "Machine is booting; Please be patient"
 	sleep 120

--- a/ansible/pbTestScripts/qemuPlaybookCheck.sh
+++ b/ansible/pbTestScripts/qemuPlaybookCheck.sh
@@ -75,7 +75,7 @@ usage() {
 		--infra-branch | -ib		Specify the branch of the infra-repo (default: master)
 		--jdk-version | -v		Specify which JDK to build if '-b' is used (default: jdk8u)
 		--retainVM | -r			Retain the VM once running the playbook
-		--operating-system | -o Combined with --architecture runs a VM with the desired architecture and OS combo.
+		--operating-system | -o 	Combined with --architecture runs a VM with the desired architecture and OS combo.
 		--skip-more | -sm		Skip non-essential roles from the playbook
 		--test | -t			Test the built JDK
 		"	
@@ -101,11 +101,11 @@ defaultVars() {
 
 	case "$OS" in
 		"debian8" | "Debian8" | "deb8" )
-			echo "debian8 selected for $ARCHITECTURE"; OS=DEBIAN8;;
+			echo "DEBIAN8 selected for $ARCHITECTURE"; OS=DEBIAN8;;
 		"debian10" | "Debian10" | "deb10" )
-			echo "debian10 selected for $ARCHITECURE"; OS=DEBIAN10;;
+			echo "DEBIAN10 selected for $ARCHITECTURE"; OS=DEBIAN10;;
 		"ubuntu18" | "u18" | "Ubuntu18" )
-			echo "ubuntu18 selected for $ARCHITECURE"; OS=UBUNTU18;;
+			echo "UBUNTU18 selected for $ARCHITECTURE"; OS=UBUNTU18;;
 		* )
 			echo "Please use the -o flag to select a supported OS"; showArchList; exit 1;;
 	esac
@@ -150,6 +150,11 @@ setupWorkspace() {
 	local workFolder=$WORKSPACE/qemu_pbCheck
 	# Images are in this consistent place on the 'vagrant' jenkins machines
 	local imageLocation="/qemu_base_images"
+
+	if [[ ! -f "$imageLocation/${OS}.${ARCHITECTURE}.dsk.xz" ]]; then
+		echo "Either this script does not support ${OS} on ${ARCHITECTURE}, or the disk image is not in $imageLocation"
+		exit 1;
+	fi
 	
 	mkdir -p "$workFolder"/logFiles
 	if [[ "$cleanWorkspace" = true ]]; then
@@ -160,7 +165,7 @@ setupWorkspace() {
 	fi
 	if [[ ! -f "${workFolder}/$OS.${ARCHITECTURE}.dsk" ]]; then 
 		echo "Copying new disk image"
-		xz -cd "$imageLocation"/"$OS.$ARCHITECTURE".dsk.xz > "$workFolder"/"$OS.$ARCHITECTURE".dsk
+		xz -cd "$imageLocation"/"$OS.{$ARCHITECTURE}".dsk.xz > "$workFolder"/"$OS.$ARCHITECTURE".dsk
 	else
 		echo "Using old disk image"
 	fi
@@ -181,12 +186,12 @@ done
 	case "$ARCHITECTURE" in
 		"S390X" )
 			export MACHINE="s390-ccw-virtio"
-			export DRIVE="-drive file=$workFolder/$OS.${ARCHITECTURE}.dsk,if=none,id=hd0 -device virtio-blk-ccw,drive=hd0,id=virtio-disk0"
+			export DRIVE="-drive file=$workFolder/${OS}.${ARCHITECTURE}.dsk,if=none,id=hd0 -device virtio-blk-ccw,drive=hd0,id=virtio-disk0"
 			export QEMUARCH="s390x"
 			export SSH_CMD="-net user,hostfwd=tcp::$PORTNO-:22 -net nic";;
 		"PPC64LE" )
 			export MACHINE="pseries-2.12"
-			export DRIVE="-hda $workFolder/$OS.${ARCHITECTURE}.dsk"
+			export DRIVE="-hda $workFolder/${OS}.${ARCHITECTURE}.dsk"
 			export QEMUARCH="ppc64"
 			export SSH_CMD="-net user,hostfwd=tcp::$PORTNO-:22 -net nic";;
 		"AARCH64" )
@@ -194,12 +199,12 @@ done
 			case $OS in
 				"UBUNTU18" )
 					export MACHINE="virt,gic-version=max"
-					export DRIVE="-drive file=$workFolder/$OS.$ARCHITECTURE.dsk,if=none,id=drive0,cache=writeback -device virtio-blk,drive=drive0,bootindex=0"
+					export DRIVE="-drive file=$workFolder/${OS}.${ARCHITECTURE}.dsk,if=none,id=drive0,cache=writeback -device virtio-blk,drive=drive0,bootindex=0"
 					export SSH_CMD="-netdev user,id=vnet,hostfwd=:127.0.0.1:$PORTNO-:22 -device virtio-net-pci,netdev=vnet"
 					export EXTRA_ARGS="-drive file=/qemu_base_images/arm64_tools/QEMU_EFI-flash.img,format=raw,if=pflash -drive file=/qemu_base_images/arm64_tools/flash1.img,format=raw,if=pflash -cpu max";;
 				"DEBIAN10" )
 					export MACHINE="virt"
-					export DRIVE="-drive if=none,file=$workFolder/$OS.${ARCHITECTURE}.dsk,id=hd -device virtio-blk-device,drive=hd"
+					export DRIVE="-drive if=none,file=$workFolder/${OS}.${ARCHITECTURE}.dsk,id=hd -device virtio-blk-device,drive=hd"
 					export SSH_CMD="-device e1000,netdev=net0 -netdev user,id=net0,hostfwd=tcp:127.0.0.1:$PORTNO-:22"
 					export EXTRA_ARGS="-cpu cortex-a57 -bios /usr/share/qemu-efi-aarch64/QEMU_EFI.fd";;
 			esac ;;
@@ -207,12 +212,12 @@ done
 			export MACHINE="virt"
 			export QEMUARCH="arm"
 			export SSH_CMD="-device virtio-net-device,netdev=mynet -netdev user,id=mynet,hostfwd=tcp::$PORTNO-:22"
-			export DRIVE="-drive if=none,file=$workFolder/$OS.$ARCHITECTURE.dsk,format=qcow2,id=hd -device virtio-blk-device,drive=hd"
+			export DRIVE="-drive if=none,file=$workFolder/${OS}.${ARCHITECTURE}.dsk,format=qcow2,id=hd -device virtio-blk-device,drive=hd"
 			export EXTRA_ARGS="-kernel /qemu_base_images/arm32_tools/kernel.arm32 -initrd /qemu_base_images/arm32_tools/initrd.arm32 -append root=/dev/vda2";;
 		"RISCV" )
 			export QEMUARCH="riscv64"
 			export MACHINE="virt"
-			export DRIVE="-device virtio-blk-device,drive=hd -drive file=$workFolder/$OS.${ARCHITECTURE}.dsk,if=none,id=hd"
+			export DRIVE="-device virtio-blk-device,drive=hd -drive file=$workFolder/${OS}.${ARCHITECTURE}.dsk,if=none,id=hd"
 			export SSH_CMD="-device virtio-net-device,netdev=net -netdev user,id=net,hostfwd=tcp::$PORTNO-:22"
 			export EXTRA_ARGS="-kernel /usr/lib/riscv64-linux-gnu/opensbi/qemu/virt/fw_jump.elf -device loader,file=/usr/lib/u-boot/qemu-riscv64_smode/u-boot.bin,addr=0x80200000";;
 	esac

--- a/ansible/pbTestScripts/qemuPlaybookCheck.sh
+++ b/ansible/pbTestScripts/qemuPlaybookCheck.sh
@@ -85,15 +85,15 @@ usage() {
 defaultVars() {
 	case "$ARCHITECTURE" in
 		"s390x" | "S390X" | "S390x" )
-			echo "s390x selected"; ARCHITECTURE=S390X;;
+			ARCHITECTURE=S390X;;
 		"aarch64" | "arm64" | "ARM64" )
-			echo "aarch64 selected"; ARCHITECTURE=AARCH64;;
+			ARCHITECTURE=AARCH64;;
 		"ppc64le" | "ppc64" | "PPC64LE" | "PPC64" )
-			echo "ppc64le selected"; ARCHITECTURE=PPC64LE;;
+			ARCHITECTURE=PPC64LE;;
 		"arm32" | "ARM32" | "armv7l" | "ARMV7L")
-			echo "arm32 selected"; ARCHITECTURE=ARM32;;
+			ARCHITECTURE=ARM32;;
 		"RISC-V" | "riscv" | "risc-v" | "RISCV" )
-			echo "riscv selected"; ARCHITECTURE=RISCV;;
+			ARCHITECTURE=RISCV;;
 		"" )
 			echo "Please input an architecture to test"; exit 1;;
 		*) echo "Please select a valid architecture"; showArchList; exit 1;;

--- a/ansible/pbTestScripts/qemuPlaybookCheck.sh
+++ b/ansible/pbTestScripts/qemuPlaybookCheck.sh
@@ -168,7 +168,9 @@ setupWorkspace() {
 	fi
 	if [[ ! -f "$workFolder/$OS.$ARCHITECTURE.dsk" ]]; then 
 		echo "Copying new disk image"
-		xz -cd "$imageLocation"/"$OS.$ARCHITECTURE".dsk.xz > "$workFolder"/"$OS.$ARCHITECTURE".dsk
+		# Copy disk image and tools from imageLocation to workFolder
+		cp "$imageLocation"/"$OS.$ARCHITECTURE" "$workFolder"
+		xz -cd "$workFolder"/"$OS.$ARCHITECTURE".dsk.xz > "$workFolder"/"$OS.$ARCHITECTURE".dsk
 	else
 		echo "Using old disk image"
 	fi
@@ -178,7 +180,6 @@ runImage() {
 
 local EXTRA_ARGS=""
 local workFolder="$WORKSPACE/qemu_pbCheck"
-local imageLocation="/home/jenkins/qemu_base_images"
 
 # Find/stop port collisions
 while netstat -lp 2>/dev/null | grep "tcp.*:$PORTNO " > /dev/null; do
@@ -205,7 +206,7 @@ done
 					export MACHINE="virt,gic-version=max"
 					export DRIVE="-drive file=$workFolder/${OS}.${ARCHITECTURE}.dsk,if=none,id=drive0,cache=writeback -device virtio-blk,drive=drive0,bootindex=0"
 					export SSH_CMD="-netdev user,id=vnet,hostfwd=:127.0.0.1:$PORTNO-:22 -device virtio-net-pci,netdev=vnet"
-					export EXTRA_ARGS="-drive file=$imageLocation/arm64_tools/QEMU_EFI-flash.img,format=raw,if=pflash -drive file=$imageLocation/arm64_tools/flash1.img,format=raw,if=pflash -cpu max";;
+					export EXTRA_ARGS="-drive file=$workFolder/QEMU_EFI-flash.img,format=raw,if=pflash -drive file=$workFolder/flash1.img,format=raw,if=pflash -cpu max";;
 				"DEBIAN10" )
 					export MACHINE="virt"
 					export DRIVE="-drive if=none,file=$workFolder/${OS}.${ARCHITECTURE}.dsk,id=hd -device virtio-blk-device,drive=hd"

--- a/ansible/pbTestScripts/qemuPlaybookCheck.sh
+++ b/ansible/pbTestScripts/qemuPlaybookCheck.sh
@@ -93,7 +93,7 @@ defaultVars() {
 		"arm32" | "ARM32" | "armv7l" | "ARMV7L")
 			echo "arm32 selected"; ARCHITECTURE=ARM32;;
 		"RISC-V" | "riscv" | "risc-v" | "RISCV" )
-			echo "riscv selected"; ARCHITECTURE=RISCV; OS=RISCV;;
+			echo "riscv selected"; ARCHITECTURE=RISCV;;
 		"" )
 			echo "Please input an architecture to test"; exit 1;;
 		*) echo "Please select a valid architecture"; showArchList; exit 1;;

--- a/ansible/pbTestScripts/qemuPlaybookCheck.sh
+++ b/ansible/pbTestScripts/qemuPlaybookCheck.sh
@@ -169,7 +169,7 @@ setupWorkspace() {
 	if [[ ! -f "$workFolder/$OS.$ARCHITECTURE.dsk" ]]; then 
 		echo "Copying new disk image"
 		# Copy disk image and tools from imageLocation to workFolder
-		cp "$imageLocation"/"$OS.$ARCHITECTURE/*" "$workFolder"
+		cp -r $imageLocation/$OS.$ARCHITECTURE/. $workFolder
 		xz -cd "$workFolder"/"$OS.$ARCHITECTURE".dsk.xz > "$workFolder"/"$OS.$ARCHITECTURE".dsk
 	else
 		echo "Using old disk image"

--- a/ansible/pbTestScripts/qemuPlaybookCheck.sh
+++ b/ansible/pbTestScripts/qemuPlaybookCheck.sh
@@ -154,7 +154,7 @@ setupWorkspace() {
 	# Images are in this consistent place on the 'vagrant' jenkins machines
 	local imageLocation="/home/jenkins/qemu_base_images"
 
-	if [[ ! -f "$imageLocation/${OS}.${ARCHITECTURE}.dsk.xz" ]]; then
+	if [[ ! -d "$imageLocation/${OS}.${ARCHITECTURE}" ]]; then
 		echo "Either this script does not support ${OS} on ${ARCHITECTURE}, or the disk image is not in $imageLocation"
 		exit 1;
 	fi

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/tasks/Ubuntu.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/tasks/Ubuntu.yml
@@ -14,7 +14,7 @@
   when: ansible_architecture == "s390x"
   tags: patch_update
 
-- name: Install gnugp2 for aarch64
+- name: Install gnupg2 for aarch64
   apt:
     name: gnupg2
     state: present

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/tasks/Ubuntu.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/tasks/Ubuntu.yml
@@ -14,6 +14,14 @@
   when: ansible_architecture == "s390x"
   tags: patch_update
 
+- name: Install gnugp2 for aarch64
+  apt:
+    name: gnupg2
+    state: present
+    update_cache: yes
+  when: ansible_architecture == "aarch64"
+  tags: patch_update
+
 - name: Add the openjdk repository to apt
   apt_repository: repo='ppa:openjdk-r/ppa'
   when:


### PR DESCRIPTION
ref https://github.com/AdoptOpenJDK/openjdk-infrastructure/issues/1538

I will be creating more qemu disk images, which will involve different OSs for already supported architectures.

Im currently adding a ubuntu 18 on arm64 qemu disk image onto `infra-softlayer-ubuntu1804-x64-1`. To accommodate the changes I have made to the script, I will rename the xz compressed disk images to support the `OS.ARCHITECTURE.dsk.xz` style.