### PR TITLE
ansible: add Packages (installer generator) to macOS playbook

### DIFF
--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/vars/MacOSX.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/vars/MacOSX.yml
@@ -20,6 +20,7 @@ Build_Tool_Casks:
   - adoptopenjdk8
   - adoptopenjdk10
   - adoptopenjdk11
+  - packages
 
 Test_Tool_Packages:
   - mercurial


### PR DESCRIPTION
We are switching the installers over to use [Packages](http://s.sudre.free.fr/Software/Packages/about.html) 

See https://github.com/AdoptOpenJDK/openjdk-installer/pull/248