### PR TITLE
inventory: Sync OSUOSL Linux machines with reality

### DIFF
--- a/ansible/inventory.yml
+++ b/ansible/inventory.yml
@@ -149,7 +149,6 @@ hosts:
           aix72-ppc64-2: {ip: 140.211.9.36}
           centos74-ppc64le-1: {ip: 140.211.168.228, user: centos}
           centos74-ppc64le-2: {ip: 140.211.168.217, user: centos}
-          centos74-ppc64le-3: {ip: 140.211.168.225, user: centos}
           centos74-ppc64le-4: {ip: 140.211.168.245, user: centos}
           ubuntu1604-ppc64le-1: {ip: 140.211.168.227, user: ubuntu}
           ubuntu1604-ppc64le-2: {ip: 140.211.168.190, user: ubuntu}
@@ -157,7 +156,6 @@ hosts:
           ubuntu1604-ppc64le-4: {ip: 140.211.168.239, user: ubuntu}
           ubuntu1804-ppc64le-1: {ip: 140.211.168.5, user: ubuntu}
           ubuntu1804-ppc64le-2: {ip: 140.211.168.8, user: ubuntu}
-          ubuntu1804-ppc64le-3: {ip: 140.211.168.4, user: ubuntu}
 
       - packet:
           ubuntu1604-armv8-1: {ip: 147.75.74.50}


### PR DESCRIPTION
The inventory for the OSUOSL Linux machines is out of sync with what we have. Fortunately Jenkins is correct, although Bastillion will need updates which I'll do as soon as I click "Create Pull Request" here.

**Updates required:**

- The ones in this PR
- Remove `ubuntu1804-1` from Bastillion as it's defined with the same IP as `ubuntu1604-1`
- Renaming `ubuntu1804-2` to `-1` in Bastillion
- Renaming `ubuntu1804-3` to `-2` in Bastillion
- Removing `ubuntu1804-ppc64le-4` from Bastillion as it does not exist
- Removing `centos74-3` from Bastillion as it does not exist

We should look at updating some of the machines we have here to cover newer OSs once the current GA cycle is out of the way

Assigning Will as reviewer as he raised the issues with me :-)

Signed-off-by: Stewart X Addison <sxa@redhat.com>