### PR TITLE
inventory: Move bastillion server to digitalocean

### DIFF
--- a/ansible/inventory.yml
+++ b/ansible/inventory.yml
@@ -14,12 +14,10 @@ hosts:
           ubuntu1604-x64-1: {ip: 54.78.186.5, user: ubuntu, description: trss.adoptopenjdk.net}
 
       - digitalocean:
-          ubuntu1604-x64-1: {ip: 138.68.167.199, description: api.adoptopenjdk.net}
+          ubuntu2004-x64-1: {ip: 178.62.115.224, description: bastillion.adoptopenjdk.net}
 
       - packet:
           ubuntu1604-x64-1: {ip: 147.75.80.219, description: ansible.adoptopenjdk.net}
-
-      - packet:
           ubuntu2004-x64-1: {ip: 147.75.80.235, description: awx.adoptopenjdk.net}
 
       - ibmcloud:
@@ -40,7 +38,6 @@ hosts:
           win2012r2-x64-2: {ip: 51.132.22.249, user: adoptopenjdk}
 
       - digitalocean:
-          centos69-x64-1: {ip: 159.65.95.239}
           centos69-x64-2: {ip: 167.71.130.191}
 
       - packet_esxi:


### PR DESCRIPTION
Various inventory fixes (the important one being the bastillion change)

- Removes api.adoptopenjdk.net as that is no longer hosted at digitalocean
- Removes dogitial ocean build machine 1 as it is no longer in use (keeping -2 for now as backup)
- **Adding bastillion.adoptopenjdk.net on its new dogitalocean home**
- Merges the two `packet` stanzas in the `infra` section

Note: The existing bastillion machine has not yet been removed from it's current home as it used for another purpose besides bastillion

Signed-off-by: Stewart X Addison <sxa@redhat.com>

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.
-->

##### Checklist
<!-- Remove items that are not applicable. For completed items, change [ ] to [x]. -->

- [ ] commit message has one of the [standard prefixes](https://github.com/AdoptOpenJDK/openjdk-infrastructure/blob/master/FAQ.md#commit-messages)
- [ ] FAQ.md updated if appropriate
- [ ] other documentation is changed or added (if applicable)
- [ ] playbook changes run through [VPC](https://ci.adoptopenjdk.net/view/Tooling/job/VagrantPlaybookCheck/) or [QPC](https://ci.adoptopenjdk.net/view/Tooling/job/QEMUPlaybookCheck/) (if you have access)
- [ ] inventory changes, ensure bastillion is updated accordingly
