### PR TITLE
winPB: Update ccert role to get windows.p12 from vendor_files

### DIFF
--- a/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/roles/CodesignCert/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/roles/CodesignCert/tasks/main.yml
@@ -10,6 +10,7 @@
   tags:
     - ccert
     - jenkins
+    - adoptopenjdk
 
 # The vendor files are retrieved by the Get_Vendor_Files role
 - name: Get windows.p12 and put in C:\openjdk Directory
@@ -20,3 +21,4 @@
   tags:
     - ccert
     - jenkins
+    - adoptopenjdk

--- a/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/roles/CodesignCert/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/roles/CodesignCert/tasks/main.yml
@@ -5,18 +5,17 @@
 
 - name: Check if windows.p12 exists
   win_stat:
-    path: C:\Users\jenkins\windows.p12
+    path: C:\openjdk\windows.p12
   register: cert_installed
   tags:
     - ccert
     - jenkins
 
-- name: Get windows.p12 and put in Jenkins Home Directory
-  win_get_url:
-    url: https://github.com/AdoptOpenJDK/openjdk-installer/raw/master/windows.p12
-    dest: C:\Users\jenkins
-    checksum: 836c302e944cae970b1fa57b9e5cff552e3d61f0ce4445e79185900c1098e40e
-    checksum_algorithm: sha256
+# The vendor files are retrieved by the Get_Vendor_Files role
+- name: Get windows.p12 and put in C:\openjdk Directory
+  win_copy:
+    src: vendor_files/windows.p12
+    dest: C:\openjdk\windows.p12
   when: (not cert_installed.stat.exists)
   tags:
     - ccert


### PR DESCRIPTION
Fixes: #1558 
ref: #1556 
In draft until #1560 is merged.

Retrieve the `windows.p12` file from the vendor files that are retrieved from the `Get_Vendor_Files` role that is put in with #1560 . Update the place in which the `windows.p12` file is located, to `C:/openjdk`