### PR TITLE
winPB:  Fix typo in Dragonwell Download url and rename bootstrap image

### DIFF
--- a/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/main.yml
@@ -74,3 +74,4 @@
     - IcedTea-Web                 # For Jenkins webstart
     - WiX                         # For creating installers
     - shortNames
+    - Dragonwell                  # Dragonwell bootstrap image

--- a/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/roles/Dragonwell/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/roles/Dragonwell/tasks/main.yml
@@ -19,8 +19,6 @@
     url: https://github.com/alibaba/dragonwell8/releases/download/dragonwell-8.5.4_jdk8u272-ga/Alibaba_Dragonwell_8.5.4-GA_Experimental_Windows_x64.zip
     checksum: 0f04bee12ce1acd70d603759e1c57d8381c08669bdeed743474ce9ecfae51fb3
     checksum_algorithm: sha256
-    checksum: 0f04bee12ce1acd70d603759e1c57d8381c08669bdeed743474ce9ecfae51fb3
-    checksum_algorithm: sha256
     dest: 'C:\temp\dragonwell.zip'
   when: (not dragonwell_download.stat.exists)
         and (not dragonwell_installed.stat.exists)

--- a/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/roles/Dragonwell/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/roles/Dragonwell/tasks/main.yml
@@ -19,6 +19,8 @@
     url: https://github.com/alibaba/dragonwell8/releases/download/dragonwell-8.5.4_jdk8u272-ga/Alibaba_Dragonwell_8.5.4-GA_Experimental_Windows_x64.zip
     checksum: 0f04bee12ce1acd70d603759e1c57d8381c08669bdeed743474ce9ecfae51fb3
     checksum_algorithm: sha256
+    checksum: 0f04bee12ce1acd70d603759e1c57d8381c08669bdeed743474ce9ecfae51fb3
+    checksum_algorithm: sha256
     dest: 'C:\temp\dragonwell.zip'
   when: (not dragonwell_download.stat.exists)
         and (not dragonwell_installed.stat.exists)

--- a/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/roles/Dragonwell/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/roles/Dragonwell/tasks/main.yml
@@ -4,7 +4,7 @@
 ###################################################
 - name: Test if Dragonwell is already installed
   win_stat:
-    path: 'C:\openjdk\dragonwell-jdk8u272-ga'
+    path: 'C:\openjdk\dragonwell-bootstrap\jdk8u272-ga'
   register: dragonwell_installed
   tags: dragonwell
 
@@ -16,7 +16,9 @@
 
 - name: Download Dragonwell
   win_get_url:
-    url: 'https://github.com/alibaba/dragonwell8/releases/download/ragonwell-8.5.4_jdk8u272-ga/Alibaba_Dragonwell_8.5.4-GA_Experimental_Windows_x64.zip'
+    url: https://github.com/alibaba/dragonwell8/releases/download/dragonwell-8.5.4_jdk8u272-ga/Alibaba_Dragonwell_8.5.4-GA_Experimental_Windows_x64.zip
+    checksum: 0f04bee12ce1acd70d603759e1c57d8381c08669bdeed743474ce9ecfae51fb3
+    checksum_algorithm: sha256
     dest: 'C:\temp\dragonwell.zip'
   when: (not dragonwell_download.stat.exists)
         and (not dragonwell_installed.stat.exists)
@@ -25,7 +27,7 @@
 - name: Install Dragonwell
   win_unzip:
     src: C:\temp\dragonwell.zip
-    dest: C:\openjdk\dragonwell-jdk8u272-ga
+    dest: C:\openjdk\dragonwell-bootstrap
   when: (not dragonwell_installed.stat.exists)
   tags: dragonwell
 


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.
-->

Fix typo in Dragonwell download URL, and rename jdk8u272-ga to dragonwell-bootstrap-j2sdk-image

##### Checklist
<!-- Remove items that are not applicable. For completed items, change [ ] to [x]. -->

- [x] commit message has one of the [standard prefixes](https://github.com/AdoptOpenJDK/openjdk-infrastructure/blob/master/FAQ.md#commit-messages)
- [ ] FAQ.md updated if appropriate
- [ ] other documentation is changed or added (if applicable)
- [ ] playbook changes run through [VPC](https://ci.adoptopenjdk.net/view/Tooling/job/VagrantPlaybookCheck/) or [QPC](https://ci.adoptopenjdk.net/view/Tooling/job/QEMUPlaybookCheck/) (if you have access)
- [ ] inventory changes, ensure bastillion is updated accordingly
