### PR TITLE
ansible: Create Windows JDK7 link as jdk-7 instead of jdk7

### DIFF
--- a/ansible/pbTestScripts/buildJDKWin.sh
+++ b/ansible/pbTestScripts/buildJDKWin.sh
@@ -67,7 +67,7 @@ checkJDK() {
 		exit 1
 	fi
 	if ((JAVA_TO_BUILD == 8)); then
-		export JDK_BOOT_DIR=/cygdrive/c/openjdk/jdk7
+		export JDK_BOOT_DIR=/cygdrive/c/openjdk/jdk-7
 		export JAVA_TO_BUILD="jdk8u"
 	elif ((JAVA_TO_BUILD > JDK_GA)); then
 		export JDK_BOOT_DIR=/cygdrive/c/openjdk/jdk-${JDK_GA}
@@ -106,7 +106,7 @@ cloneRepo() {
 }
 # Set defaults
 export JAVA_TO_BUILD=jdk8
-export JDK_BOOT_DIR=/cygdrive/c/openjdk/jdk7
+export JDK_BOOT_DIR=/cygdrive/c/openjdk/jdk-7
 export VARIANT=openj9
 export PATH=/usr/bin/:$PATH
 export TARGET_OS=windows

--- a/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/roles/Java7/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/roles/Java7/tasks/main.yml
@@ -34,12 +34,12 @@
 
 - name: Test if Java 7 symlink is already created
   win_stat:
-    path: 'C:\openjdk\jdk7'
+    path: 'C:\openjdk\jdk-7'
   register: java7_symlink
   tags: Java7
 
 - name: Create symlink to Java 7
-  win_shell: mklink /D "C:\openjdk\jdk7" "C:\Program Files\Java\java-se-7u75-ri"
+  win_shell: mklink /D "C:\openjdk\jdk-7" "C:\Program Files\Java\java-se-7u75-ri"
   args:
     executable: cmd
   when: (not java7_symlink.stat.exists)


### PR DESCRIPTION
I would like to obtain explicit approval from EVERYONE on the reviewers list. Can I ask no-one else other than me to merge please (which is the default policy for the openjdk-infrastructure repo anyway, but let's make sure no-one misses it for this one ;-)

The link in `C:\openjdk` for the Java 7 boot JDK is created as `jdk7` instead of `jdk-7`. This is inconsistent with all other versions. The current production build machines seem to have a mix, so I'm choosing to standardise on the same as the other versions.

To all reviewers: Please let me know if this will impact you and if so when you will have mitigated it (or if you are unable to do so - in which case we would still have the option to put both in place but I'd rather avoid that)

Attempting test via [VPC](https://ci.adoptopenjdk.net/job/VagrantPlaybookCheck/OS=Win2012,label=vagrant/900/console)

Signed-off-by: Stewart X Addison <sxa@redhat.com>