### PR TITLE
ansible: remove osuosl docker machine from inventory

### DIFF
--- a/ansible/inventory.yml
+++ b/ansible/inventory.yml
@@ -90,9 +90,6 @@ hosts:
       - packet:
           ubuntu1604-armv8-1: {ip: 147.75.77.146}
 
-      - osuosl:
-          ubuntu1604-ppc64le-1: {ip: 140.211.168.243}
-
       - scaleway:
           ubuntu1604-armv7-1: {ip: 51.158.73.136}
 


### PR DESCRIPTION
This machine has been removed. We are now able to use the dynamic docker machines for building images