### PR TITLE
vagrant: Force win2012r2 to use tls1.2 in provision script

### DIFF
--- a/ansible/Vagrantfile.Win2012
+++ b/ansible/Vagrantfile.Win2012
@@ -1,14 +1,22 @@
 # -*- mode: ruby -*-
 # vi: set ft=ruby :
 
-# Runs powershell as an administator and gets/executes an Ansible provided script that configures WinRM to allow Ansible to communicate over it. Then places a file in the shared folder of the VM that contains the IP address of the VM.
+# Runs Powershell as an administator and does the following:
+#  - Gets/executes an Ansible provided script that configures WinRM to allow Ansible to communicate over it.
+#  - Resizes the disk to ~100GB, in line with the 'disksize.size = 100GB' option in the config below
+
 $script = <<SCRIPT
 Start-Process powershell -Verb runAs
+
+# Windows 2012r2 needs to be forced to use TLS1.2, see: https://github.com/AdoptOpenJDK/openjdk-infrastructure/issues/1858
+[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
+
 wget https://raw.githubusercontent.com/ansible/ansible/devel/examples/scripts/ConfigureRemotingForAnsible.ps1 -OutFile .\\ConfigureRemotingForAnsible.ps1
 .\\ConfigureRemotingForAnsible.ps1 -CertValidityDays 9999
 .\\ConfigureRemotingForAnsible.ps1 -EnableCredSSP
 .\\ConfigureRemotingForAnsible.ps1 -ForceNewSSLCert
 .\\ConfigureRemotingForAnsible.ps1 -SkipNetworkProfileCheck
+
 # Retrieving disk's current size
 $currentDiskSize =(Get-Partition -DriveLetter c | select Size)
 $currentDiskSize =($currentDiskSize -replace "[^0-9]" , "")
@@ -21,6 +29,7 @@ if ([long]$currentDiskSize -lt $diskSizeBoundary) {
 }else {
         echo "Disk is already at max size"
 }
+
 Start-Process cmd -Verb runAs
 winrm set winrm/config/service '@{AllowUnencrypted="true"}'
 SCRIPT

--- a/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/README.md
+++ b/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/README.md
@@ -4,6 +4,8 @@ There's a process to setting up Windows machines and getting them connected to J
 
 1) Log on to the Windows machine via RDP and run the `ConfigureRemotingForAnsible` commands listed in [main.yml](https://github.com/AdoptOpenJDK/openjdk-infrastructure/blob/master/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/main.yml).
 
+Note: If setting up a win2012r2 machine, `[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12` needs to be executed to stop `Invoke-WebRequest` encountering a `Could not create SSL/TLS secure channel` error. See: https://github.com/AdoptOpenJDK/openjdk-infrastructure/issues/1858
+
 2) Run the playbook on the machine, without skipping the 'adoptopenjdk' and 'jenkins' tags. (See [this](https://github.com/AdoptOpenJDK/openjdk-infrastructure/blob/master/ansible/README.md) for more information).
 
 3) Login to the Jenkins user on the machine via RDP.

--- a/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/main.yml
@@ -11,6 +11,7 @@
 # *** This playbook assumes that the Windows client machine has been configure to allow Ansible to run on it (WINRM)***
 # Ensure you have opened Internet Explorer and completed the setup (other wise wget will not work)
 # Run powershell as the Administrator
+# If setting up a win2012r2 machine, run '[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12' See: https://github.com/AdoptOpenJDK/openjdk-infrastructure/issues/1858
 # wget https://raw.githubusercontent.com/ansible/ansible/devel/examples/scripts/ConfigureRemotingForAnsible.ps1 -OutFile .\ConfigureRemotingForAnsible.ps1
 # .\ConfigureRemotingForAnsible.ps1 -CertValidityDays 9999
 # .\ConfigureRemotingForAnsible.ps1 -EnableCredSSP


### PR DESCRIPTION
Fixes: #1858 

Also updates the comments to better reflect what's happening in the VF

##### Checklist
<!-- Remove items that are not applicable. For completed items, change [ ] to [x]. -->

- [x] commit message has one of the [standard prefixes](https://github.com/AdoptOpenJDK/openjdk-infrastructure/blob/master/FAQ.md#commit-messages)
- [x] other documentation is changed or added (if applicable)
- [x] playbook changes run through [VPC](https://ci.adoptopenjdk.net/view/Tooling/job/VagrantPlaybookCheck/) or [QPC](https://ci.adoptopenjdk.net/view/Tooling/job/QEMUPlaybookCheck/) (if you have access). In progress: https://ci.adoptopenjdk.net/job/VagrantPlaybookCheck/993/
