### PR TITLE
inventory: Sync up marist machines with reality (jenkins)

### DIFF
--- a/ansible/inventory.yml
+++ b/ansible/inventory.yml
@@ -48,9 +48,6 @@ hosts:
       - marist:
           rhel77-s390x-1: {ip: 148.100.86.102, user: linux1}
           rhel77-s390x-2: {ip: 148.100.245.197, user: linux1}
-          ubuntu1604-s390x-1: {ip: 148.100.113.58}
-          zOS-s390x-1: {ip: 148.100.36.136, user: OPEN1}
-          zOS-s390x-2: {ip: 148.100.36.137, user: OPEN1}
 
       - osuosl:
           aix71-ppc64-1: {ip: 140.211.9.10}


### PR DESCRIPTION
We do not use Ubuntu bulid machines - the remaining one was switched to be a docker image production machine.

Fixes #1621 where the discrepencies were raised

Signed-off-by: Stewart X Addison <sxa@redhat.com>