### PR TITLE
pbTests: switch mirrorlist to vault on centOS6 yum repo

### DIFF
--- a/ansible/Vagrantfile.CentOS6
+++ b/ansible/Vagrantfile.CentOS6
@@ -2,6 +2,7 @@
 # vi: set ft=ruby :
 
 $script = <<SCRIPT
+sudo perl -p -i -e 's/mirrorlist.centos.org/vault.centos.org/g' /etc/yum.repos.d/Cent*
 sudo yum -y update
 sudo yum install -y libselinux-python
 sudo yum install -y ansible


### PR DESCRIPTION
This should fix the yum problem on CentOS6 in VPC ...

Draft while
- I verify that it works ok
- I decide whether this is the right place to do it instead of the playbooks (it probably isn't)

##### Checklist

<!-- Remove items that are not applicable. For completed items, change [ ] to [x]. -->

- [x] commit message has one of the [standard prefixes](https://github.com/AdoptOpenJDK/openjdk-infrastructure/blob/master/FAQ.md#commit-messages)
- [ ] FAQ.md updated if appropriate
- [ ] other documentation is changed or added (if applicable)
- [x] playbook changes run through [VPC](https://ci.adoptopenjdk.net/view/Tooling/job/VagrantPlaybookCheck/) or [QPC](https://ci.adoptopenjdk.net/view/Tooling/job/QEMUPlaybookCheck/) (if you have access) - https://ci.adoptopenjdk.net/view/Tooling/job/VagrantPlaybookCheck/964/
- [ ] inventory changes, ensure bastillion is updated accordingly
