### PR TITLE
inventory: Replace 'softlayer' machines with 'ibmcloud'

### DIFF
--- a/ansible/inventory.yml
+++ b/ansible/inventory.yml
@@ -16,9 +16,8 @@ hosts:
       - packet:
           ubuntu1604-x64-1: {ip: 147.75.80.219, description: ansible.adoptopenjdk.net}
 
-      - softlayer:
-          ubuntu1604-x64-3: {ip: 158.176.72.83, description: jckservices.adoptopenjdk.net}
-          ubuntu1804-x64-1: {ip: 52.117.150.132, description: Bare metal machine to run VM playbook testing}
+      - ibmcloud:
+          vagrant-x64: {ip: 150.239.60.120, description: Bare metal machine to run vagrantPlaybookCheck and qemuPlaybookCheck}
 
       - godaddy:
           ubuntu1604-x64-1: {ip: 160.153.247.225, description: git-hg/load relief for jenkins master}
@@ -67,10 +66,9 @@ hosts:
           ubuntu1604-armv7-2: {ip: 212.47.246.7}
           ubuntu1604-x64-1: {ip: 51.15.46.107}
 
-      - softlayer:
-          centos6-x64-1: {ip: 52.117.29.5}
-          win2012r2-x64-1: {ip: 37.58.103.195, user: Administrator}
-          win2012r2-x64-2: {ip: 37.58.103.196, user: Administrator}
+      - ibmcloud:
+          win2012r2-x64-1: {ip: 169.48.4.138, user: Administrator}
+          win2012r2-x64-2: {ip: 169.48.4.142, user: Administrator}
 
       - spearhead:
           freebsd12-x64-1: {ip: 185.131.222.224}
@@ -191,9 +189,9 @@ hosts:
       - scaleway:
           ubuntu1604-x64-1: {ip: 51.15.76.107}
 
-      - softlayer:
-          rhel74-x64-1: {ip: 169.55.170.70}
-          rhel69-x64-1: {ip: 169.55.150.147}
+      - ibmcloud:
+          rhel6-x64-1: {ip: 169.48.4.140}
+          rhel7-x64-1: {ip: 169.48.4.136}
           ubuntu1604-x64-1: {ip: 169.55.150.155}
-          win2012r2-x64-1: {ip: 169.55.170.72, user: admin}
-          win2012r2-x64-2: {ip: 52.117.29.13, user: Administrator}
+          win2012r2-x64-1: {ip: 169.48.4.131, user: Administrator}
+          win2012r2-x64-2: {ip: 169.48.4.139, user: Administrator}

--- a/ansible/inventory.yml
+++ b/ansible/inventory.yml
@@ -17,7 +17,7 @@ hosts:
           ubuntu1604-x64-1: {ip: 147.75.80.219, description: ansible.adoptopenjdk.net}
 
       - ibmcloud:
-          vagrant-x64: {ip: 150.239.60.120, description: Bare metal machine to run vagrantPlaybookCheck and qemuPlaybookCheck}
+          vagrant-x64-1: {ip: 150.239.60.120, description: Bare metal machine to run vagrantPlaybookCheck and qemuPlaybookCheck}
 
       - godaddy:
           ubuntu1604-x64-1: {ip: 160.153.247.225, description: git-hg/load relief for jenkins master}

--- a/ansible/plugins/inventory/adoptopenjdk_yaml.py
+++ b/ansible/plugins/inventory/adoptopenjdk_yaml.py
@@ -45,7 +45,7 @@ valid = {
 
   # providers - validated for consistency
   'provider': ('azure', 'marist', 'osuosl', 'scaleway',
-        'macstadium', 'macincloud', 'softlayer', 'spearhead',
+        'macstadium', 'macincloud', 'ibmcloud', 'spearhead',
         'packet', 'linaro','digitalocean', 'ibm', 'godaddy', 'aws')
 }
 


### PR DESCRIPTION
The SoftLayer branding is no longer used on IBM cloud. This PR makes two changes:
1. Changes the softlayer provider name to ibmcloud
2. Replaces all of our `-softlayer-` machines in the inventory with other ones with `-ibmcloud-` names that we have obtained and tested (This is independent of the rename but we had to do it for other reasons)

Signed-off-by: Stewart X Addison <sxa@redhat.com>