### PR TITLE
unixPB: Update playbook for SLES12SP5

### DIFF
--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/tasks/SLES.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/tasks/SLES.yml
@@ -9,7 +9,7 @@
 - name: Add Devel-Tools repository (SLES12, x86_64/ppc64le)
   zypper_repository:
     name: devel-tools
-    repo: 'https://download.opensuse.org/repositories/devel:/tools/SLE_12_SP4/'
+    repo: 'https://download.opensuse.org/repositories/devel:/tools/SLE_12_SP5/'
     auto_import_keys: yes
     state: present
   when:

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/vars/SLES.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/vars/SLES.yml
@@ -18,7 +18,6 @@ Build_Tool_Packages:
   - libelf1
   - make
   - pkg-config
-  - systemtap-sdt-devel
   - unzip
   - wget
   - zip
@@ -39,6 +38,7 @@ Additional_Build_Tools_SLES15:
   - libXrender-devel
   - libXt-devel
   - libXtst-devel
+  - systemtap-sdt-devel
 
 Additional_Build_Tools_SLES12:
   - java-1_8_0-openjdk


### PR DESCRIPTION
Updated repo to `SLE_12_SP5`, and moved `systemtap-sdt-devel` from `Build_Tool_Packages` package list to `Additional_Build_Tools_SLES15 `.

This fixes issue #1820

Signed-off-by: Sej <sarah_jackson@uk.ibm.com>

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.
-->

##### Checklist
<!-- Remove items that are not applicable. For completed items, change [ ] to [x]. -->

- [x] commit message has one of the [standard prefixes](https://github.com/AdoptOpenJDK/openjdk-infrastructure/blob/master/FAQ.md#commit-messages)
- [ ] FAQ.md updated if appropriate
- [ ] other documentation is changed or added (if applicable)
- [ ] playbook changes run through [VPC](https://ci.adoptopenjdk.net/view/Tooling/job/VagrantPlaybookCheck/) or [QPC](https://ci.adoptopenjdk.net/view/Tooling/job/QEMUPlaybookCheck/) (if you have access)
- [ ] inventory changes, ensure bastillion is updated accordingly
