### PR TITLE
Revert garbage inventory path from adoptopenjdk_yaml.py

### DIFF
--- a/ansible/plugins/inventory/adoptopenjdk_yaml.py
+++ b/ansible/plugins/inventory/adoptopenjdk_yaml.py
@@ -29,6 +29,7 @@ import json
 import os
 import subprocess
 import sys
+from os import path
 
 import yaml
 try:
@@ -50,8 +51,6 @@ valid = {
         'aws', 'inspira', 'packet_esxi')
 }
 
-INVENTORY_FILENAME = "inventory.yml"
-
 def main():
 
     # load config file for special cases
@@ -59,7 +58,9 @@ def main():
     config.read('ansible.cfg')
 
     # load public inventory
-    export = parse_yaml(load_yaml_file(INVENTORY_FILENAME), config)
+    basepath = path.dirname(__file__)
+    inventory_path = path.abspath(path.join(basepath, "..", "..", "inventory.yml"))
+    export = parse_yaml(load_yaml_file(inventory_path), config)
 
     # export in JSON for Ansible
     print(json.dumps(export, sort_keys=True, indent=2))
@@ -87,6 +88,7 @@ def load_yaml_file(file_name):
     """Loads YAML data from a file"""
 
     hosts = {}
+
 
     # get inventory
     with open(file_name, 'r') as stream:


### PR DESCRIPTION
Signed-off-by: Stewart X Addison <sxa@redhat.com>
[fix_ansible_lint](https://github.com/AdoptOpenJDK/openjdk-infrastructure/pull/1574/files) completely broke the ability for adoptopenjdk_yaml.py to parse the inventory unless you were in the same directory as `inventory.yml`. This means that AWX cannot utilise it. This is a minimal revert of some of the changes in there to allow it to work again.


##### Checklist
<!-- Remove items that are not applicable. For completed items, change [ ] to [x]. -->

- [x] commit message has one of the [standard prefixes](https://github.com/AdoptOpenJDK/openjdk-infrastructure/blob/master/FAQ.md#commit-messages)
- [ ] FAQ.md updated if appropriate
- [ ] other documentation is changed or added (if applicable)
- [ ] playbook changes run through [VPC](https://ci.adoptopenjdk.net/view/Tooling/job/VagrantPlaybookCheck/) or [QPC](https://ci.adoptopenjdk.net/view/Tooling/job/QEMUPlaybookCheck/) (if you have access)
- [ ] inventory changes, ensure bastillion is updated accordingly
