### PR TITLE
unixPB: Fix CentOS6 SCL repo baseurl

### DIFF
--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/tasks/CentOS.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/tasks/CentOS.yml
@@ -104,6 +104,14 @@
     - ansible_distribution_major_version != "8"
   tags: build_tools
 
+- name: Sed change the baseurl for CentOS SCL (CentOS6)
+  shell: |
+    sed -i -e 's!mirrorlist!#mirrorlist!g' /etc/yum.repos.d/CentOS-SCLo-scl*.repo
+    sed -i -e 's!^#.*baseurl=http://mirror.centos.org/centos/6/!baseurl=https://vault.centos.org/6.10/!g' /etc/yum.repos.d/CentOS-SCLo-scl*.repo
+  when:
+    - ansible_architecture == "x86_64" and ansible_distribution_major_version == "6"
+  tags: build_tools
+
 - name: Install additional build tools for CentOS on x86
   package: "name={{ item }} state=latest"
   with_items: "{{ Additional_Build_Tools_CentOS_x86 }}"


### PR DESCRIPTION
Fixes: #1745  (hopefully)
Ref: #1778 , #1765 

Changes the baseurl of the CentOS-SCL and CentOS-SCL-rh repo. I've used `win_shell` and `sed`, as opposed to `replace` / `lineinfile`, primarily because I couldn't get those modules' regex to work. The linter may not like that ...

- [x] commit message has one of the [standard prefixes](https://github.com/AdoptOpenJDK/openjdk-infrastructure/blob/master/FAQ.md#commit-messages)
- [x] playbook changes run through [VPC](https://ci.adoptopenjdk.net/view/Tooling/job/VagrantPlaybookCheck/) or [QPC](https://ci.adoptopenjdk.net/view/Tooling/job/QEMUPlaybookCheck/) Yep! :https://ci.adoptopenjdk.net/job/VagrantPlaybookCheck/977/

Note, the above check may uncovered other issues with CentOS6, but it does fix the SCL repo issue.

