### PR TITLE
Github: Fix Solaris check brew-cask error

### DIFF
--- a/.github/workflows/build_vagrant.yml
+++ b/.github/workflows/build_vagrant.yml
@@ -19,7 +19,7 @@ jobs:
     - name: Install dependencies
       run: |
         brew install ansible
-        brew cask install virtualbox vagrant
+        brew install --cask virtualbox vagrant
 
     - name: Setup Vagrant VM
       run: |

--- a/.github/workflows/build_vagrant.yml
+++ b/.github/workflows/build_vagrant.yml
@@ -3,7 +3,7 @@ name: Vagrant Playbook Checker
 on:
   pull_request:
     paths:
-    - .github/workflows/build_solaris.yml
+    - .github/workflows/build_vagrant.yml
     - ansible/**
     branches:         
     - master


### PR DESCRIPTION
Fixes: #1879 

The reason the check is failing due to `brew` when the check is regarding Solaris, is due to Solaris being run as a VM, on a macOS machine. The `brew cask install` command was failing when trying to install Virtualbox/Vagrant, as `brew cask install` has been swapped for `brew install --cask`.

Kept in draft until I can confirm this has fixed the issue.

- [x] commit message has one of the [standard prefixes](https://github.com/AdoptOpenJDK/openjdk-infrastructure/blob/master/FAQ.md#commit-messages) 
- [ ] [FAQ.md](https://github.com/AdoptOpenJDK/openjdk-infrastructure/blob/master/FAQ.md) updated if appropriate : N/A
- [ ] other documentation is changed or added (if applicable) : N/A
- [ ] playbook changes run through [VPC](https://ci.adoptopenjdk.net/view/Tooling/job/VagrantPlaybookCheck/) or [QPC](https://ci.adoptopenjdk.net/view/Tooling/job/QEMUPlaybookCheck/) (if you have access) : N/A
- [ ] for inventory.yml changes, bastillion/nagios/jenkins updated accordingly : N/A
