### PR TITLE
winPB: Install Cygwin without a cache

### DIFF
--- a/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/roles/cygwin/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/roles/cygwin/tasks/main.yml
@@ -15,35 +15,21 @@
   register: cygwin_installed
   tags: cygwin
 
-# For details about the cache, see: https://github.com/AdoptOpenJDK/openjdk-infrastructure/issues/1210#issuecomment-679076545
-- name: Retrieve cygwin cache from ci.adoptopenjdk.net
+- name: Retrieve Cygwin setup
   win_get_url:
-    url: https://ci.adoptopenjdk.net/userContent/winansible/cygwin64.tar.gz
-    dest: C:/temp/cygwin64.tar.gz
-    checksum: 8f8b1d7d00233e384e725390c4018941fe7125290b94ecc0eeb3cf6684b4ce23
+    url: https://cygwin.com/setup-x86_64.exe
+    dest: C:\temp\cygwin.exe
+    checksum: 4dd4d4531e8e63ade849daaaf587ba1c1430368701772c8ee42a27f4e8c373e4
     checksum_algorithm: sha256
-  when: (not cygwin_installed.stat.exists)
+  when: not cygwin_installed.stat.exists
   tags: cygwin
 
-- name: Retrieve cygwin toolset from ci.adoptopenjdk.net
-  win_get_url:
-    url: https://ci.adoptopenjdk.net/userContent/winansible/cygwin64_bootstrap.zip
-    dest: C:/temp/cyg_toolset.zip
-    checksum: d7950df964a0618ac47561d349276d4644e27f5b8f0a5fba9b10db702d09ecad
-    checksum_algorithm: sha256
-  when: (not cygwin_installed.stat.exists)
-  tags: cygwin
-
-- name: Use cygwin 'tar' and 'pigz' to extract cygwin cache
+- name: Install Cygwin
   win_shell: |
-    New-Item -ItemType directory -Name cygwin_toolset -Path C:\temp\
-    Expand-Archive -LiteralPath C:\temp\cyg_toolset.zip -DestinationPath C:\temp\cygwin_toolset;
-    $env:path="C:\temp\cygwin_toolset;$env:path"
-    cd C:\
-    tar --force-local -I pigz -xf C:\temp\cygwin64.tar.gz
+    Start-Process -Wait -FilePath 'C:\temp\cygwin.exe' -ArgumentList '--packages autoconf,automake,bsdtar,cpio,curl,gcc-core,git,gnupg,grep,libtool,make,mingw64-x86_64-gcc-core,perl,rsync,unzip,wget,zip --quiet-mode --download --local-install --delete-orphans --site https://mirrors.kernel.org/sourceware/cygwin/ --local-package-dir C:\cygwin_packages --root C:\cygwin64'
   args:
     executable: powershell
-  when: (not cygwin_installed.stat.exists)
+  when: not cygwin_installed.stat.exists
   tags: cygwin
 
 - name: Change git config to not replace Line endings

--- a/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/roles/cygwin/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/roles/cygwin/tasks/main.yml
@@ -19,8 +19,6 @@
   win_get_url:
     url: https://cygwin.com/setup-x86_64.exe
     dest: C:\temp\cygwin.exe
-    checksum: 4dd4d4531e8e63ade849daaaf587ba1c1430368701772c8ee42a27f4e8c373e4
-    checksum_algorithm: sha256
   when: not cygwin_installed.stat.exists
   tags: cygwin
 

--- a/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/roles/cygwin/vars/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/roles/cygwin/vars/main.yml
@@ -1,9 +1,0 @@
----
-##########
-# cygwin #
-##########
-
-Cygwin_SITE_URL: https://mirrors.kernel.org/sourceware/cygwin/
-Cygwin_PACKAGE_DIR: c:\cygwin_packages
-Cygwin_ROOT_INST_DIR: C:\cygwin64
-Cygwin_CATEGORIES: Devel


### PR DESCRIPTION
@gdams found a better way to install Cygwin on the OpenJDK-build github actions, so I thought it'd be best to do the same here: 
https://ci.adoptopenjdk.net/job/VagrantPlaybookCheck/883/
This ends up installing in 2 minutes as opposed to the ~20-25 minutes to install it before.