### PR TITLE
UnixPB: update docker-ce repo checksum for centos7

### DIFF
--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Docker/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Docker/tasks/main.yml
@@ -204,7 +204,7 @@
     owner: root
     group: root
     mode: 0644
-    checksum: sha256:6650718e0fe5202ae7618521f695d43a8bc051c539d7570f0edbfa5b4916f218
+    checksum: sha256:8ab5599eef0afcac10cbd3e8670873efee20fcceb5fb3526a62edeade603cec7
   when:
     - docker_installed.rc != 0
     - ansible_distribution == "CentOS"


### PR DESCRIPTION
Ref https://github.com/AdoptOpenJDK/openjdk-infrastructure/issues/1641

Tested on a centos 7 machine. I was able to reproduce the error, and updating the checksum allowed the docker role to run without error
