### PR TITLE
winPB: Replace MSVS_2017/9 installer URLs and reinstate checksums

### DIFF
--- a/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/roles/MSVS_2017/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/roles/MSVS_2017/tasks/main.yml
@@ -11,7 +11,9 @@
 
 - name: Download Visual Studio Community 2017
   win_get_url:
-    url: 'https://aka.ms/vs/15/release/vs_community.exe'
+    url: 'https://download.visualstudio.microsoft.com/download/pr/c5c75dfa-1b29-4419-80f8-bd39aed6bcd9/7ed8fa27575648163e07548ff5667b55b95663a2323e2b2a5f87b16284e481e6/vs_Community.exe'
+    checksum: 7ed8fa27575648163e07548ff5667b55b95663a2323e2b2a5f87b16284e481e6
+    checksum_algorithm: sha256
     dest: 'C:\TEMP\vs_community.exe'
     force: no
   when: (not vs2017_installed.stat.exists)

--- a/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/roles/MSVS_2017/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/roles/MSVS_2017/tasks/main.yml
@@ -9,6 +9,7 @@
   register: vs2017_installed
   tags: MSVS_2017
 
+# This is the target that you're redirected to when you go to https://aka.ms/vs/15/release/vs_community.exe
 - name: Download Visual Studio Community 2017
   win_get_url:
     url: 'https://download.visualstudio.microsoft.com/download/pr/c5c75dfa-1b29-4419-80f8-bd39aed6bcd9/7ed8fa27575648163e07548ff5667b55b95663a2323e2b2a5f87b16284e481e6/vs_Community.exe'

--- a/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/roles/MSVS_2019/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/roles/MSVS_2019/tasks/main.yml
@@ -11,7 +11,9 @@
 
 - name: Download Visual Studio Community 2019
   win_get_url:
-    url: 'https://aka.ms/vs/16/release/vs_community.exe'
+    url: 'https://download.visualstudio.microsoft.com/download/pr/6b655578-de8c-4862-ad77-65044ca714cf/f29399a618bd3a8d1dcc96d349453f686b6176590d904308402a6402543e310b/vs_Community.exe'
+    checksum: f29399a618bd3a8d1dcc96d349453f686b6176590d904308402a6402543e310b
+    checksum_algorithm: sha256
     dest: 'C:\temp\vs_community19.exe'
     force: no
   when: (not vs2019_installed.stat.exists)

--- a/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/roles/MSVS_2019/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/roles/MSVS_2019/tasks/main.yml
@@ -9,6 +9,7 @@
   register: vs2019_installed
   tags: MSVS_2019
 
+# This is the target that you're redirected to when you go to https://aka.ms/vs/16/release/vs_community.exe
 - name: Download Visual Studio Community 2019
   win_get_url:
     url: 'https://download.visualstudio.microsoft.com/download/pr/6b655578-de8c-4862-ad77-65044ca714cf/f29399a618bd3a8d1dcc96d349453f686b6176590d904308402a6402543e310b/vs_Community.exe'


### PR DESCRIPTION
Fixes: #1546 

@gdams found some alternative links to retrieve the MSVS installers, that should be persistent (i.e. not have their checksum change every X weeks). This means we're able to reinstate the checksums again :-)

VPC Run: https://ci.adoptopenjdk.net/job/VagrantPlaybookCheck/908/