### PR TITLE
UnixPb: add perl-Time-HiRes to rhel vars

### DIFF
--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/vars/RedHat.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/vars/RedHat.yml
@@ -91,6 +91,7 @@ Test_Tool_Packages:
   - acl
   - perl
   - perl-Digest-SHA
+  - perl-Time-HiRes
   - xorg-x11-xauth
   - xorg-x11-server-Xvfb
   - zlib-devel


### PR DESCRIPTION
Ref https://github.com/AdoptOpenJDK/openjdk-tests/issues/1998

It seems that `perl-Time-HiRes` isnt included in the standard Perl library so Ive added the package to the Rhel playbook