### PR TITLE
winPB: Remove cygwin include variables task

### DIFF
--- a/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/roles/cygwin/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/roles/cygwin/tasks/main.yml
@@ -1,11 +1,4 @@
 ---
-########################
-# Include OS variables #
-########################
-- name: Include OS variables
-  include_vars: "../vars/main.yml"
-  tags: main
-
 ##########
 # cygwin #
 ##########


### PR DESCRIPTION
Ref: #1596 
Removed the `vars` file, but not the task that includes it :facepalm: 