### PR TITLE
UnixPB: prevent improper hostname and /etc/hosts change

### DIFF
--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/main.yml
@@ -5,7 +5,7 @@
 # Groups can be passed in as a command-line variable in Ansible playbook.
 # It can be defined as 'all' or a specific group which the host belongs to.
 # For example, it can be 'all' or 'x86' for when a host is in the group 'x86'.
-- hosts: "{{ Groups | default('localhost:build:test:!*zos*:!*win*:!*aix*') }}"
+- hosts: all
   gather_facts: yes
   tasks:
     - block:
@@ -20,8 +20,8 @@
   #########
   roles:
     - Debug
-    - role: Get_Vendor_Files
-      tags: [vendor_files, adoptopenjdk]
+    # - role: Get_Vendor_Files
+    #   tags: [vendor_files, adoptopenjdk]
     - Version
     - Common
     - Providers                   # AdoptOpenJDK Infrastructure

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/main.yml
@@ -5,7 +5,7 @@
 # Groups can be passed in as a command-line variable in Ansible playbook.
 # It can be defined as 'all' or a specific group which the host belongs to.
 # For example, it can be 'all' or 'x86' for when a host is in the group 'x86'.
-- hosts: all
+- hosts: "{{ Groups | default('localhost:build:test:!*zos*:!*win*:!*aix*') }}"
   gather_facts: yes
   tasks:
     - block:

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/main.yml
@@ -20,8 +20,8 @@
   #########
   roles:
     - Debug
-    # - role: Get_Vendor_Files
-    #   tags: [vendor_files, adoptopenjdk]
+    - role: Get_Vendor_Files
+      tags: [vendor_files, adoptopenjdk]
     - Version
     - Common
     - Providers                   # AdoptOpenJDK Infrastructure

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/main.yml
@@ -5,7 +5,7 @@
 # Groups can be passed in as a command-line variable in Ansible playbook.
 # It can be defined as 'all' or a specific group which the host belongs to.
 # For example, it can be 'all' or 'x86' for when a host is in the group 'x86'.
-- hosts: all
+- hosts: "{{ Groups | default('localhost:build:test:!*zos*:!*win*:!*aix*') }}"
   gather_facts: yes
   tasks:
     - block:
@@ -14,16 +14,14 @@
           include_vars: group_vars/all/adoptopenjdk_variables.yml
   environment:
     PATH: "/usr/local/bin:{{ ansible_env.PATH }}"
-  # vars:
-  #   my_version: "{{ version }}"
 
   #########
   # Roles #
   #########
   roles:
     - Debug
-    # - role: Get_Vendor_Files
-    #   tags: [vendor_files, adoptopenjdk]
+    - role: Get_Vendor_Files
+      tags: [vendor_files, adoptopenjdk]
     - Version
     - Common
     - Providers                   # AdoptOpenJDK Infrastructure

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/main.yml
@@ -5,7 +5,7 @@
 # Groups can be passed in as a command-line variable in Ansible playbook.
 # It can be defined as 'all' or a specific group which the host belongs to.
 # For example, it can be 'all' or 'x86' for when a host is in the group 'x86'.
-- hosts: "{{ Groups | default('localhost:build:test:!*zos*:!*win*:!*aix*') }}"
+- hosts: all
   gather_facts: yes
   tasks:
     - block:
@@ -14,14 +14,16 @@
           include_vars: group_vars/all/adoptopenjdk_variables.yml
   environment:
     PATH: "/usr/local/bin:{{ ansible_env.PATH }}"
+  # vars:
+  #   my_version: "{{ version }}"
 
   #########
   # Roles #
   #########
   roles:
     - Debug
-    - role: Get_Vendor_Files
-      tags: [vendor_files, adoptopenjdk]
+    # - role: Get_Vendor_Files
+    #   tags: [vendor_files, adoptopenjdk]
     - Version
     - Common
     - Providers                   # AdoptOpenJDK Infrastructure

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/tasks/main.yml
@@ -39,6 +39,7 @@
   when:
     - Domain == "adoptopenjdk.net" and ansible_distribution != "MacOSX"
     - inventory_hostname != ansible_default_ipv4.address
+    - inventory_hostname != "localhost"
   tags: hostname,adoptopenjdk
 
 - name: Set hostname to inventory_hostname (macOS)
@@ -50,6 +51,7 @@
   when:
     - Domain == "adoptopenjdk.net" and ansible_distribution == "MacOSX"
     - inventory_hostname != ansible_default_ipv4.address
+    - inventory_hostname != "localhost"
   tags: hostname,adoptopenjdk
 
 #####################
@@ -64,6 +66,7 @@
   when:
     - Domain == "adoptopenjdk.net"
     - inventory_hostname != ansible_default_ipv4.address
+    - inventory_hostname != "localhost"
   tags: hosts_file
 
 - name: Update /etc/hosts file - IP FQDN hostname (Domain != "adoptopenjdk.net")
@@ -75,11 +78,16 @@
   when:
     - Domain != "adoptopenjdk.net"
     - inventory_hostname != ansible_default_ipv4.address
+    - inventory_hostname != "localhost"
   tags: hosts_file
 
 - debug:
-    msg: "Inventory_hostname is the same as the ip address. Manually add the fqdn to /etc/hosts and update the /etc/hostname file"
-  when: inventory_hostname == ansible_default_ipv4.address
+    msg: "Inventory_hostname is the same as the ip address or is localhost.
+    The fqdn has not been added to /etc/hosts.
+    The hostname of the machine has not been updated.
+    Manually add the fqdn to /etc/hosts.
+    Manually update the hostname in /etc/hostname."
+  when: (inventory_hostname == ansible_default_ipv4.address) or (inventory_hostname == "localhost")
   tags: hosts_file, hostname
 
 - name: Update /etc/hosts file - 127.0.0.1

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/tasks/main.yml
@@ -36,7 +36,7 @@
 - name: Set hostname to inventory_hostname
   hostname:
     name: "{{ inventory_hostname }}.{{ Domain }}"
-  when: 
+  when:
     - Domain == "adoptopenjdk.net" and ansible_distribution != "MacOSX"
     - inventory_hostname != ansible_default_ipv4.address
   tags: hostname,adoptopenjdk
@@ -47,7 +47,7 @@
     - "sudo scutil --set HostName {{ inventory_hostname }}.adoptopenjdk.net"
     - "sudo scutil --set ComputerName {{ inventory_hostname }}.adoptopenjdk.net"
     - "dscacheutil -flushcache"
-  when: 
+  when:
     - Domain == "adoptopenjdk.net" and ansible_distribution == "MacOSX"
     - inventory_hostname != ansible_default_ipv4.address
   tags: hostname,adoptopenjdk
@@ -61,7 +61,7 @@
     regexp: "^(.*){{ ansible_hostname }}(.*)$"
     line: "{{ ansible_default_ipv4.address }} {{ inventory_hostname }}.{{ Domain }} {{ inventory_hostname }}"
     state: present
-  when: 
+  when:
     - Domain == "adoptopenjdk.net"
     - inventory_hostname != ansible_default_ipv4.address
   tags: hosts_file
@@ -72,7 +72,7 @@
     regexp: "^(.*){{ ansible_hostname }}(.*)$"
     line: "{{ ansible_default_ipv4.address }} {{ ansible_fqdn }} {{ ansible_hostname }}"
     state: present
-  when: 
+  when:
     - Domain != "adoptopenjdk.net"
     - inventory_hostname != ansible_default_ipv4.address
   tags: hosts_file

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/tasks/main.yml
@@ -87,7 +87,7 @@
     The hostname of the machine has not been updated.
     Manually add the fqdn to /etc/hosts
     and manually update the hostname in /etc/hostname.
-    Or use the command line argument --extra-vars 'inventory_hostname=<realhostname>', 
+    Or use the command line argument --extra-vars 'inventory_hostname=<realhostname>',
     when running the playbook next time"
   when: (inventory_hostname == ansible_default_ipv4.address) or (inventory_hostname == "localhost")
   tags: hosts_file, hostname

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/tasks/main.yml
@@ -36,7 +36,9 @@
 - name: Set hostname to inventory_hostname
   hostname:
     name: "{{ inventory_hostname }}.{{ Domain }}"
-  when: Domain == "adoptopenjdk.net" and ansible_distribution != "MacOSX"
+  when: 
+    - Domain == "adoptopenjdk.net" and ansible_distribution != "MacOSX"
+    - inventory_hostname != ansible_default_ipv4.address
   tags: hostname,adoptopenjdk
 
 - name: Set hostname to inventory_hostname (macOS)
@@ -45,7 +47,9 @@
     - "sudo scutil --set HostName {{ inventory_hostname }}.adoptopenjdk.net"
     - "sudo scutil --set ComputerName {{ inventory_hostname }}.adoptopenjdk.net"
     - "dscacheutil -flushcache"
-  when: Domain == "adoptopenjdk.net" and ansible_distribution == "MacOSX"
+  when: 
+    - Domain == "adoptopenjdk.net" and ansible_distribution == "MacOSX"
+    - inventory_hostname != ansible_default_ipv4.address
   tags: hostname,adoptopenjdk
 
 #####################
@@ -57,7 +61,9 @@
     regexp: "^(.*){{ ansible_hostname }}(.*)$"
     line: "{{ ansible_default_ipv4.address }} {{ inventory_hostname }}.{{ Domain }} {{ inventory_hostname }}"
     state: present
-  when: Domain == "adoptopenjdk.net"
+  when: 
+    - Domain == "adoptopenjdk.net"
+    - inventory_hostname != ansible_default_ipv4.address
   tags: hosts_file
 
 - name: Update /etc/hosts file - IP FQDN hostname (Domain != "adoptopenjdk.net")
@@ -66,8 +72,15 @@
     regexp: "^(.*){{ ansible_hostname }}(.*)$"
     line: "{{ ansible_default_ipv4.address }} {{ ansible_fqdn }} {{ ansible_hostname }}"
     state: present
-  when: Domain != "adoptopenjdk.net"
+  when: 
+    - Domain != "adoptopenjdk.net"
+    - inventory_hostname != ansible_default_ipv4.address
   tags: hosts_file
+
+- debug:
+    msg: "Inventory_hostname is the same as the ip address. Manually add the fqdn to /etc/hosts and update the /etc/hostname file"
+  when: inventory_hostname == ansible_default_ipv4.address
+  tags: hosts_file, hostname
 
 - name: Update /etc/hosts file - 127.0.0.1
   lineinfile:

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/tasks/main.yml
@@ -85,8 +85,10 @@
     msg: "Inventory_hostname is the same as the ip address or is localhost.
     The fqdn has not been added to /etc/hosts.
     The hostname of the machine has not been updated.
-    Manually add the fqdn to /etc/hosts.
-    Manually update the hostname in /etc/hostname."
+    Manually add the fqdn to /etc/hosts
+    and manually update the hostname in /etc/hostname.
+    Or use the command line argument --extra-vars 'inventory_hostname=<realhostname>', 
+    when running the playbook next time"
   when: (inventory_hostname == ansible_default_ipv4.address) or (inventory_hostname == "localhost")
   tags: hosts_file, hostname
 


### PR DESCRIPTION
Ive added a condition to prevent the playbooks from improperly changing the hostname or adding an incorrect line into /etc/hosts when the ip address is passed as the `inventory_hostname` variable