### PR TITLE
unix/winPB: Allow use of local Vendor_Files folder

### DIFF
--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/main.yml
@@ -21,7 +21,7 @@
   roles:
     - Debug
     - role: Get_Vendor_Files
-      tags: [vendor_files, adoptopenjdk]
+      tags: [vendor_files, adoptopenjdk, jenkins_user, nagios_plugins, superuser]
     - Version
     - Common
     - Providers                   # AdoptOpenJDK Infrastructure

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Get_Vendor_Files/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Get_Vendor_Files/tasks/main.yml
@@ -3,24 +3,54 @@
 # VENDOR_FILES
 ##############
 
-- name: check out AdoptOpenJDK/secrets
+- name: Check if local Vendor_Files exists
+  stat: path=/Vendor_Files
+  register: local_vendor_files
+  delegate_to: localhost
+  run_once: true
+
+- name: Check out AdoptOpenJDK/secrets
   git: repo=git@github.com:AdoptOpenJDK/secrets.git dest=vendor_files force=true
   delegate_to: localhost
+  when:
+    - not local_vendor_files.stat.exists
   run_once: true
 
-- name: check if dotgpg is installed
+- name: Check if dotgpg is installed
   shell: command -v dotgpg
   delegate_to: localhost
+  when:
+    - not local_vendor_files.stat.exists
   run_once: true
 
-- name: generate list of vendor_files
+- name: Generate list of remote vendor_files
   command: dotgpg cat {{ item }}
   delegate_to: localhost
-  register: vendor_files
+  register: remote_vendor_files_list
+  when:
+    - not local_vendor_files.stat.exists
   loop: "{{ lookup('fileglob', 'vendor_files/vendor_files/*', wantlist=True) }}"
   run_once: true
 
-- name: set facts from output of dotgpg
+- name: Generate list of local vendor_files
+  command: cat {{ item }}
+  delegate_to: localhost
+  register: local_vendor_files_list
+  when:
+    - local_vendor_files.stat.exists
+  loop: "{{ lookup('fileglob', '/Vendor_Files/*', wantlist=True) }}"
+  run_once: true
+
+- name: Set facts from output of dotgpg
   set_fact: {"{{ item.item | basename | replace('.gpg','') | replace('.','_') }}":"{{ item.stdout }}"}
-  with_items: "{{ vendor_files.results }}"
+  with_items: "{{ remote_vendor_files_list.results }}"
+  when:
+    - not local_vendor_files.stat.exists
+  run_once: true
+
+- name: Set facts from output of local vendor_files
+  set_fact: {"{{ item.item | basename | replace('.','_') }}":"{{ item.stdout }}"}
+  with_items: "{{ local_vendor_files_list.results }}"
+  when:
+    - local_vendor_files.stat.exists
   run_once: true

--- a/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/main.yml
@@ -35,7 +35,7 @@
   roles:
     - Debug
     - role: Get_Vendor_Files
-      tags: [vendor_files, adoptopenjdk]
+      tags: [vendor_files, adoptopenjdk, jenkins]
     - Version
     - Common
     - Windows_Updates

--- a/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/roles/Get_Vendor_Files/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/roles/Get_Vendor_Files/tasks/main.yml
@@ -3,24 +3,54 @@
 # VENDOR_FILES
 ##############
 
-- name: check out AdoptOpenJDK/secrets
+- name: Check if local Vendor_Files exists
+  stat: path=/Vendor_Files
+  register: local_vendor_files
+  delegate_to: localhost
+  run_once: true
+
+- name: Check out AdoptOpenJDK/secrets
   git: repo=git@github.com:AdoptOpenJDK/secrets.git dest=vendor_files force=true
   delegate_to: localhost
+  when:
+    - not local_vendor_files.stat.exists
   run_once: true
 
-- name: check if dotgpg is installed
+- name: Check if dotgpg is installed
   shell: command -v dotgpg
   delegate_to: localhost
+  when:
+    - not local_vendor_files.stat.exists
   run_once: true
 
-- name: generate list of vendor_files
+- name: Generate list of remote vendor_files
   command: dotgpg cat {{ item }}
   delegate_to: localhost
-  register: vendor_files
+  register: remote_vendor_files_list
+  when:
+    - not local_vendor_files.stat.exists
   loop: "{{ lookup('fileglob', 'vendor_files/vendor_files/*', wantlist=True) }}"
   run_once: true
 
-- name: set facts from output of dotgpg
+- name: Generate list of local vendor_files
+  command: cat {{ item }}
+  delegate_to: localhost
+  register: local_vendor_files_list
+  when:
+    - local_vendor_files.stat.exists
+  loop: "{{ lookup('fileglob', '/Vendor_Files/*', wantlist=True) }}"
+  run_once: true
+
+- name: Set facts from output of dotgpg
   set_fact: {"{{ item.item | basename | replace('.gpg','') | replace('.','_') }}":"{{ item.stdout }}"}
-  with_items: "{{ vendor_files.results }}"
+  with_items: "{{ remote_vendor_files_list.results }}"
+  when:
+    - not local_vendor_files.stat.exists
+  run_once: true
+
+- name: Set facts from output of local vendor_files
+  set_fact: {"{{ item.item | basename | replace('.','_') }}":"{{ item.stdout }}"}
+  with_items: "{{ local_vendor_files_list.results }}"
+  when:
+    - local_vendor_files.stat.exists
   run_once: true


### PR DESCRIPTION
Fixes: #1850 

In cases where `dotgpg` can't be used, or we need to automate running the playbooks, (such as AWX, see the referenced issue), currently, there's no way to run the `adoptopenjdk` tagged roles (or any roles requiring vendor file material). To fix this, I've adapted the `Get_Vendor_Files` role to allow  the use of the local vendor files, or retrieving them from the secrets repo in the case that the machine doesn't have local vendor files.

This assumes that the local vendor files:
1) Follow the same structure as the vendor_files in the secrets repo (i.e. https://github.com/AdoptOpenJDK/secrets/blob/master/vendor_files/Nagios_User_SSHKey.gpg --> /Vendor_Files/Nagios_User_SSHKey)
2) aren't gpg encrypted.

##### Checklist
<!-- Remove items that are not applicable. For completed items, change [ ] to [x]. -->

- [x] commit message has one of the [standard prefixes](https://github.com/AdoptOpenJDK/openjdk-infrastructure/blob/master/FAQ.md#commit-messages) (Sort of)
- [ ] FAQ.md updated if appropriate : N/A
- [ ] other documentation is changed or added (if applicable) 
- [ ] playbook changes run through [VPC](https://ci.adoptopenjdk.net/view/Tooling/job/VagrantPlaybookCheck/) or [QPC](https://ci.adoptopenjdk.net/view/Tooling/job/QEMUPlaybookCheck/) :  Not beneficial as the `adoptopenjdk` is skipped in `VPC`. 
- [ ] inventory changes, ensure bastillion is updated accordingly: N/A
