### PR TITLE
inventory: add new awx and bastillion servers

### DIFF
--- a/ansible/inventory.yml
+++ b/ansible/inventory.yml
@@ -19,11 +19,15 @@ hosts:
       - packet:
           ubuntu1604-x64-1: {ip: 147.75.80.219, description: ansible.adoptopenjdk.net}
 
+      - packet:
+          ubuntu2004-x64-1: {ip: 147.75.80.235, description: awx.adoptopenjdk.net}
+
       - ibmcloud:
           vagrant-x64-1: {ip: 150.239.60.120, description: Bare metal machine to run vagrantPlaybookCheck and qemuPlaybookCheck}
 
       - godaddy:
           ubuntu1604-x64-1: {ip: 160.153.247.225, description: git-hg/load relief for jenkins master}
+          ubuntu1604-x64-2: {ip: 160.153.244.137, desciption: bastillion.adoptopenjdk.net}
 
   - build:
 


### PR DESCRIPTION
Signed-off-by: Stewart X Addison <sxa@redhat.com>

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.
-->

##### Checklist
<!-- Remove items that are not applicable. For completed items, change [ ] to [x]. -->

- [x] commit message has one of the [standard prefixes](https://github.com/AdoptOpenJDK/openjdk-infrastructure/blob/master/FAQ.md#commit-messages)
- [ ] FAQ.md updated if appropriate
- [x] other documentation is changed or added (if applicable)
- [ ] playbook changes run through [VPC](https://ci.adoptopenjdk.net/view/Tooling/job/VagrantPlaybookCheck/) or [QPC](https://ci.adoptopenjdk.net/view/Tooling/job/QEMUPlaybookCheck/) (if you have access)
- [ ] inventory changes, ensure bastillion is updated accordingly

ACLs on infra machines TBC therefore not yet added into bastillion

Leaving the original ansible server in here for now as it is still available, although no longer being used