### PR TITLE
unixPB: Update cmake location (Downloads now on github)

### DIFF
--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/cmake/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/cmake/tasks/main.yml
@@ -23,7 +23,7 @@
 
 - name: Download cmake
   get_url:
-    url: https://cmake.org/files/v3.11/cmake-{{ cmakeVersion }}.tar.gz
+    url: https://github.com/Kitware/CMake/releases/download/v3.11.4/cmake-{{ cmakeVersion }}.tar.gz
     dest: /tmp/cmake-{{ cmakeVersion }}.tar.gz
     mode: 0440
     force: no


### PR DESCRIPTION
The cmake website seems to have moved where cmake is stored. This is causing playbook executions to fail as it is not at the expected location. This moves it to the new location on github. Checksum is the same so this should be a safe change.

Testing along with another (build) change at https://ci.adoptopenjdk.net/view/Tooling/job/VagrantPlaybookCheck/891

Signed-off-by: Stewart X Addison <sxa@redhat.com>