### PR TITLE
inv: Correct Docker marist s390x node name

### DIFF
--- a/ansible/inventory.yml
+++ b/ansible/inventory.yml
@@ -96,7 +96,7 @@ hosts:
           ubuntu1604-x64-1: {ip: 160.153.235.114, user: adoptopenjdk}
 
       - marist:
-          ubuntu1603-s390x-1: {ip: 148.100.113.58, user: ubuntu}
+          ubuntu1604-s390x-1: {ip: 148.100.113.58, user: ubuntu}
 
       - packet:
           ubuntu1604-armv8-1: {ip: 147.75.77.146, description: D05}


### PR DESCRIPTION
ref: https://github.com/AdoptOpenJDK/openjdk-infrastructure/issues/1716#issuecomment-755202080

- [x] inventory changes, ensure bastillion is updated accordingly

Just some mistakes I noticed whilst going through the list of machines that need to be added to Nagios. As these are inconsistent with the node names in Jenkins, my Nagios check (#1717) is unable to find them. I opted for changing the inventory entry as this is easier than renaming the node in Jenkins :-) 