### PR TITLE
QPC: Change kernel path for RISC-V VM

### DIFF
--- a/ansible/pbTestScripts/qemuPlaybookCheck.sh
+++ b/ansible/pbTestScripts/qemuPlaybookCheck.sh
@@ -224,7 +224,7 @@ done
 			export MACHINE="virt"
 			export DRIVE="-device virtio-blk-device,drive=hd -drive file=$workFolder/${OS}.${ARCHITECTURE}.dsk,if=none,id=hd"
 			export SSH_CMD="-device virtio-net-device,netdev=net -netdev user,id=net,hostfwd=tcp::$PORTNO-:22"
-			export EXTRA_ARGS="-kernel /usr/lib/riscv64-linux-gnu/opensbi/qemu/virt/fw_jump.elf -device loader,file=/usr/lib/u-boot/qemu-riscv64_smode/u-boot.bin,addr=0x80200000";;
+			export EXTRA_ARGS="-kernel /usr/lib/riscv64-linux-gnu/opensbi/generic/fw_jump.elf -device loader,file=/usr/lib/u-boot/qemu-riscv64_smode/u-boot.bin,addr=0x80200000";;
 	esac
 	
 	# Run the command, mask output and send to background


### PR DESCRIPTION
Ref: #1483 

The RISC-V QPC run wasn't working as the path to the kernel changed (That kernel is provided by an `apt` package `opensbi`, so It possibly changed due to somebody upgrading the package)

- [x] Playbook changes run through [VPC](https://ci.adoptopenjdk.net/view/Tooling/job/VagrantPlaybookCheck/) or [QPC](https://ci.adoptopenjdk.net/view/Tooling/job/QEMUPlaybookCheck/): Yup; https://ci.adoptopenjdk.net/job/QEMUPlaybookCheck/169/ARCHITECTURE=riscv,OS=debian11,label=vagrant/console

