### PR TITLE
winPB: Create Shortname for 'Program Files (x86)' before major installations

### DIFF
--- a/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/roles/Common/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/roles/Common/tasks/main.yml
@@ -22,7 +22,7 @@
   tags: basic_config
 
 # Builds need a shortname for Program Files (x86), that needs to be made without any major installations
-# See: https://github.com/AdoptOpenJDK/openjdk-infrastructure/issues/1594#issuecomment-704229594 
+# See: https://github.com/AdoptOpenJDK/openjdk-infrastructure/issues/1594#issuecomment-704229594
 - name: Enable shortname creation
   win_shell: "fsutil behavior set disable8dot3 0;"
   tags: basic_config

--- a/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/roles/Common/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/roles/Common/tasks/main.yml
@@ -20,3 +20,15 @@
     dest: C:\Users\Public\Desktop\cmd.lnk
     icon: C:\Windows\System32\cmd.exe,0
   tags: basic_config
+
+# Builds need a shortname for Program Files (x86), that needs to be made without any major installations
+# See: https://github.com/AdoptOpenJDK/openjdk-infrastructure/issues/1594#issuecomment-704229594 
+- name: Enable shortname creation
+  win_shell: "fsutil behavior set disable8dot3 0;"
+  tags: basic_config
+
+- name: Ensure 'Program Files (x86)' has a shortname
+  win_shell: "fsutil file setshortname \"C:\\Program Files (x86)\" \"PROGRA~2\""
+  args:
+    executable: cmd
+  tags: basic_config


### PR DESCRIPTION
Fixes: #1598 

Ensures the 8dot3 shortnames are enabled, and gives `Program Files (x86)` a shortname before any major installations. It was found when setting up the IBMCloud windows machines that the `incredibuild` processes were stopping the shortname from being assigned, giving an `Access is Denied` error message, despite being Administrator. 

The playbook has been checked on the Windows Vagrant VM , as well as put through VPC, however, these particular Windows installations already have shortnames enabled, with `Program Files (x86)` already having a shortname. This did, however, fix the Windows 2016 Dockerfile (#1610), so I can't see why it wouldn't work on an actual windows machine.

##### Checklist
<!-- Remove items that are not applicable. For completed items, change [ ] to [x]. -->

- [x] Commit message has one of the [standard prefixes](https://github.com/AdoptOpenJDK/openjdk-infrastructure/blob/master/FAQ.md#commit-messages)
- [x] Playbook changes run through [VPC](https://ci.adoptopenjdk.net/view/Tooling/job/VagrantPlaybookCheck/) : https://ci.adoptopenjdk.net/job/VagrantPlaybookCheck/923/
