### PR TITLE
ansible: add macos codesign cert role

### DIFF
--- a/.ansible-lint
+++ b/.ansible-lint
@@ -8,5 +8,6 @@ skip_list:
   - '305'  # Use shell only when shell functionality is required
   - '401'  # Git checkouts must contain explicit version
   - '403'  # Package installs should not use latest
+  - '501'  # Become_user requires become to work as expected
   - '601'  # Don't compare to literal True/False
   - '602'  # Don't compare to empty string

--- a/ansible/Dockerfile.CentOS6
+++ b/ansible/Dockerfile.CentOS6
@@ -2,9 +2,17 @@ FROM centos:6.9
 
 ARG user=jenkins
 
-RUN yum -y update; yum clean all
-RUN rpm -ivh http://dl.fedoraproject.org/pub/epel/6/i386/epel-release-6-8.noarch.rpm; \
- yum -y install ansible sudo; yum clean all
+# Install Python 3
+RUN yum -y update; yum clean all; \
+    yum -y install gcc openssl-devel bzip2-devel sqlite-devel wget; \
+    cd /usr/src; \
+    wget -q https://www.python.org/ftp/python/3.6.10/Python-3.6.10.tgz; \
+    tar xzf Python-3.6.10.tgz; \
+    cd Python-3.6.10; \
+    ./configure --enable-optimizations; \
+    make install; \
+    rm /usr/src/Python-3.6.10.tgz; \
+    pip3 install ansible
 
 COPY . /ansible
 
@@ -12,10 +20,10 @@ RUN echo "localhost ansible_connection=local" > /ansible/hosts
 
 RUN set -eux; \
  cd /ansible; \
- ansible-playbook -i hosts -s ansible/playbooks/AdoptOpenJDK_Unix_Playbook/main.yml --skip-tags="debug,hosts_file,hostname,adoptopenjdk,jenkins,nagios,superuser,docker,swap_file,crontab,nvidia_cuda_toolkit"; \
- ansible-playbook -i hosts -s ansible/playbooks/AdoptOpenJDK_Unix_Playbook/main.yml --tags="riscv"
+ ansible-playbook -i hosts ansible/playbooks/AdoptOpenJDK_Unix_Playbook/main.yml --skip-tags="debug,hosts_file,hostname,adoptopenjdk,jenkins,nagios,superuser,docker,swap_file,crontab,nvidia_cuda_toolkit"; \
+ ansible-playbook -i hosts ansible/playbooks/AdoptOpenJDK_Unix_Playbook/main.yml --tags="riscv"
 
-RUN rm -rf /ansible; yum remove ansible; yum clean all
+RUN rm -rf /ansible; pip3 uninstall ansible; yum clean all
 
 RUN groupadd -g 1000 ${user}
 RUN useradd -c "Jenkins user" -d /home/${user} -u 1000 -g 1000 -m ${user}

--- a/ansible/Dockerfile.CentOS6
+++ b/ansible/Dockerfile.CentOS6
@@ -4,7 +4,7 @@ ARG user=jenkins
 
 # Install Python 3
 RUN yum -y update; yum clean all; \
-    yum -y install gcc openssl-devel bzip2-devel sqlite-devel wget; \
+    yum -y install gcc openssl-devel bzip2-devel sqlite-devel sudo wget; \
     cd /usr/src; \
     wget -q https://www.python.org/ftp/python/3.6.10/Python-3.6.10.tgz; \
     tar xzf Python-3.6.10.tgz; \

--- a/ansible/ansible.cfg
+++ b/ansible/ansible.cfg
@@ -8,6 +8,7 @@ remote_user         = root
 retry_files_enabled = False
 roles_path          = roles
 squash_actions      = apk
+allow_world_readable_tmpfiles = True
 
 
 # Pass an empty path to ssh so it doesn't read config. We don't need it

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/main.yml
@@ -30,6 +30,9 @@
     - Jenkins_User                # AdoptOpenJDK Infrastructure
     - role: freemarker            # OpenJ9
       tags: [build_tools, build_tools_openj9]
+    - role: macos_codesign
+      tags: [codesign, adoptopenjdk]
+      when: ansible_distribution == "MacOSX" 
     - ant                         # Testing
     - Ant-Contrib                 # Testing
     - maven                       # Testing

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/main.yml
@@ -31,8 +31,8 @@
     - role: freemarker            # OpenJ9
       tags: [build_tools, build_tools_openj9]
     - role: macos_codesign
-      tags: [codesign, adoptopenjdk]
-      when: ansible_distribution == "MacOSX" 
+      tags: [adoptopenjdk, codesign]
+      when: ansible_distribution == "MacOSX"
     - ant                         # Testing
     - Ant-Contrib                 # Testing
     - maven                       # Testing

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/macos_codesign/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/macos_codesign/tasks/main.yml
@@ -1,0 +1,163 @@
+---
+##################
+# macOS Codesign #
+##################
+
+- name: Set Jenkins user password
+  user:
+    name: jenkins
+    password: "{{ macOS_Jenkins_Password }}"
+  tags:
+   - adoptopenjdk
+   - codesign
+
+- name: Create Jenkins password file
+  file: path="/Users/jenkins/.password" state=touch
+
+- name: Copy password to file
+  copy: content="{{ macOS_Jenkins_Password }}" dest="/Users/jenkins/.password"
+
+- name: Get macOS version
+  shell: sw_vers -productVersion
+  register: macos_version
+
+- name: Check if Default keychain is correct
+  shell: security default-keychain | tr -d '[:space:]' | sed 's/"//g'
+  register: default_keychain
+  become_user: jenkins
+  ignore_errors: true
+  tags:
+   - adoptopenjdk
+   - codesign
+
+- name: Create Keychain if it doesn't exist
+  shell: security create-keychain -p "{{ macOS_Jenkins_Password }}" "/Users/jenkins/Library/Keychains/login.keychain-db"
+  become_user: jenkins
+  when:
+    - not macos_version | regex_search("10.10")
+    - default_keychain.stderr | regex_search("A default keychain could not be found")
+  tags:
+   - adoptopenjdk
+   - codesign
+
+- name: Set Default keychain
+  shell: security default-keychain -s "/Users/jenkins/Library/Keychains/login.keychain-db"
+  become_user: jenkins
+  when:
+    - not macos_version | regex_search("10.10")
+    - default_keychain.stdout != "/Users/jenkins/Library/Keychains/login.keychain-db"
+  tags:
+   - adoptopenjdk
+   - codesign
+
+- name: Reboot macOS after setting Default keychain
+  reboot:
+    reboot_timeout: 3600
+  when:
+    - not macos_version | regex_search("10.10")
+    - default_keychain.stdout != "/Users/jenkins/Library/Keychains/login.keychain-db"
+  tags:
+   - adoptopenjdk
+   - codesign
+
+- name: Test Application Certificate
+  shell: |
+    security unlock-keychain -p `cat ~/.password` login.keychain-db
+    rm -rf /Users/jenkins/test && touch /Users/jenkins/test
+    codesign --sign "Developer ID Application: London Jamocha Community CIC" /Users/jenkins/test
+  become_user: jenkins
+  register: application_cert
+  ignore_errors: true
+  when:
+    - not macos_version | regex_search("10.10")
+  tags:
+   - adoptopenjdk
+   - codesign
+
+- name: Get the Application Certificate from Vendor Secrets
+  copy:
+    src: vendor_files/macos_codesign_certs/application.p12
+    dest: /Users/jenkins/application.p12
+  when:
+    - not macos_version | regex_search("10.10")
+    - application_cert.stderr | regex_search("The specified item could not be found in the keychain")
+  tags:
+   - adoptopenjdk
+   - codesign
+
+- name: Install Application Certificate
+  shell: |
+    security unlock-keychain -p `cat ~/.password` login.keychain-db
+    security import /Users/jenkins/application.p12 -P "{{ macOS_Codesign_Application_Password }}" -T /usr/bin/codesign
+  become_user: jenkins
+  when:
+    - not macos_version | regex_search("10.10")
+    - application_cert.stderr | regex_search("The specified item could not be found in the keychain")
+  tags:
+   - adoptopenjdk
+   - codesign
+
+- name: Test Installer Certificate
+  shell: |
+    security unlock-keychain -p `cat ~/.password` login.keychain-db
+    rm -rf /Users/jenkins/installer.pkg /Users/jenkins/installer_signed.pkg
+    # We need to test sign an actual installer
+    curl -L https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u265-b01/OpenJDK8U-jre_x64_mac_hotspot_8u265b01.pkg -o /Users/jenkins/installer.pkg
+    productsign --sign "Developer ID Installer: London Jamocha Community CIC" /Users/jenkins/installer.pkg /Users/jenkins/installer_signed.pkg
+  become_user: jenkins
+  register: installer_cert
+  ignore_errors: true
+  when:
+    - not macos_version | regex_search("10.10")
+  tags:
+   - adoptopenjdk
+   - codesign
+
+- name: Get the Installer Certificate from Vendor Secrets
+  copy:
+    src: vendor_files/macos_codesign_certs/installer.p12
+    dest: /Users/jenkins/installer.p12
+  when:
+    - not macos_version | regex_search("10.10")
+    - installer_cert.stderr | regex_search("no identity found")
+  tags:
+   - adoptopenjdk
+   - codesign
+
+- name: Install Installer Certificate
+  shell: |
+    security unlock-keychain -p `cat ~/.password` login.keychain-db
+    security import /Users/jenkins/installer.p12 -P "{{ macOS_Codesign_Installer_Password }}" -T /usr/bin/pkgbuild -T /usr/bin/productsign -T /usr/bin/productbuild
+  become_user: jenkins
+  when:
+    - not macos_version | regex_search("10.10")
+    - installer_cert.stderr | regex_search("no identity found")
+  tags:
+   - adoptopenjdk
+   - codesign
+
+- name: Allow codesign via ssh
+  shell: |
+    security unlock-keychain -p `cat ~/.password` login.keychain-db
+    security set-key-partition-list -S apple-tool:,apple: -s -k "{{ macOS_Jenkins_Password }}" /Users/jenkins/Library/Keychains/login.keychain-db
+  become_user: jenkins
+  when:
+    - not macos_version | regex_search("10.10")
+  tags:
+   - adoptopenjdk
+   - codesign
+
+- name: Cleanup files
+  file:
+    path: "{{ item }}"
+    state: absent
+  with_items:
+    - /Users/jenkins/application.p12
+    - /Users/jenkins/installer.p12
+    - /Users/jenkins/test
+    - /Users/jenkins/installer.pkg
+    - /Users/jenkins/installer_signed.pkg
+  ignore_errors: yes
+  tags:
+   - adoptopenjdk
+   - codesign

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/macos_codesign/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/macos_codesign/tasks/main.yml
@@ -7,9 +7,6 @@
   user:
     name: jenkins
     password: "{{ macOS_Jenkins_Password }}"
-  tags:
-   - adoptopenjdk
-   - codesign
 
 - name: Create Jenkins password file
   file: path="/Users/jenkins/.password" state=touch
@@ -26,9 +23,6 @@
   register: default_keychain
   become_user: jenkins
   ignore_errors: true
-  tags:
-   - adoptopenjdk
-   - codesign
 
 - name: Create Keychain if it doesn't exist
   shell: security create-keychain -p "{{ macOS_Jenkins_Password }}" "/Users/jenkins/Library/Keychains/login.keychain-db"
@@ -36,9 +30,6 @@
   when:
     - not macos_version | regex_search("10.10")
     - default_keychain.stderr | regex_search("A default keychain could not be found")
-  tags:
-   - adoptopenjdk
-   - codesign
 
 - name: Set Default keychain
   shell: security default-keychain -s "/Users/jenkins/Library/Keychains/login.keychain-db"
@@ -46,9 +37,6 @@
   when:
     - not macos_version | regex_search("10.10")
     - default_keychain.stdout != "/Users/jenkins/Library/Keychains/login.keychain-db"
-  tags:
-   - adoptopenjdk
-   - codesign
 
 - name: Reboot macOS after setting Default keychain
   reboot:
@@ -56,9 +44,6 @@
   when:
     - not macos_version | regex_search("10.10")
     - default_keychain.stdout != "/Users/jenkins/Library/Keychains/login.keychain-db"
-  tags:
-   - adoptopenjdk
-   - codesign
 
 - name: Test Application Certificate
   shell: |
@@ -70,9 +55,6 @@
   ignore_errors: true
   when:
     - not macos_version | regex_search("10.10")
-  tags:
-   - adoptopenjdk
-   - codesign
 
 - name: Get the Application Certificate from Vendor Secrets
   copy:
@@ -81,9 +63,6 @@
   when:
     - not macos_version | regex_search("10.10")
     - application_cert.stderr | regex_search("The specified item could not be found in the keychain")
-  tags:
-   - adoptopenjdk
-   - codesign
 
 - name: Install Application Certificate
   shell: |
@@ -93,9 +72,6 @@
   when:
     - not macos_version | regex_search("10.10")
     - application_cert.stderr | regex_search("The specified item could not be found in the keychain")
-  tags:
-   - adoptopenjdk
-   - codesign
 
 - name: Test Installer Certificate
   shell: |
@@ -109,9 +85,6 @@
   ignore_errors: true
   when:
     - not macos_version | regex_search("10.10")
-  tags:
-   - adoptopenjdk
-   - codesign
 
 - name: Get the Installer Certificate from Vendor Secrets
   copy:
@@ -120,9 +93,6 @@
   when:
     - not macos_version | regex_search("10.10")
     - installer_cert.stderr | regex_search("no identity found")
-  tags:
-   - adoptopenjdk
-   - codesign
 
 - name: Install Installer Certificate
   shell: |
@@ -132,9 +102,6 @@
   when:
     - not macos_version | regex_search("10.10")
     - installer_cert.stderr | regex_search("no identity found")
-  tags:
-   - adoptopenjdk
-   - codesign
 
 - name: Allow codesign via ssh
   shell: |
@@ -143,9 +110,6 @@
   become_user: jenkins
   when:
     - not macos_version | regex_search("10.10")
-  tags:
-   - adoptopenjdk
-   - codesign
 
 - name: Cleanup files
   file:
@@ -158,6 +122,3 @@
     - /Users/jenkins/installer.pkg
     - /Users/jenkins/installer_signed.pkg
   ignore_errors: yes
-  tags:
-   - adoptopenjdk
-   - codesign


### PR DESCRIPTION
Adds the missing steps to install the macos codesign certs

Also bumps the centos6 build image to use python 3 because the retart module requires a more recent version of ansible