### PR TITLE
inventory: add description to packet aarch64 systems

### DIFF
--- a/ansible/inventory.yml
+++ b/ansible/inventory.yml
@@ -74,8 +74,8 @@ hosts:
           centos74-ppc64le-2: {ip: 140.211.168.117}
 
       - packet:
-          centos74-armv8-1: {ip: 147.75.196.30}
-          ubuntu1804-armv8-1: {ip: 139.178.82.234}
+          centos74-armv8-1: {ip: 147.75.196.30, description: ThunderX}
+          ubuntu1804-armv8-1: {ip: 139.178.82.234, description: D05}
 
       - scaleway:
           ubuntu1604-armv7-1: {ip: 212.47.233.28}
@@ -102,7 +102,7 @@ hosts:
           ubuntu1603-s390x-1: {ip: 148.100.113.58, user: ubuntu}
 
       - packet:
-          ubuntu1604-armv8-1: {ip: 147.75.77.146}
+          ubuntu1604-armv8-1: {ip: 147.75.77.146, description: D05}
 
       - scaleway:
           ubuntu1604-armv7-1: {ip: 51.158.73.136}
@@ -167,8 +167,8 @@ hosts:
           ubuntu1804-ppc64le-2: {ip: 140.211.168.8, user: ubuntu}
 
       - packet:
-          ubuntu1604-armv8-1: {ip: 147.75.74.50}
-          ubuntu1604-armv8-2: {ip: 147.75.193.234}
+          ubuntu1604-armv8-1: {ip: 147.75.74.50, description: ThunderX}
+          ubuntu1604-armv8-2: {ip: 147.75.193.234, description: ThunderX}
           ubuntu1604-x64-1: {ip: 147.75.204.239}
           ubuntu1604-x64-2: {ip: 147.75.100.127}
           ubuntu1604-x64-3: {ip: 147.75.83.133}


### PR DESCRIPTION
We have a couple of differnt types of Linux/aarch64 systems from packet - this PR adds the system type as a description to the inventory file to differentiate them.

Signed-off-by: Stewart X Addison <sxa@redhat.com>

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.
-->

##### Checklist
<!-- Remove items that are not applicable. For completed items, change [ ] to [x]. -->

- [x] commit message has one of the [standard prefixes](https://github.com/AdoptOpenJDK/openjdk-infrastructure/blob/master/FAQ.md#commit-messages)
- [ ] FAQ.md updated if appropriate
- [ ] other documentation is changed or added (if applicable)
- [ ] playbook changes run through [VPC](https://ci.adoptopenjdk.net/view/Tooling/job/VagrantPlaybookCheck/) or [QPC](https://ci.adoptopenjdk.net/view/Tooling/job/QEMUPlaybookCheck/) (if you have access)
- [ ] inventory changes, ensure bastillion is updated accordingly
