### PR TITLE
unixPB: Ensure GPG is installed for Debian

### DIFF
--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/tasks/Debian.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/tasks/Debian.yml
@@ -16,10 +16,18 @@
     - ansible_distribution_major_version != "10"
   tags: patch_update
 
+# Required for the apt-key task next
+- name: Ensure gnupg is installed
+  apt:
+    name: gnupg
+    state: present
+  tags: patch_update
+
 - name: Add AdoptOpenJDK GPG key
   apt_key:
     url: https://adoptopenjdk.jfrog.io/adoptopenjdk/api/gpg/key/public
     state: present
+  tags: patch_update
 
 - name: Add the adoptopenjdk repository to apt for JDK8
   apt_repository: repo='deb https://adoptopenjdk.jfrog.io/adoptopenjdk/deb jessie main' update_cache=no


### PR DESCRIPTION
Fixes: #1828

We need to make sure `gnupg` is installed on the Debian machine before the `Add AdoptOpenJDK GPG key` task is run. I added this as a comment, too. Also, added the `tags: patch_update` to the aforementioned task, for consistency.

- [x] commit message has one of the [standard prefixes](https://github.com/AdoptOpenJDK/openjdk-infrastructure/blob/master/FAQ.md#commit-messages)
- [x] playbook changes run through [VPC](https://ci.adoptopenjdk.net/view/Tooling/job/VagrantPlaybookCheck/) or [QPC](https://ci.adoptopenjdk.net/view/Tooling/job/QEMUPlaybookCheck/) : https://ci.adoptopenjdk.net/job/VagrantPlaybookCheck/988/

