### PR TITLE
workflow: Remove ansible-lint pin to v4.2

### DIFF
--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -51,7 +51,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install ansible ansible-lint==4.2.0
+        pip install ansible ansible-lint
 
     - name: ansible_lint
       run: | 

--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -2,13 +2,9 @@ name: Linter
 
 on:
   pull_request:
-    paths:
-    - ansible/**
     branches:         
     - master
   push:
-    paths:
-    - ansible/**
     branches:         
     - master
 


### PR DESCRIPTION
Test to see if removing the version pin to `ansible-lint` will stop the previous linter issues. (I speculate that the version of ansible compared to ansible-lint is too new)