### PR TITLE
vagrant: create known_hosts file if it does not exist

### DIFF
--- a/ansible/pbTestScripts/vagrantPlaybookCheck.sh
+++ b/ansible/pbTestScripts/vagrantPlaybookCheck.sh
@@ -233,7 +233,7 @@ startVMPlaybook()
 	echo "[127.0.0.1]:${vagrantPORT}" >> playbooks/AdoptOpenJDK_Unix_Playbook/hosts.unx
 	# Remove IP from known_hosts if already found
 	# ssh-keygen -R will fail if the known_hosts file does not exist
-        [ ! -r $HOME/.ssh/known_hosts ] && touch $HOME/.ssh/known_hosts && chmod 644 $HOME/.ssh/known_hosts
+	[ ! -r $HOME/.ssh/known_hosts ] && touch $HOME/.ssh/known_hosts && chmod 644 $HOME/.ssh/known_hosts
 	ssh-keygen -R $(cat playbooks/AdoptOpenJDK_Unix_Playbook/hosts.unx)
 	
 	sed -i -e "s/.*hosts:.*/- hosts: all/g" playbooks/AdoptOpenJDK_Unix_Playbook/main.yml

--- a/ansible/pbTestScripts/vagrantPlaybookCheck.sh
+++ b/ansible/pbTestScripts/vagrantPlaybookCheck.sh
@@ -232,6 +232,8 @@ startVMPlaybook()
 	rm -f playbooks/AdoptOpenJDK_Unix_Playbook/hosts.unx
 	echo "[127.0.0.1]:${vagrantPORT}" >> playbooks/AdoptOpenJDK_Unix_Playbook/hosts.unx
 	# Remove IP from known_hosts if already found
+	# ssh-keygen -R will fail if the known_hosts file does not exist
+        [ ! -r $HOME/.ssh/known_hosts ] && touch $HOME/.ssh/known_hosts && chmod 644 $HOME/.ssh/known_hosts
 	ssh-keygen -R $(cat playbooks/AdoptOpenJDK_Unix_Playbook/hosts.unx)
 	
 	sed -i -e "s/.*hosts:.*/- hosts: all/g" playbooks/AdoptOpenJDK_Unix_Playbook/main.yml


### PR DESCRIPTION
Fixes this problem which occurs if there is no known_hosts file:
```
13:34:03 ++ cat playbooks/AdoptOpenJDK_Unix_Playbook/hosts.unx
13:34:03 + ssh-keygen -R '[127.0.0.1]:2200'
13:34:03 do_known_hosts: hostkeys_foreach failed: No such file or directory
13:34:04 Build step 'Execute shell' marked build as failure
13:34:05 [Checks API] No suitable checks publisher found.
13:34:05 Finished: FAILURE
```
Testing under https://ci.adoptopenjdk.net/view/Tooling/job/VagrantPlaybookCheck/896/

Signed-off-by: Stewart X Addison <sxa@redhat.com>