### PR TITLE
unixPB: Adjust Cent6 repo editing to not change hostname

### DIFF
--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/tasks/CentOS.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/tasks/CentOS.yml
@@ -106,7 +106,7 @@
 
 - name: Sed change the baseurl for CentOS SCL (CentOS6)
   shell: |
-    sed -i -e 's!mirrorlist!#mirrorlist!g' /etc/yum.repos.d/CentOS-SCLo-scl*.repo
+    sed -i -e 's!^mirrorlist!#mirrorlist!g' /etc/yum.repos.d/CentOS-SCLo-scl*.repo
     sed -i -e 's!^#.*baseurl=http://mirror.centos.org/centos/6/!baseurl=https://vault.centos.org/6.10/!g' /etc/yum.repos.d/CentOS-SCLo-scl*.repo
   when:
     - ansible_architecture == "x86_64" and ansible_distribution_major_version == "6"


### PR DESCRIPTION
Fix to https://github.com/AdoptOpenJDK/openjdk-infrastructure/pull/1780 which was changing the URL from `http://mirrorlist` to http://#mirrorlist` - doesn't cause a problem as the line is being commented out, but would make it harder to back it out :-)

Signed-off-by: Stewart X Addison <sxa@redhat.com>

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.
-->

##### Checklist
<!-- Remove items that are not applicable. For completed items, change [ ] to [x]. -->

- [x] commit message has one of the [standard prefixes](https://github.com/AdoptOpenJDK/openjdk-infrastructure/blob/master/FAQ.md#commit-messages)
- [ ] FAQ.md updated if appropriate
- [ ] other documentation is changed or added (if applicable)
- [x] playbook changes run through [VPC](https://ci.adoptopenjdk.net/view/Tooling/job/VagrantPlaybookCheck/) or [QPC](https://ci.adoptopenjdk.net/view/Tooling/job/QEMUPlaybookCheck/) (if you have access) https://ci.adoptopenjdk.net/view/Tooling/job/VagrantPlaybookCheck/979/
- [ ] inventory changes, ensure bastillion is updated accordingly
