### PR TITLE
UnixPB: Enable PowerTools repo CentOS8, install libdwarf-devel

### DIFF
--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/tasks/CentOS.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/tasks/CentOS.yml
@@ -23,9 +23,9 @@
     - ansible_distribution_major_version == "8"
   tags: patch_update
 
-- name: Enable CentOS-Powershell repo for CentOS8
+- name: Enable CentOS-PowerTools repo for CentOS8
   replace:
-    path: /etc/yum.repos.d/CentOS-PowerTools.repo
+    path: /etc/yum.repos.d/CentOS-Linux-PowerTools.repo
     regexp: 'enabled=0'
     replace: "enabled=1"
   ignore_errors: yes

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/vars/CentOS.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/vars/CentOS.yml
@@ -26,6 +26,7 @@ Build_Tool_Packages:
   - gmp-devel
   - java-1.8.0-openjdk-devel
   - libcurl-devel
+  - libdwarf-devel                # OpenJ9
   - libpng-devel
   - libXext-devel
   - libXi-devel                   # JDK12+ compilation
@@ -66,7 +67,6 @@ Additional_Build_Tools_CentOS8:
   - glibc-langpack-zh             # required for creating Chinese locales
 
 Additional_Build_Tools_NOT_CentOS8:
-  - libdwarf-devel                # OpenJ9.  Now in PowerTools repo.
   - lbzip2
   - java-1.7.0-openjdk-devel
   - ntp


### PR DESCRIPTION
Ref: #1750 

We had the task to enable the PowerTools repo in there, it just had the incorrect path. `libdwarf-devel` resides in the PowerTools repo now, hence the need to enable it, otherwise we can't build OpenJ9.

Note: `libmpc-devel` can also be installed from the PowerTools repo, but looking at #1743 , we never had it in the CentOS build package list? Either way, If we need it, should be easy enough to just add it to the package list :-)

##### Checklist
<!-- Remove items that are not applicable. For completed items, change [ ] to [x]. -->

- [x] commit message has one of the [standard prefixes](https://github.com/AdoptOpenJDK/openjdk-infrastructure/blob/master/FAQ.md#commit-messages)
- [x] playbook changes run through [VPC](https://ci.adoptopenjdk.net/view/Tooling/job/VagrantPlaybookCheck/) or [QPC](https://ci.adoptopenjdk.net/view/Tooling/job/QEMUPlaybookCheck/) . See : https://ci.adoptopenjdk.net/job/VagrantPlaybookCheck/968/



