### PR TITLE
unixPB: do not update hosts_file when 'adoptopenjdk' tag is skipped

### DIFF
--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/tasks/main.yml
@@ -78,7 +78,7 @@
     - Domain == "adoptopenjdk.net"
     - inventory_hostname != ansible_default_ipv4.address
     - inventory_hostname != "localhost"
-  tags: hosts_file
+  tags: hosts_file, adoptopenjdk
 
 - name: Update /etc/hosts file - IP FQDN hostname (Domain != "adoptopenjdk.net")
   lineinfile:
@@ -90,7 +90,7 @@
     - Domain != "adoptopenjdk.net"
     - inventory_hostname != ansible_default_ipv4.address
     - inventory_hostname != "localhost"
-  tags: hosts_file
+  tags: hosts_file, adoptopenjdk
 
 - debug:
     msg: "Inventory_hostname is the same as the ip address or is localhost.
@@ -110,7 +110,7 @@
     line: "127.0.0.1   localhost  localhost.localdomain"
     state: present
     backup: yes
-  tags: hosts_file
+  tags: hosts_file, adoptopenjdk
 
 ########################
 # Include OS variables #


### PR DESCRIPTION
Signed-off-by: Stewart X Addison <sxa@redhat.com>

Since we generally recommed that end-users skip the `adoptopenjdk` tag, we should also make that tag skip the updating of the `hosts` file and other network configuration options to avoid a potentially destructive situation on the end-users' machines

##### Checklist
<!-- Remove items that are not applicable. For completed items, change [ ] to [x]. -->

- [x] commit message has one of the [standard prefixes](https://github.com/AdoptOpenJDK/openjdk-infrastructure/blob/master/FAQ.md#commit-messages)
- [ ] FAQ.md updated if appropriate
- [ ] other documentation is changed or added (if applicable)
- [ ] playbook changes run through [VPC](https://ci.adoptopenjdk.net/view/Tooling/job/VagrantPlaybookCheck/) or [QPC](https://ci.adoptopenjdk.net/view/Tooling/job/QEMUPlaybookCheck/) (if you have access)
- [ ] inventory changes, ensure bastillion is updated accordingly
