### PR TITLE
winPB: Remove MSVS_2017 checksum

### DIFF
--- a/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/roles/MSVS_2017/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/roles/MSVS_2017/tasks/main.yml
@@ -14,8 +14,6 @@
     url: 'https://aka.ms/vs/15/release/vs_community.exe'
     dest: 'C:\TEMP\vs_community.exe'
     force: no
-    checksum: 29aeed55de6158a0968f8cb17944b733f65b0300cd10ffb2a53011f29159f1c1
-    checksum_algorithm: sha256
   when: (not vs2017_installed.stat.exists)
   tags: MSVS_2017
 

--- a/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/roles/MSVS_2017/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/roles/MSVS_2017/tasks/main.yml
@@ -9,6 +9,8 @@
   register: vs2017_installed
   tags: MSVS_2017
 
+# We're not using the checksum here as it changes too often
+# See: https://github.com/AdoptOpenJDK/openjdk-infrastructure/pull/1545#issue-487838598
 - name: Download Visual Studio Community 2017
   win_get_url:
     url: 'https://aka.ms/vs/15/release/vs_community.exe'

--- a/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/roles/MSVS_2019/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/roles/MSVS_2019/tasks/main.yml
@@ -9,6 +9,8 @@
   register: vs2019_installed
   tags: MSVS_2019
 
+# We're not using the checksum here as it changes too often
+# See: https://github.com/AdoptOpenJDK/openjdk-infrastructure/pull/1517#issue-470753202
 - name: Download Visual Studio Community 2019
   win_get_url:
     url: 'https://aka.ms/vs/16/release/vs_community.exe'


### PR DESCRIPTION
Ref: #1517 , https://ci.adoptopenjdk.net/job/VagrantPlaybookCheck/OS=Win2012,label=vagrant/876/console

Again, this is to reduce the PRs to update the checksum every so often. To ensure we don't forget about finding a better solution to this (i.e. caching an installer so the checksum doesn't change), I'll raise an issue and link this PR to it.
