### PR TITLE
UnixPB: Add perl-Digest-SHA to rhel vars

### DIFF
--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/vars/RedHat.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/vars/RedHat.yml
@@ -90,6 +90,7 @@ Java_RHEL6_PPC64:
 Test_Tool_Packages:
   - acl
   - perl
+  - perl-Digest-SHA
   - xorg-x11-xauth
   - xorg-x11-server-Xvfb
   - zlib-devel


### PR DESCRIPTION
While following instructions [here](https://github.com/eclipse/openj9/wiki/Reproducing-Test-Failures-Locally#openjdk-tests) to run an openjdk sanity test on a rhel 6 and 7 x64 machine, during the `make compile` stage I hit the following error
```
[root@169 TKG]# make compile
JAVA_HOME is set to /root/jdk-11.0.8+10/
perl scripts/getDependencies.pl -path '/root/openjdk-tests/TKG/../TKG/lib' -task default
Can't locate Digest/SHA.pm in @INC (@INC contains: /usr/local/lib64/perl5 /usr/local/share/perl5 /usr/lib64/perl5/vendor_perl /usr/share/perl5/vendor_perl /usr/lib64/perl5 /usr/share/perl5 .) at scripts/getDependencies.pl line 19.
BEGIN failed--compilation aborted at scripts/getDependencies.pl line 19.
makefile:40: recipe for target 'getdependency' failed
make: *** [getdependency] Error 2
```
The error is caused by an import statement on line 19 in `openjdk-tests/TKG/scripts/getDependencies.pl` 
```
use Digest::SHA;
```

Installing `perl-Digest-SHA` seemed to do the trick