### PR TITLE
docs: Add note about needing ITW to run Jenkins Agent

### DIFF
--- a/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/README.md
+++ b/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/README.md
@@ -8,7 +8,7 @@ There's a process to setting up Windows machines and getting them connected to J
 
 3) Login to the Jenkins user on the machine via RDP.
 
-4) On the machine, in a web browser, login to [ci.adoptopenjdk.net](https://ci.adoptopenjdk.net/), create a new node and download/run the `slave-agent.jnlp`. IcedTea-Web will need to be installed to run the `.jnlp` file.
+4) On the machine, in a web browser, login to [ci.adoptopenjdk.net](https://ci.adoptopenjdk.net/), create a new node and download/run the `slave-agent.jnlp`. [IcedTea-Web](https://adoptopenjdk.net/icedtea-web.html) (or another `javaws` implementation) will need to be installed to run the `.jnlp` file.
 
 5) Install the Jenkins agent as a service, by clicking 'File > Install as a Service'. This will require the Administrator credentials.
 

--- a/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/README.md
+++ b/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/README.md
@@ -8,7 +8,7 @@ There's a process to setting up Windows machines and getting them connected to J
 
 3) Login to the Jenkins user on the machine via RDP.
 
-4) On the machine, in a web browser, login to [ci.adoptopenjdk.net](https://ci.adoptopenjdk.net/), create a new node and download/run the `slave-agent.jnlp`.
+4) On the machine, in a web browser, login to [ci.adoptopenjdk.net](https://ci.adoptopenjdk.net/), create a new node and download/run the `slave-agent.jnlp`. IcedTea-Web will need to be installed to run the `.jnlp` file.
 
 5) Install the Jenkins agent as a service, by clicking 'File > Install as a Service'. This will require the Administrator credentials.
 


### PR DESCRIPTION
ref: #1773 , https://adoptopenjdk.slack.com/archives/C53GHCXL4/p1610356948467700, #1818 

- [x] commit message has one of the [standard prefixes](https://github.com/AdoptOpenJDK/openjdk-infrastructure/blob/master/FAQ.md#commit-messages)
- [x] other documentation is changed or added (if applicable)

Adding a note that IcedTea-Web is needed to run `.jnlp` files- It's tripped me up, and it has other people as well, so I feel it's necessary to mention.