### PR TITLE
ansible: dynamically pull vendor files from the secrets repo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 ansible/playbooks/*.retry
 *.pyc
 ansible/host_vars/*
+**/vendor_files

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/group_vars/all/adoptopenjdk_variables.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/group_vars/all/adoptopenjdk_variables.yml
@@ -11,25 +11,20 @@ Sudoers_File: /etc/sudoers
 
 # Jenkins User Variables:
 Jenkins_Username: jenkins
-Jenkins_User_SSHKey: /Vendor_Files/keys/id_rsa.pub
 
 # Superuser Variables:
 Superuser_Account: Enabled
-Zeus_User_SSHKey: /Vendor_Files/keys/zeus.key
 
 # Nagios Variables:
 Nagios_Plugins: Enabled
-Nagios_User_SSHKey: /Vendor_Files/keys/nagios.key
 Nagios_Monitoring: Enabled
 Nagios_Master_IP: 78.47.239.96
 
 # Security Variables:
 Security: Enabled
-Keybox_SSHKey: /Vendor_Files/keys/keybox.key
 
 # JCK Variables:
 jckftp_Username: jckftp
-jckftp_Passwd: /Vendor_Files/passwords/ftp
 
 # Vendor Variables:
 Vendor_File: Disabled

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/main.yml
@@ -20,6 +20,8 @@
   #########
   roles:
     - Debug
+    - role: Get_Vendor_Files
+      tags: [vendor_files, adoptopenjdk]
     - Version
     - Common
     - Providers                   # AdoptOpenJDK Infrastructure

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Get_Vendor_Files/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Get_Vendor_Files/tasks/main.yml
@@ -4,16 +4,20 @@
 ##############
 
 - name: check out AdoptOpenJDK/secrets
-  local_action: git repo=git@github.com:AdoptOpenJDK/secrets.git dest=vendor_files
+  local_action: git repo=git@github.com:AdoptOpenJDK/secrets.git dest=vendor_files force=true
+  run_once: true
 
 - name: check if dotgpg is installed
   local_action: shell command -v dotgpg
+  run_once: true
 
 - name: generate list of vendor_files
   local_action: command dotgpg cat {{ item }}
   register: vendor_files
   loop: "{{ lookup('fileglob', 'vendor_files/vendor_files/*', wantlist=True) }}"
+  run_once: true
 
 - name: set facts from output of dotgpg
   set_fact: {"{{ item.item | basename | replace('.gpg','') | replace('.','_') }}":"{{ item.stdout }}"}
   with_items: "{{vendor_files.results}}"
+  run_once: true

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Get_Vendor_Files/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Get_Vendor_Files/tasks/main.yml
@@ -1,0 +1,19 @@
+---
+##############
+# VENDOR_FILES
+##############
+
+- name: check out AdoptOpenJDK/secrets
+  local_action: git repo=git@github.com:AdoptOpenJDK/secrets.git dest=vendor_files
+
+- name: check if dotgpg is installed
+  local_action: shell command -v dotgpg
+
+- name: generate list of vendor_files
+  local_action: command dotgpg cat {{ item }}
+  register: vendor_files
+  loop: "{{ lookup('fileglob', 'vendor_files/vendor_files/*', wantlist=True) }}"
+
+- name: set facts from output of dotgpg
+  set_fact: {"{{ item.item | basename | replace('.gpg','') | replace('.','_') }}":"{{ item.stdout }}"}
+  with_items: "{{vendor_files.results}}"

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Jenkins_User/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Jenkins_User/tasks/main.yml
@@ -22,7 +22,7 @@
   authorized_key:
     user: "{{ Jenkins_Username }}"
     state: present
-    key: "{{ lookup('file', '{{ Jenkins_User_SSHKey }}') }}"
+    key: "{{ Jenkins_User_SSHKey }}"
   tags: [jenkins_user, jenkins_authorized_key, adoptopenjdk]
 
 - name: Add Jenkins user to the audio group

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Nagios_Plugins/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Nagios_Plugins/tasks/main.yml
@@ -25,7 +25,7 @@
   authorized_key:
     user: nagios
     state: present
-    key: "{{ lookup('file', '{{ Nagios_User_SSHKey }}') }}"
+    key: "{{ Nagios_User_SSHKey }}"
   when:
     - Nagios_Plugins == "Enabled"
   tags: [nagios_plugins, adoptopenjdk]

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Security/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Security/tasks/main.yml
@@ -19,7 +19,7 @@
   authorized_key:
     user: root
     state: present
-    key: "{{ lookup('file', '{{ Keybox_SSHKey }}') }}"
+    key: "{{ Keybox_SSHKey }}"
   when:
     - Security == "Enabled"
   tags: [security, adoptopenjdk]

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Superuser/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Superuser/tasks/main.yml
@@ -23,7 +23,7 @@
   authorized_key:
     user: zeus
     state: present
-    key: "{{ lookup('file', '{{ Zeus_User_SSHKey }}') }}"
+    key: "{{ Zeus_User_SSHKey }}"
   when: Superuser_Account == "Enabled"
   tags: [superuser, superuser_authorized_key, adoptopenjdk]
 

--- a/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/group_vars/all/adoptopenjdk_variables.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/group_vars/all/adoptopenjdk_variables.yml
@@ -2,7 +2,6 @@
 ansible_port: 5986
 ansible_connection: winrm
 ansible_winrm_server_cert_validation: ignore
-Jenkins_Win_Passwd: /Vendor_Files/jenkins/jenkins_win_passwd
 Jenkins_Username: jenkins
 Nagios_Plugins: Disabled
 

--- a/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/main.yml
@@ -33,6 +33,8 @@
   #########
   roles:
     - Debug
+    - role: Get_Vendor_Files
+      tags: [vendor_files, adoptopenjdk]
     - Version
     - Common
     - Windows_Updates

--- a/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/roles/Get_Vendor_Files/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/roles/Get_Vendor_Files/tasks/main.yml
@@ -4,16 +4,20 @@
 ##############
 
 - name: check out AdoptOpenJDK/secrets
-  local_action: git repo=git@github.com:AdoptOpenJDK/secrets.git dest=vendor_files
+  local_action: git repo=git@github.com:AdoptOpenJDK/secrets.git dest=vendor_files force=true
+  run_once: true
 
 - name: check if dotgpg is installed
   local_action: shell command -v dotgpg
+  run_once: true
 
 - name: generate list of vendor_files
   local_action: command dotgpg cat {{ item }}
   register: vendor_files
   loop: "{{ lookup('fileglob', 'vendor_files/vendor_files/*', wantlist=True) }}"
+  run_once: true
 
 - name: set facts from output of dotgpg
   set_fact: {"{{ item.item | basename | replace('.gpg','') | replace('.','_') }}":"{{ item.stdout }}"}
   with_items: "{{vendor_files.results}}"
+  run_once: true

--- a/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/roles/Get_Vendor_Files/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/roles/Get_Vendor_Files/tasks/main.yml
@@ -1,0 +1,19 @@
+---
+##############
+# VENDOR_FILES
+##############
+
+- name: check out AdoptOpenJDK/secrets
+  local_action: git repo=git@github.com:AdoptOpenJDK/secrets.git dest=vendor_files
+
+- name: check if dotgpg is installed
+  local_action: shell command -v dotgpg
+
+- name: generate list of vendor_files
+  local_action: command dotgpg cat {{ item }}
+  register: vendor_files
+  loop: "{{ lookup('fileglob', 'vendor_files/vendor_files/*', wantlist=True) }}"
+
+- name: set facts from output of dotgpg
+  set_fact: {"{{ item.item | basename | replace('.gpg','') | replace('.','_') }}":"{{ item.stdout }}"}
+  with_items: "{{vendor_files.results}}"

--- a/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/roles/Jenkins/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/roles/Jenkins/tasks/main.yml
@@ -11,7 +11,7 @@
   win_user:
     name: "{{ Jenkins_Username }}"
     fullname: AdoptOpenJDK Jenkins User
-    password: "{{ lookup('file', '{{ Jenkins_Win_Passwd }}') }}"
+    password: "{{ Jenkins_Win_Passwd }}"
     state: present
     password_never_expires: true
     groups:

--- a/ansible/playbooks/adoptopenjdk_variables.yml
+++ b/ansible/playbooks/adoptopenjdk_variables.yml
@@ -1,14 +1,10 @@
 ---
 # AdoptOpenJDK variables file
-Jenkins_User_SSHKey: /Vendor_Files/keys/id_rsa.pub
-Zeus_User_SSHKey: /Vendor_Files/keys/zeus.key
-Nagios_User_SSHKey: /Vendor_Files/keys/nagios.key
 Jenkins_Username: jenkins
 Nagios_Plugins: Enabled
 Slack_Notification: Disabled
 Superuser_Account: Enabled
 jckftp_Username: jckftp
-jckftp_Passwd: /Vendor_Files/passwords/ftp
 Asian_Locales: Disabled
 # Jcktestr User Variables:
 Jcktestr_Username: jcktestr


### PR DESCRIPTION
This PR allows us to pull all vendor file secrets from https://github.com/AdoptOpenJDK/secrets/tree/master/vendor_files

## Requirements

- The user running the job has to have permission to clone the secrets repo
- The user must have gpg access to the secrets. (see more information in the secrets repo readme)
- The user must have dotgpg installed to extract the secrets