### PR TITLE
inventory: add missing inspira SPARC systems

### DIFF
--- a/ansible/inventory.yml
+++ b/ansible/inventory.yml
@@ -36,6 +36,10 @@ hosts:
       - godaddy:
           rhel7-x64-1: {ip: 160.153.248.216, user: adoptopenjdk}
 
+      - inspira:
+          solaris10u11-sparcv9-1: {ip: }
+          solaris10u11-sparcv9-2: {ip: }
+
       - linaro:
           centos76-armv8-2: {ip: 213.146.141.123, user: centos}
 
@@ -141,8 +145,8 @@ hosts:
           aix71-ppc64-1: {ip: 129.33.196.209, user: b9s010a}
           aix71-ppc64-2: {ip: 129.33.196.210, user: b9s010a}
 
-#     - inspira:
-#         solaris10u11-sparcv9-1: {ip: }
+      - inspira:
+          solaris10u11-sparcv9-1: {ip: }
 
       - osuosl:
           aix72-ppc64-1: {ip: 140.211.9.28}

--- a/ansible/inventory.yml
+++ b/ansible/inventory.yml
@@ -37,8 +37,8 @@ hosts:
           rhel7-x64-1: {ip: 160.153.248.216, user: adoptopenjdk}
 
       - inspira:
-          solaris10u11-sparcv9-1: {ip: }
-          solaris10u11-sparcv9-2: {ip: }
+          solaris10u11-sparcv9-1: {}
+          solaris10u11-sparcv9-2: {}
 
       - linaro:
           centos76-armv8-2: {ip: 213.146.141.123, user: centos}
@@ -146,7 +146,7 @@ hosts:
           aix71-ppc64-2: {ip: 129.33.196.210, user: b9s010a}
 
       - inspira:
-          solaris10u11-sparcv9-1: {ip: }
+          solaris10u11-sparcv9-1: {}
 
       - osuosl:
           aix72-ppc64-1: {ip: 140.211.9.28}

--- a/ansible/plugins/inventory/adoptopenjdk_yaml.py
+++ b/ansible/plugins/inventory/adoptopenjdk_yaml.py
@@ -38,14 +38,14 @@ except ImportError:
 
 valid = {
   # taken from nodejs/node.git: ./configure
-  'arch': ('armv7', 'armv8', 'ppc64le', 'ppc64', 'x64', 's390x', 'arm64' 'sparcv9'),
+  'arch': ('armv7', 'armv8', 'ppc64le', 'ppc64', 'x64', 's390x', 'arm64', 'sparcv9'),
 
   # valid roles - add as necessary
   'type': ('build', 'test', 'infrastructure', 'perf', 'docker'),
 
   # providers - validated for consistency
   'provider': ('azure', 'marist', 'osuosl', 'scaleway',
-        'macstadium', 'macincloud', 'softlayer', 'spearhead',
+        'macstadium', 'macincloud', 'ibmcloud', 'spearhead',
         'packet', 'linaro','digitalocean', 'ibm', 'godaddy',
         'aws', 'inspira')
 }

--- a/ansible/plugins/inventory/adoptopenjdk_yaml.py
+++ b/ansible/plugins/inventory/adoptopenjdk_yaml.py
@@ -38,7 +38,7 @@ except ImportError:
 
 valid = {
   # taken from nodejs/node.git: ./configure
-  'arch': ('armv7', 'armv8', 'ppc64le', 'ppc64', 'x64', 's390x', 'arm64'),
+  'arch': ('armv7', 'armv8', 'ppc64le', 'ppc64', 'x64', 's390x', 'arm64' 'sparcv9'),
 
   # valid roles - add as necessary
   'type': ('build', 'test', 'infrastructure', 'perf', 'docker'),
@@ -46,7 +46,8 @@ valid = {
   # providers - validated for consistency
   'provider': ('azure', 'marist', 'osuosl', 'scaleway',
         'macstadium', 'macincloud', 'softlayer', 'spearhead',
-        'packet', 'linaro','digitalocean', 'ibm', 'godaddy', 'aws')
+        'packet', 'linaro','digitalocean', 'ibm', 'godaddy',
+        'aws', 'inspira')
 }
 
 INVENTORY_FILENAME = "inventory.yml"


### PR DESCRIPTION
As per slack discussion @gdams it would be good to understand if [build machine -1](https://ci.adoptopenjdk.net/computer/build-inspira-solaris10u11-sparcv9-1/) is supposed to be online as it is not currently.

Initial test system was added (commented out) under https://github.com/AdoptOpenJDK/openjdk-infrastructure/pull/1338

Signed-off-by: Stewart X Addison <sxa@redhat.com>