### PR TITLE
unixPB: Minor nagios_server_plugins fixes

### DIFF
--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Nagios_Plugins/tasks/additional_plugins/nagios_server_plugins/check_inventory
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Nagios_Plugins/tasks/additional_plugins/nagios_server_plugins/check_inventory
@@ -1,3 +1,5 @@
+#!/usr/bin/env bash
+
 # Copyright 2020 The Original Author(s)
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,12 +14,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-#!/usr/bin/env bash
-
 # Nagios Plugin to check that inventory.yml / Nagios / Jenkins are in sync
 # This check assumes:
 #  - The inventory is the definitive list we should be comparing to
 #  - This is run on locally on the Nagios Server
+
+set -euxo pipefail
 
 # List of machines that are ignored if they're not in Nagios
 exceptionsList="win sxa gdams will EC2 azurebuildagent aahlenst vagrant master infrastructure esxi aix"

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Nagios_Plugins/tasks/additional_plugins/nagios_server_plugins/check_nagios_sync
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Nagios_Plugins/tasks/additional_plugins/nagios_server_plugins/check_nagios_sync
@@ -1,3 +1,5 @@
+#!/usr/bin/env bash
+
 # Copyright 2020 The Original Author(s)
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,12 +14,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-#!/usr/bin/env bash
-
 # Nagios Plugin to check that machines don't need removing from Nagios
 # This check assumes:
 #  - This is run on locally on the Nagios Server
 #  - The Nagios Server has jq installed
+
+set -euxo pipefail
 
 exceptionList="ci ansible"
 
@@ -64,7 +66,7 @@ IFS=$'\n'$'\t'" "
 
 mkdir -p $HOME/check_inventory_logs
 logPath="$HOME/check_inventory_logs/check_nagios_sync_`date +%H%M_%d%m%Y`"
-rm -rf $logPath
+rm -rf "$HOME/check_inventory_logs/check_nagios_sync_*"
 
 nagiosList=$(ls -la /usr/local/nagios/etc/servers/ | awk '/.cfg/ { print $9 }' | cut -d. -f1)
 jenkinsList=$(curl -s https://ci.adoptopenjdk.net/computer/api/json | jq -r '.computer[] | .displayName')


### PR DESCRIPTION
ref: #1717 #1844 

Just some things I noticed whilst setting up the `check_nagios_sync` module on the Nagios Server. The interpreter definition needs to be at the top of the script, and the `rm -rf` command for the latest module wasn't removing the old logs.

- [x] commit message has one of the [standard prefixes](https://github.com/AdoptOpenJDK/openjdk-infrastructure/blob/master/FAQ.md#commit-messages)

