### PR TITLE
Add issue and PR templates to the repository

### DIFF
--- a/.github/ISSUE_TEMPLATE/ansible.md
+++ b/.github/ISSUE_TEMPLATE/ansible.md
@@ -1,0 +1,15 @@
+---
+name: 🐛 Machine setup (ansible) bug or new installation/setup request
+about: Use this if you need to report a machine setup issue or if you want something changed in the setup
+title: Ansible request for <affected product>
+labels: 'ansible'
+assignees: ''
+
+---
+Please put the name of the software product (and affectred platforms if relevant) in the title of this issue
+
+- [ ] Missing install
+- [ ] Bug in ansible playbook
+- [ ] Request for new playbook addition
+
+Details:

--- a/.github/ISSUE_TEMPLATE/machineaccess.md
+++ b/.github/ISSUE_TEMPLATE/machineaccess.md
@@ -1,0 +1,17 @@
+---
+name: ⌨️  Request access to a machine
+about: Request access to an AdoptOpenJDK machine or set of machines
+title: Access request for <your username>
+labels: 'Temp Infra Access'
+assignees: 'sxa'
+
+---
+Access level:
+- [ ] Non-privileged
+- [ ] jenkins user
+- [ ] root/Administrative
+- [ ] other (Please specify):
+
+System for which access is needed: 
+
+Please explain why you need this access including whether it is a temporary or permanent request:

--- a/.github/ISSUE_TEMPLATE/newmachine.md
+++ b/.github/ISSUE_TEMPLATE/newmachine.md
@@ -1,0 +1,18 @@
+---
+name: 🖥️  Request for additional machines
+about: Request for new machine to be added to the project
+title: New Machine requirement
+labels: 'Machine Request'
+assignees: ''
+
+---
+I need to request a new machine:
+
+- New machine operating system (e.g. linux/windows/macos/solaris/aix):
+- New machine architecture (e.g. x64/aarch32/arm32/ppc64/ppc64le/sparc):
+- Provider (leave blank if it does not matter): 
+- Desired usage:
+- Any unusual specification/setup required: 
+- How many of them are required: 1
+
+Please explain what this machine is needed for:

--- a/.github/ISSUE_TEMPLATE/systemdown.md
+++ b/.github/ISSUE_TEMPLATE/systemdown.md
@@ -1,0 +1,14 @@
+---
+name: 😓 System down
+about: Use this if a system is non-responsive, not working as it should, or needs to be marked back online in jenkins
+title: 'System unavailable: '
+labels: 'systemdown'
+assignees: ''
+
+---
+
+- Please put the system name in the title of this issue.
+
+- Link to any log file showing the problem:
+
+- Please describe the issue:

--- a/.github/ISSUE_TEMPLATE/teamaccess.md
+++ b/.github/ISSUE_TEMPLATE/teamaccess.md
@@ -1,0 +1,16 @@
+---
+name: Request/revoke access to an infrastructure team
+about: Request access to a github team
+title: Access request for <your username>
+labels: ''
+assignees: 'sxa'
+
+---
+Team requested:
+
+- [ ] infrastructure-triage
+- [ ] infrastructure
+- [ ] infrastructure-core
+- [ ] infrastructure-secret
+
+Please explain why you need this access:

--- a/.github/ISSUE_TEMPLATE/testcasefail.md
+++ b/.github/ISSUE_TEMPLATE/testcasefail.md
@@ -1,0 +1,19 @@
+---
+name: 👀 Machine-specific test case failure
+about: Tst case failures believed to be due to the configuration of specific machines
+labels: 'testFail'
+assignees: ''
+
+---
+Please set the title to indicate the test name and machine name where known.
+
+To make it easy for the infrastructure team to repeat and diagnose, please
+answer the following questions:
+
+- test suite/name? 
+- Is there an existing issue elsewhere covering this?
+- Which machine(s) does it work on? 
+- Which machine(s) does it fail on?
+- Do you have a link to a Grinder re-run if the test with the failure?
+
+Any other details:

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,13 @@
+<!--
+Thank you for your pull request. Please provide a description above and review
+the requirements below.
+-->
+
+##### Checklist
+<!-- Remove items that are not applicable. For completed items, change [ ] to [x]. -->
+
+- [ ] commit message has one of the [standard prefixes](https://github.com/AdoptOpenJDK/openjdk-infrastructure/blob/master/FAQ.md#commit-messages)
+- [ ] FAQ.md updated if appropriate
+- [ ] other documentation is changed or added (if applicable)
+- [ ] playbook changes run through [VPC](https://ci.adoptopenjdk.net/view/Tooling/job/VagrantPlaybookCheck/) or [QPC](https://ci.adoptopenjdk.net/view/Tooling/job/QEMUPlaybookCheck/) (if you have access)
+- [ ] inventory changes, ensure bastillion is updated accordingly


### PR DESCRIPTION
I've been meaning to do this for a while. Add an initial set of issue and PR templates fo the repository to make it easier for people submitting issues/PRs to have them categorised correctly and supply all relevant information and think about ensuring documentation is available for others. We can update/refine as we go on (and see which issues don't fit into these!)

Signed-off-by: Stewart X Addison <sxa@redhat.com>