### PR TITLE
QPC: Clone the specified branch for using buildJDK.sh

### DIFF
--- a/ansible/pbTestScripts/qemuPlaybookCheck.sh
+++ b/ansible/pbTestScripts/qemuPlaybookCheck.sh
@@ -242,7 +242,7 @@ runPlaybook() {
 	if [[ "$buildJDK" == true ]]; then
 		local buildLogPath="$workFolder/logFiles/$ARCHITECTURE.build_log"
 		
-		ssh linux@localhost -p "$PORTNO" -i "$workFolder"/id_rsa "git clone https://github.com/adoptopenjdk/openjdk-infrastructure \$HOME/openjdk-infrastructure && \$HOME/openjdk-infrastructure/ansible/pbTestScripts/buildJDK.sh --version $jdkToBuild $buildVariant --URL $buildURL/tree/$buildBranch" 2>&1 | tee "$buildLogPath"
+		ssh linux@localhost -p "$PORTNO" -i "$workFolder"/id_rsa "git clone -b "$gitBranch" "$gitURL" \$HOME/openjdk-infrastructure && \$HOME/openjdk-infrastructure/ansible/pbTestScripts/buildJDK.sh --version $jdkToBuild $buildVariant --URL $buildURL/tree/$buildBranch" 2>&1 | tee "$buildLogPath"
 		if grep -q '] Error' "$buildLogPath" || grep -q 'configure: error' "$buildLogPath"; then
 			echo BUILD FAILED
 			destroyVM


### PR DESCRIPTION
Spotted by @Haroon-Khel when looking at #1534 

Currently, the script will clone the user specified branch only to test the playbooks, and then clone the default adoptopenjdk/master branch to run `buildJDK.sh`. This makes it more difficult to test changes to `buildJDK.sh` on platforms other than `x86_64`. This way, it also more accurately reflects what `vagrantPlaybookCheck.sh` does, too.