### PR TITLE
aixPB: remove unnecessary register: result.role

### DIFF
--- a/ansible/playbooks/AdoptOpenJDK_AIX_Playbook/roles/X11/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_AIX_Playbook/roles/X11/tasks/main.yml
@@ -28,14 +28,12 @@
 
 - name: Install IBM X11 Extensions - installp
   command: installp -aXYgd /tmp/x11/X11.adt X11.adt.ext
-  register: result.x11
   ignore_errors: yes
   when: does_X11_adt_ext_exist.rc != 0
   tags: x11
 
 - name: Install X11.vfb - installp
   command: installp -agXYd /tmp/x11/X11.vfb all
-  register: result.x11.vfb
   ignore_errors: yes
   when: does_x11_exist.rc != 0
   tags: x11

--- a/ansible/playbooks/AdoptOpenJDK_AIX_Playbook/roles/openssl/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_AIX_Playbook/roles/openssl/tasks/main.yml
@@ -25,7 +25,6 @@
 
 - name: Install IBM Openssl - installp
   command: installp -aXYgd /tmp/openssl-1.0.2.1601 openssl.base
-  register: result.openssl
   ignore_errors: yes
   when: does_openssl_exist.rc != 0
   tags: openssl

--- a/ansible/playbooks/AdoptOpenJDK_AIX_Playbook/roles/xlc_v13/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_AIX_Playbook/roles/xlc_v13/tasks/main.yml
@@ -23,7 +23,6 @@
 
 - name: Install IBM XLC13 - installp
   command: installp -aXYg -e /tmp/usr/install.log -d /tmp/usr/sys/inst.images all
-  register: result.xlc
   ignore_errors: yes
   when: xlc13.stat.islnk is not defined
   tags: xlc13

--- a/ansible/playbooks/AdoptOpenJDK_AIX_Playbook/roles/xlc_v16/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_AIX_Playbook/roles/xlc_v16/tasks/main.yml
@@ -23,7 +23,6 @@
 
 - name: Install IBM XLC16 - installp
   command: installp -aXYg -e /tmp/usr/install.log -d /tmp/usr/sys/inst.images all
-  register: result.xlc
   ignore_errors: yes
   when: xlc16.stat.islnk is not defined
   tags: xlc16

--- a/ansible/playbooks/AdoptOpenJDK_AIX_Playbook/roles/yum/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_AIX_Playbook/roles/yum/tasks/main.yml
@@ -33,7 +33,6 @@
 
 - name: Install yum and dependencies
   command: /tmp/yum.sh
-  register: result.yum
   ignore_errors: yes
   when: yum.stat.islnk is not defined
   tags:


### PR DESCRIPTION
The roles yum, x11, xlc 13 and 16 and openssl unnecessarily register a `result.$role` variable which isnt referenced later in the role, rendering it useless. Moreover, it causes an error during the execution of the playbook:

```
TASK [Install yum and dependencies] *****************************************************************************************************************************************************************************************************************************************************
task path: /Users/hkhel/AdoptOpenJDK/openjdk-infrastructure/ansible/playbooks/AdoptOpenJDK_AIX_Playbook/roles/yum/tasks/main.yml:34
fatal: [p9-aix1-ojdk06.osuosl.org]: FAILED! => {"msg": "Invalid variable name in 'register' specified: 'result.yum'"}
```

```
TASK [Install X11.vfb - installp] *******************************************************************************************************************************************************
task path: /Users/hkhel/AdoptOpenJDK/openjdk-infrastructure/ansible/playbooks/AdoptOpenJDK_AIX_Playbook/roles/X11/tasks/main.yml:36
fatal: [p9-aix1-ojdk05.osuosl.org]: FAILED! => {"msg": "Invalid variable name in 'register' specified: 'result.x11.vfb'"}
...ignoring
```