### PR TITLE
unixPB/winPB: Add JDK15 for bootstrapping JDK16

### DIFF
--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/main.yml
@@ -67,12 +67,12 @@
       jdk_version: 11
       when: ansible_distribution != "Alpine"
       tags: build_tools
-    - role: adoptopenjdk_install  # JDK14 Build Bootstrap
-      jdk_version: 13
-      when: ansible_distribution != "Alpine"
-      tags: build_tools
     - role: adoptopenjdk_install  # JDK15 Build Bootstrap
       jdk_version: 14
+      when: ansible_distribution != "Alpine"
+      tags: build_tools
+    - role: adoptopenjdk_install  # JDK16 Build Bootstrap
+      jdk_version: 15
       when: ansible_distribution != "Alpine"
       tags: build_tools
     - OpenSSL102                  # OpenJ9

--- a/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/main.yml
@@ -56,10 +56,10 @@
       jdk_version: 10
     - role: Java_install          # For Gradle
       jdk_version: 11
-    - role: Java_install          # JDK14 build bootstrap
-      jdk_version: 13
     - role: Java_install          # JDK15 build bootstrap
       jdk_version: 14
+    - role: Java_install          # JDK16 build bootstrap
+      jdk_version: 15
     - ANT                         # Testing
     - MSVS_2013
     - MSVS_2017                   # OpenJ9


### PR DESCRIPTION
Replace JDK13 (since 14 is out of support) with JDK15 used for bootstrapping JDK16

Signed-off-by: Stewart X Addison <sxa@redhat.com>