### PR TITLE
github: remove CentOS6 PR check

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,11 +1,11 @@
 name: Docker
 
 on:
-  pull_request:
-    paths:
-    - ansible/**
-    branches:         
-    - master
+#  pull_request:
+#    paths:
+#    - ansible/**
+#    branches:         
+#    - master
   push:
     paths:
     - ansible/**


### PR DESCRIPTION
To avoid confusion and not put off potential contributors we should remove this check for now until https://github.com/AdoptOpenJDK/openjdk-infrastructure/issues/1745 is resolved.

Signed-off-by: Stewart X Addison <sxa@redhat.com>

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.
-->

##### Checklist
<!-- Remove items that are not applicable. For completed items, change [ ] to [x]. -->

- [x] commit message has one of the [standard prefixes](https://github.com/AdoptOpenJDK/openjdk-infrastructure/blob/master/FAQ.md#commit-messages)
- [ ] FAQ.md updated if appropriate
- [ ] other documentation is changed or added (if applicable)
- [ ] playbook changes run through [VPC](https://ci.adoptopenjdk.net/view/Tooling/job/VagrantPlaybookCheck/) or [QPC](https://ci.adoptopenjdk.net/view/Tooling/job/QEMUPlaybookCheck/) (if you have access)
- [ ] inventory changes, ensure bastillion is updated accordingly
