### PR TITLE
unixPB: Update U16/PPC64LE Cuda Repo URL

### DIFF
--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/NVidia_Cuda_Toolkit/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/NVidia_Cuda_Toolkit/tasks/main.yml
@@ -129,7 +129,7 @@
 
 - name: Download/install Nvidia CUDA Repo deb - Ubuntu 16 on PPC64LE
   apt:
-    deb: https://developer.download.nvidia.com/compute/cuda/repos/ubuntu1604/ppc64el/cuda-toolkit-9-0_9.0.176-1_ppc64el.deb
+    deb: https://developer.nvidia.com/compute/cuda/9.0/Prod/local_installers/cuda-repo-ubuntu1604-9-0-local_9.0.176-1_ppc64el-deb
   retries: 3
   delay: 5
   register: nvidia_cuda_toolkit_download


### PR DESCRIPTION
Fixes: #1889 

Updates the URL to install the base repo for CUDA. 

##### Checklist
<!-- For completed items, change [ ] to [x]. Leave unchecked if not required -->

- [x] commit message has one of the [standard prefixes](https://github.com/AdoptOpenJDK/openjdk-infrastructure/blob/master/FAQ.md#commit-messages)
- [ ] [FAQ.md](https://github.com/AdoptOpenJDK/openjdk-infrastructure/blob/master/FAQ.md) updated if appropriate
- [ ] other documentation is changed or added (if applicable) : N/A
- [ ] playbook changes run through [VPC](https://ci.adoptopenjdk.net/view/Tooling/job/VagrantPlaybookCheck/) or [QPC](https://ci.adoptopenjdk.net/view/Tooling/job/QEMUPlaybookCheck/) (if you have access): No U16 PPC64LE environment on VPC / QPC
- [ ] for inventory.yml changes, bastillion/nagios/jenkins updated accordingly: N/A
