### PR TITLE
vagrant: Fix CentOS6 mirrorlink issue

### DIFF
--- a/ansible/Dockerfile.CentOS6
+++ b/ansible/Dockerfile.CentOS6
@@ -3,7 +3,9 @@ FROM centos:6.9
 ARG user=jenkins
 
 # Install Python 3
-RUN yum -y update; yum clean all; \
+RUN sed -i -e 's!mirrorlist!#mirrorlist!g' /etc/yum.repos.d/CentOS-Base.repo; \
+    sed -i -e 's!#baseurl=http://mirror.centos.org/centos/\$releasever!baseurl=https://vault.centos.org/6.10/!g' /etc/yum.repos.d/CentOS-Base.repo; \
+    yum -y update; yum clean all; \
     yum -y install gcc openssl-devel bzip2-devel sqlite-devel sudo wget; \
     cd /usr/src; \
     wget -q https://www.python.org/ftp/python/3.6.10/Python-3.6.10.tgz; \

--- a/ansible/Vagrantfile.CentOS6
+++ b/ansible/Vagrantfile.CentOS6
@@ -2,6 +2,8 @@
 # vi: set ft=ruby :
 
 $script = <<SCRIPT
+sudo sed -i -e 's!mirrorlist!#mirrorlist!g' /etc/yum.repos.d/CentOS-Base.repo
+sudo sed -i -e 's!#baseurl=http://mirror.centos.org/centos/\$releasever!baseurl=https://vault.centos.org/6.10/!g' /etc/yum.repos.d/CentOS-Base.repo
 sudo yum -y update
 sudo yum install -y libselinux-python
 sudo yum install -y ansible


### PR DESCRIPTION
ref: #1745 , #1756 

Fixes the issue that the repos for CentOS6 are outdated due to C6 coming to the end of it's lifespan November 2020. This PR just enables the baseURL, and changes it to CentOS's `vault` URL. 

As mentioned in #1756  , this may not be the best place for this fix. It is affecting the CentOS6 Docker containers too (#1745)- however the Vagrantfiles certainly do need it, as it can't install `libselinux-python` without it. 

##### Checklist
<!-- Remove items that are not applicable. For completed items, change [ ] to [x]. -->

- [x] commit message has one of the [standard prefixes](https://github.com/AdoptOpenJDK/openjdk-infrastructure/blob/master/FAQ.md#commit-messages)
- [ ] playbook changes run through [VPC](https://ci.adoptopenjdk.net/view/Tooling/job/VagrantPlaybookCheck/) or [QPC](https://ci.adoptopenjdk.net/view/Tooling/job/QEMUPlaybookCheck/) . 
^ I'd love to, but unfortunately, there's an issue with the machine that runs it, currently. I've tested this locally though and it does work. 
