### PR TITLE
winPB: Add README.md instructions on how to setup a Windows Machine

### DIFF
--- a/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/README.md
+++ b/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/README.md
@@ -8,12 +8,12 @@ There's a process to setting up Windows machines and getting them connected to J
 
 3) Login to the Jenkins user on the machine via RDP.
 
-4) On the machine, login to ci.adoptopenjdk.net, create a new Node and download/run the `slave-agent.jnlp`.
+4) On the machine, in a web browser, login to [ci.adoptopenjdk.net](https://ci.adoptopenjdk.net/), create a new node and download/run the `slave-agent.jnlp`.
 
-5) Install the Jenkins agent as a service. This will require the Administrator credentials.
+5) Install the Jenkins agent as a service, by clicking 'File > Install as a Service'. This will require the Administrator credentials.
 
 6) Ensure the Jenkins Agent starts as the Jenkins user, under the 'Properties/Log On` tab of the 'Jenkins agent' service.
 
 7) If done correctly, under the `C:\Users\jenkins\` directory, there will be a series of `jenkins-slave.*` files, as well as the default Windows home folders, such as 'Desktop','Contacts' and 'Documents' etc.
 
-8) Ensure you have signed off from ci.adoptopenjdk.net
+8) Ensure you have signed out of ci.adoptopenjdk.net

--- a/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/README.md
+++ b/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/README.md
@@ -1,0 +1,19 @@
+# Setting up Windows Machines
+
+There's a process to setting up Windows machines and getting them connected to Jenkins. If not followed, issues can occur with Jenkins workspaces (See: https://github.com/AdoptOpenJDK/openjdk-infrastructure/issues/1674).
+
+1) Log on to the Windows machine via RDP and run the `ConfigureRemotingForAnsible` commands listed in [main.yml](https://github.com/AdoptOpenJDK/openjdk-infrastructure/blob/master/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/main.yml).
+
+2) Run the playbook on the machine, without skipping the 'adoptopenjdk' and 'jenkins' tags. (See [this](https://github.com/AdoptOpenJDK/openjdk-infrastructure/blob/master/ansible/README.md) for more information).
+
+3) Login to the Jenkins user on the machine via RDP.
+
+4) On the machine, login to ci.adoptopenjdk.net, create a new Node and download/run the `slave-agent.jnlp`.
+
+5) Install the Jenkins agent as a service. This will require the Administrator credentials.
+
+6) Ensure the Jenkins Agent starts as the Jenkins user, under the 'Properties/Log On` tab of the 'Jenkins agent' service.
+
+7) If done correctly, under the `C:\Users\jenkins\` directory, there will be a series of `jenkins-slave.*` files, as well as the default Windows home folders, such as 'Desktop','Contacts' and 'Documents' etc.
+
+8) Ensure you have signed off from ci.adoptopenjdk.net


### PR DESCRIPTION
Fixes: #1674 

The process in which we setup Windows machines (and connect them to Jenkins) isn't properly documented, as far as I know. Due to this, there was a bit of a difference in how @sxa and I did it, resulting in the folder problem that is spoken about in the referenced issue. As far as I tested, there wasn't any way around this, except logging into the Jenkins User before setting up the agent. In @sxa 's method of setting up Windows machines, the folder doesn't occur, so I've documented this process on how to setup the machines.
  This will also make it easier for any newcomers to Infra :-) 

##### Checklist

- [x] commit message has one of the [standard prefixes](https://github.com/AdoptOpenJDK/openjdk-infrastructure/blob/master/FAQ.md#commit-messages)
- [x] other documentation is changed or added (if applicable)

