### PR TITLE
linter: fix ansible-lint

### DIFF
--- a/.ansible-lint
+++ b/.ansible-lint
@@ -1,0 +1,12 @@
+skip_list:
+  - '106'  # Role name {} does not match ``^[a-z][a-z0-9_]+$`` pattern
+  - '204'  # Lines should be no longer than 160 chars
+  - '207'  # Nested jinja pattern
+  - '208'  # File permissions unset or incorrect
+  - '301'  # Commands should not change things if nothing needs doing
+  - '303'  # Using command rather than module 
+  - '305'  # Use shell only when shell functionality is required
+  - '401'  # Git checkouts must contain explicit version
+  - '403'  # Package installs should not use latest
+  - '601'  # Don't compare to literal True/False
+  - '602'  # Don't compare to empty string

--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -43,30 +43,22 @@ jobs:
 
     - uses: actions/checkout@v2
 
-    - name: Set up Python 2.x
+    - name: Set up Python 3.x
       uses: actions/setup-python@v2
       with:
-        python-version: '2.x'
+        python-version: '3.x'
 
     - name: Install dependencies
-      run: |
-        python -m pip install --upgrade pip
-        pip install ansible ansible-lint==4.2.0
+      run: pip install ansible ansible-lint
 
     - name: ansible_lint
-      run: | 
+      run: |
+        # Ansible code static analysis
+        ansible-lint
+
         cd ansible
         # Check that the inventory is valid
         ansible-inventory --host build-marist-rhel77-s390x-1
-
-        # Ansible code static analysis
-        ansible-lint -x 403,204 playbooks/AdoptOpenJDK_Unix_Playbook/main.yml
-        ansible-lint -x 403,204 playbooks/AdoptOpenJDK_Windows_Playbook/main.yml
-        ansible-lint -x 403,204 playbooks/AdoptOpenJDK_Services_Playbooks/ubuntu-jckservices.yml
-        ansible-lint -x 403,204 playbooks/AdoptOpenJDK_ITW_Playbook/main.yml
-        ansible-lint -x 403,204 playbooks/aix.yml
-        ansible-lint -x 403,204 playbooks/vagrant.yml
-        ansible-lint -x 403,204 playbooks/ubuntu-jck.yml
 
         # Check Playbook syntax.
         ansible-playbook playbooks/AdoptOpenJDK_Unix_Playbook/main.yml --syntax-check

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Get_Vendor_Files/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Get_Vendor_Files/tasks/main.yml
@@ -4,20 +4,23 @@
 ##############
 
 - name: check out AdoptOpenJDK/secrets
-  local_action: git repo=git@github.com:AdoptOpenJDK/secrets.git dest=vendor_files force=true
+  git: repo=git@github.com:AdoptOpenJDK/secrets.git dest=vendor_files force=true
+  delegate_to: localhost
   run_once: true
 
 - name: check if dotgpg is installed
-  local_action: shell command -v dotgpg
+  shell: command -v dotgpg
+  delegate_to: localhost
   run_once: true
 
 - name: generate list of vendor_files
-  local_action: command dotgpg cat {{ item }}
+  command: dotgpg cat {{ item }}
+  delegate_to: localhost
   register: vendor_files
   loop: "{{ lookup('fileglob', 'vendor_files/vendor_files/*', wantlist=True) }}"
   run_once: true
 
 - name: set facts from output of dotgpg
   set_fact: {"{{ item.item | basename | replace('.gpg','') | replace('.','_') }}":"{{ item.stdout }}"}
-  with_items: "{{vendor_files.results}}"
+  with_items: "{{ vendor_files.results }}"
   run_once: true

--- a/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/roles/Get_Vendor_Files/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/roles/Get_Vendor_Files/tasks/main.yml
@@ -4,20 +4,23 @@
 ##############
 
 - name: check out AdoptOpenJDK/secrets
-  local_action: git repo=git@github.com:AdoptOpenJDK/secrets.git dest=vendor_files force=true
+  git: repo=git@github.com:AdoptOpenJDK/secrets.git dest=vendor_files force=true
+  delegate_to: localhost
   run_once: true
 
 - name: check if dotgpg is installed
-  local_action: shell command -v dotgpg
+  shell: command -v dotgpg
+  delegate_to: localhost
   run_once: true
 
 - name: generate list of vendor_files
-  local_action: command dotgpg cat {{ item }}
+  command: dotgpg cat {{ item }}
+  delegate_to: localhost
   register: vendor_files
   loop: "{{ lookup('fileglob', 'vendor_files/vendor_files/*', wantlist=True) }}"
   run_once: true
 
 - name: set facts from output of dotgpg
   set_fact: {"{{ item.item | basename | replace('.gpg','') | replace('.','_') }}":"{{ item.stdout }}"}
-  with_items: "{{vendor_files.results}}"
+  with_items: "{{ vendor_files.results }}"
   run_once: true

--- a/ansible/plugins/filter/filters.py
+++ b/ansible/plugins/filter/filters.py
@@ -21,12 +21,13 @@
 # IN THE SOFTWARE.
 #
 
-from ansible.errors import AnsibleFilterError
 import re
+
+from ansible.errors import AnsibleFilterError
 
 
 def match_key(value, dictionary, raise_error=True, feedback_name='os'):
-    for key, val in dictionary.iteritems():
+    for key, val in dictionary.items():
         # yes, yes; we can lambda this but my old self in
         # two years will cry having to understand
         if type(val) is list:

--- a/ansible/plugins/inventory/adoptopenjdk_yaml.py
+++ b/ansible/plugins/inventory/adoptopenjdk_yaml.py
@@ -22,20 +22,19 @@
 # IN THE SOFTWARE.
 #
 
+from __future__ import print_function
+
 import argparse
+import json
+import os
+import subprocess
+import sys
+
+import yaml
 try:
     import configparser
 except ImportError:
     import ConfigParser as configparser
-try:
-    from itertools import ifilter
-except ImportError:
-    from itertools import filter as ifilter
-import json
-import yaml
-import os
-import sys
-from os import path
 
 valid = {
   # taken from nodejs/node.git: ./configure
@@ -50,43 +49,63 @@ valid = {
         'packet', 'linaro','digitalocean', 'ibm', 'godaddy', 'aws')
 }
 
-# customisation options per host:
-#
-# - ip [string] (required): ip address of host
-# - alias [string]: 'nickname', will be used in ssh config
-# - labels [sequence]: passed to jenkins
-#
-# parsing done on host naming:
-#
-# - *freebsd*: changes path to python interpreter
-# - *smartos*: changes path to python interpreter
-#
-# @TODO: properly support --list and --host $host
-
+INVENTORY_FILENAME = "inventory.yml"
 
 def main():
 
+    # load config file for special cases
+    config = configparser.RawConfigParser()
+    config.read('ansible.cfg')
+
+    # load public inventory
+    export = parse_yaml(load_yaml_file(INVENTORY_FILENAME), config)
+
+    # export in JSON for Ansible
+    print(json.dumps(export, sort_keys=True, indent=2))
+
+
+# https://stackoverflow.com/a/7205107
+def merge(a, b, path=None):
+    "merges b into a"
+    path = path or []
+    for key in b:
+        if key in a:
+            if isinstance(a[key], dict) and isinstance(b[key], dict):
+                merge(a[key], b[key], path + [str(key)])
+            elif isinstance(a[key], list) and isinstance(b[key], list):
+                a[key] = sorted(set(a[key]).union(b[key]))
+            elif a[key] == b[key]:
+                pass  # same leaf value
+            else:
+                raise Exception('Conflict at %s' % '.'.join(path + [str(key)]))
+        else:
+            a[key] = b[key]
+    return a
+
+def load_yaml_file(file_name):
+    """Loads YAML data from a file"""
+
     hosts = {}
-    export = {'_meta': {'hostvars': {}}}
 
     # get inventory
-    basepath = path.dirname(__file__)
-    inventory_path = path.abspath(path.join(basepath, "..", "..", "inventory.yml"))
-    with open(inventory_path, 'r') as stream:
+    with open(file_name, 'r') as stream:
         try:
-            hosts = yaml.load(stream, Loader=yaml.FullLoader)
+            hosts = yaml.safe_load(stream)
 
         except yaml.YAMLError as exc:
             print(exc)
         finally:
             stream.close()
 
-    # get special cases
-    config = configparser.ConfigParser()
-    config.read('ansible.cfg')
+    return hosts
+
+def parse_yaml(hosts, config):
+    """Parses host information from the output of yaml.safe_load"""
+
+    export = {'_meta': {'hostvars': {}}}
 
     for host_types in hosts['hosts']:
-        for host_type, providers in host_types.iteritems():
+        for host_type, providers in host_types.items():
             export[host_type] = {}
             export[host_type]['hosts'] = []
 
@@ -96,58 +115,60 @@ def main():
             }
 
             for provider in providers:
-                for provider_name, hosts in provider.iteritems():
-                    for host, metadata in hosts.iteritems():
+                for provider_name, hosts in provider.items():
+                    for host, metadata in hosts.items():
+
                         # some hosts have metadata appended to provider
                         # which requires underscore
-                        delimiter = "_" if host.count('-') is 3 else "-"
+                        delimiter = "_" if host.count('-') == 3 else "-"
                         hostname = '{}-{}{}{}'.format(host_type, provider_name,
                                                       delimiter, host)
 
                         export[host_type]['hosts'].append(hostname)
 
-                        c = {}
+                        hostvars = {}
 
                         try:
                             parsed_host = parse_host(hostname)
-                            for k, v in parsed_host.iteritems():
-                                c.update({k: v[0] if type(v) is dict else v})
-                        except Exception, e:
+                            for k, v in parsed_host.items():
+                                hostvars.update({k: v[0] if type(v) is dict else v})
+                        except Exception as e:
                             raise Exception('Failed to parse host: %s' % e)
 
-                        c.update({'ansible_host': metadata['ip']})
+                        if 'ip' in metadata:
+                            hostvars.update({'ansible_host': metadata['ip']})
+                            del metadata['ip']
 
                         if 'port' in metadata:
-                            c.update({'ansible_port': str(metadata['port'])})
+                            hostvars.update({'ansible_port': str(metadata['port'])})
+                            del metadata['port']
 
                         if 'user' in metadata:
-                            c.update({'ansible_user': metadata['user']})
-                            if 'win' not in hostname:
-                                c.update({'ansible_become': True})
+                            hostvars.update({'ansible_user': metadata['user']})
+                            hostvars.update({'ansible_become': True})
+                            del metadata['user']
 
-                        if 'labels' in metadata:
-                            c.update({'labels': metadata['labels']})
+                        if 'password' in metadata:
+                            hostvars.update({'ansible_password': str(metadata['password'])})
+                            del metadata['password']
 
-                        if 'alias' in metadata:
-                            c.update({'alias': metadata['alias']})
-
-                        if 'win' in hostname:
-                            c.update({'is_win': True})
+                        hostvars.update(metadata)
 
                         # add specific options from config
-                        for option in ifilter(lambda s: s.startswith('hosts:'),
-                                              config.sections()):
+                        for option in filter(lambda s: s.startswith('hosts:'),
+                                             config.sections()):
                             # remove `hosts:`
                             if option[6:] in hostname:
                                 for o in config.items(option):
                                     # configparser returns tuples of key, value
-                                    c.update({o[0]: o[1]})
+                                    hostvars.update({o[0]: o[1]})
 
                         export['_meta']['hostvars'][hostname] = {}
-                        export['_meta']['hostvars'][hostname].update(c)
+                        export['_meta']['hostvars'][hostname].update(hostvars)
 
-    print(json.dumps(export, indent=2))
+            export[host_type]['hosts'].sort()
 
+    return export
 
 def parse_host(host):
     """Parses a host and validates it against our naming conventions"""
@@ -157,7 +178,7 @@ def parse_host(host):
 
     expected = ['type', 'provider', 'os', 'arch', 'uid']
 
-    if len(info) is not 5:
+    if len(info) != 5:
         raise Exception('Host format is invalid: %s,' % host)
 
     for key, item in enumerate(expected):
@@ -171,11 +192,12 @@ def parse_host(host):
 
 
 def has_metadata(info):
-    """Checks for metadata in variables. These are separated from the "key"
-       metadata by underscore. Not used anywhere at the moment for anything
-       other than descriptiveness"""
+    """
+    Checks for metadata in variables. These are separated from the "key"
+    metadata by underscore. Not used anywhere at the moment for anything
+    other than descriptiveness
+    """
 
-    param = dict()
     metadata = info.split('_', 1)
 
     try:

--- a/ansible/plugins/library/ssh_config.py
+++ b/ansible/plugins/library/ssh_config.py
@@ -22,13 +22,15 @@
 # IN THE SOFTWARE.
 #
 
-from ansible.module_utils.basic import *
-from jinja2 import Environment, Template, filters
 import os
 import re
 
-pre_match = '# begin: adoptopenjdk template'
-post_match = '# end: adoptopenjdk template'
+from ansible.module_utils.basic import AnsibleModule
+from jinja2 import Environment
+
+
+pre_match = '# begin: node.js template'
+post_match = '# end: node.js template'
 match = re.compile(r'^' + re.escape(pre_match) + '(.*)' + re.escape(post_match),
                    flags=re.DOTALL | re.MULTILINE)
 
@@ -58,7 +60,7 @@ Host {{ host }} {{ metadata.alias }}
 
 
 def multi_replace(content, to_replace):
-    for key, val in to_replace.iteritems():
+    for key, val in to_replace.items():
         content = content.replace(key, val)
     return content
 
@@ -99,8 +101,7 @@ def main():
                          path)
 
     if not is_templatable(path, contents):
-        module.fail_json(msg='Your ssh config lacks template stubs. ' +
-                             'Check README.md for instructions.')
+        module.fail_json(msg='Your ssh config lacks template stubs. Check README.md for instructions.')
 
     rendered = '{}{}{}'.format(
         pre_match,


### PR DESCRIPTION
Adds python3 support to the inventory scripts

Fixes linter issue (caused by using deprecated python2.7 version)

Adds centralised ansible-lint config file