### PR TITLE
move CRB packages out of common build tool list

### DIFF
--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/vars/CentOS.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/vars/CentOS.yml
@@ -26,7 +26,6 @@ Build_Tool_Packages:
   - gmp-devel
   - java-1.8.0-openjdk-devel
   - libcurl-devel
-  - libdwarf-devel                # OpenJ9
   - libpng-devel
   - libXext-devel
   - libXi-devel                   # JDK12+ compilation
@@ -67,7 +66,7 @@ Additional_Build_Tools_CentOS8:
   - glibc-langpack-zh             # required for creating Chinese locales
 
 Additional_Build_Tools_NOT_CentOS8:
-  - libdwarf-devel
+  - libdwarf-devel                # OpenJ9.  Now in PowerTools repo.
   - lbzip2
   - java-1.7.0-openjdk-devel
   - ntp

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/vars/RedHat.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/vars/RedHat.yml
@@ -24,9 +24,7 @@ Build_Tool_Packages:
   - glibc-devel
   - gmp-devel
   - libcurl-devel
-  - libdwarf-devel                # OpenJ9
   - libffi-devel
-  - libmpc-devel
   - libpng-devel
   - libXext-devel
   - libXi-devel                   # JDK12+ compilation
@@ -47,6 +45,8 @@ Build_Tool_Packages:
   - zip
 
 Additional_Build_Tools_NOT_RHEL8:
+  - libdwarf-devel                # now in CodeReady Linux Builder (CRB) repo
+  - libmpc-devel                  # now in CodeReady Linux Builder (CRB) repo
   - ntp                           # in RHEL8, ntp package is replaced by chrony
 
 Additional_Build_Tools_RHEL8:


### PR DESCRIPTION
Signed-off-by: Sej <sarah_jackson@uk.ibm.com>

The `libdwarf-devel` and `libmpc-devel` packages are no longer in the base repos for RedHat 8, and have been moved to the CodeReady Linux Builder (CRB) repository which is restricted access.  

Moving these packages to the `Additional_Build_Tools_NOT_RHEL8` list ensures that they are still installed on earlier versions of RedHat. 
