### PR TITLE
unixPB enable core dumps on macOS

### DIFF
--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/tasks/MacOSX.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/tasks/MacOSX.yml
@@ -164,6 +164,7 @@
   file:
     path: /cores
     state: directory
+    mode: 0774
     owner: root
     group: staff
   tags:

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/tasks/MacOSX.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/tasks/MacOSX.yml
@@ -154,12 +154,6 @@
   tags:
     - kernel_tuning
 
-# As per https://github.com/AdoptOpenJDK/openjdk-infrastructure/issues/1282
-- name: Enable Core dumps
-  command: ulimit -c unlimited
-  tags:
-    - core_dumps
-
 - name: Allow staff users to generate core dumps
   file:
     path: /cores

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/tasks/MacOSX.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/tasks/MacOSX.yml
@@ -154,6 +154,21 @@
   tags:
     - kernel_tuning
 
+# As per https://github.com/AdoptOpenJDK/openjdk-infrastructure/issues/1282
+- name: Enable Core dumps
+  command: ulimit -c unlimited
+  tags:
+    - core_dumps
+
+- name: Allow staff users to generate core dumps
+  file:
+    path: /cores
+    state: directory
+    owner: root
+    group: staff
+  tags:
+    - core_dumps
+
 # Skipping linting as not to introduce handlers into task-only playbooks (lint error 503)
 - name: Reboot macOS after tweaking kernel tuning parameters
   reboot:


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.
-->

##### Checklist
<!-- Remove items that are not applicable. For completed items, change [ ] to [x]. -->

- [x] commit message has one of the [standard prefixes](https://github.com/AdoptOpenJDK/openjdk-infrastructure/blob/master/FAQ.md#commit-messages)
- [ ] FAQ.md updated if appropriate
- [ ] other documentation is changed or added (if applicable)
- [ ] playbook changes run through [VPC](https://ci.adoptopenjdk.net/view/Tooling/job/VagrantPlaybookCheck/) or [QPC](https://ci.adoptopenjdk.net/view/Tooling/job/QEMUPlaybookCheck/) (if you have access)
- [ ] inventory changes, ensure bastillion is updated accordingly

fixes: https://github.com/AdoptOpenJDK/openjdk-infrastructure/issues/1282

Grinder before change: https://ci.adoptopenjdk.net/job/Grinder/5835/tapResults/
Grinder after change: https://ci.adoptopenjdk.net/job/Grinder/5837/tapResults/