### PR TITLE
pbTests: Fix -nh option on the VPC help screen

### DIFF
--- a/ansible/pbTestScripts/vagrantPlaybookCheck.sh
+++ b/ansible/pbTestScripts/vagrantPlaybookCheck.sh
@@ -74,7 +74,7 @@ usage()
   --clean-workspace | -c         Remove the old work folder if detected
   --URL | -u <GitURL>            The URL of the git repository
   --test | -t                    Runs a quick test on the built JDK
-  --no-halt | -n                 Option to stop the vagrant VMs halting
+  --no-halt | -nh                Option to stop the vagrant VMs halting
   --new-vagrant-files | -nv      Use vagrantfiles from the the specified git repository
   --skip-more | -sm              Run playbook faster by excluding things not required by buildJDK
   --help | -h                    Displays this help message"


### PR DESCRIPTION
Hopefully this is obvious :-)

Signed-off-by: Stewart X Addison <sxa@redhat.com>

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.
-->

##### Checklist
<!-- Remove items that are not applicable. For completed items, change [ ] to [x]. -->

- [x] commit message has one of the [standard prefixes](https://github.com/AdoptOpenJDK/openjdk-infrastructure/blob/master/FAQ.md#commit-messages)
- [ ] FAQ.md updated if appropriate
- [x] other documentation is changed or added (if applicable)
- [ ] playbook changes run through [VPC](https://ci.adoptopenjdk.net/view/Tooling/job/VagrantPlaybookCheck/) or [QPC](https://ci.adoptopenjdk.net/view/Tooling/job/QEMUPlaybookCheck/) (if you have access)
- [ ] inventory changes, ensure bastillion is updated accordingly
