### PR TITLE
inventory: Update test-ibmcloud-ubuntu1604-x64-1 IP

### DIFF
--- a/ansible/inventory.yml
+++ b/ansible/inventory.yml
@@ -198,6 +198,6 @@ hosts:
       - ibmcloud:
           rhel6-x64-1: {ip: 169.48.4.140}
           rhel7-x64-1: {ip: 169.48.4.136}
-          ubuntu1604-x64-1: {ip: 169.55.150.155}
+          ubuntu1604-x64-1: {ip: 169.48.4.141}
           win2012r2-x64-1: {ip: 169.48.4.131, user: Administrator}
           win2012r2-x64-2: {ip: 169.48.4.139, user: Administrator}


### PR DESCRIPTION
ref: #1716 

Spotted by @sxa when I wasn't able to ssh to it, despite my key being on the machine.

- [x] commit message has one of the [standard prefixes](https://github.com/AdoptOpenJDK/openjdk-infrastructure/blob/master/FAQ.md#commit-messages)
- [x] inventory changes, ensure bastillion is updated accordingly
