### PR TITLE
GHCheck: Fix Brew issues for macOS

### DIFF
--- a/.github/workflows/build_mac.yml
+++ b/.github/workflows/build_mac.yml
@@ -24,12 +24,11 @@ jobs:
 
     - name: Remove homebrew/cask-versions
       run: | 
-        brew untap homebrew/cask-versions
-        brew cask uninstall adoptopenjdk8
-        brew cask uninstall adoptopenjdk11
-        brew cask uninstall adoptopenjdk12
-        brew cask uninstall adoptopenjdk13
-        brew cask uninstall adoptopenjdk14
+        brew uninstall --cask adoptopenjdk8
+        brew uninstall --cask adoptopenjdk11
+        brew uninstall --cask adoptopenjdk12
+        brew uninstall --cask adoptopenjdk13
+        brew uninstall --cask adoptopenjdk14
 
     - name: Run Ansible Playbook
       run: |


### PR DESCRIPTION
ref: #1790 

Changes a few lines in `.github/workflows/build_mac.yml` file, so the GitHub Check can actually run.

##### Checklist
<!-- Remove items that are not applicable. For completed items, change [ ] to [x]. -->

- [x] commit message has one of the [standard prefixes](https://github.com/AdoptOpenJDK/openjdk-infrastructure/blob/master/FAQ.md#commit-messages) : Nope- there isn't one for GitHub Checks (ping @sxa)
- [x] FAQ.md updated if appropriate: N/A
- [x] other documentation is changed or added (if applicable): N/A
- [x] playbook changes run through [VPC](https://ci.adoptopenjdk.net/view/Tooling/job/VagrantPlaybookCheck/) or [QPC](https://ci.adoptopenjdk.net/view/Tooling/job/QEMUPlaybookCheck/) (if you have access) (Run through the GH Check)
- [x] inventory changes, ensure bastillion is updated accordingly: N/A
