### PR TITLE
inventory: add linux installer node

### DIFF
--- a/ansible/inventory.yml
+++ b/ansible/inventory.yml
@@ -41,6 +41,7 @@ hosts:
 
       - godaddy:
           rhel7-x64-1: {ip: 160.153.248.216, user: adoptopenjdk}
+          ubuntu1604-x64-1: {ip: 160.153.254.64}
 
       - inspira:
           solaris10u11-sparcv9-1: {}


### PR DESCRIPTION
ref https://github.com/AdoptOpenJDK/openjdk-infrastructure/issues/1577

- [x] inventory changes, ensure bastillion is updated accordingly

Machine is in [jenkins](https://ci.adoptopenjdk.net/computer/build-godaddy-ubuntu1604-x64-1/). Bastillion will need to be updated.