### PR TITLE
aixPB: Add adoptopenjdk tags for Vendor_File roles

### DIFF
--- a/ansible/playbooks/AdoptOpenJDK_AIX_Playbook/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_AIX_Playbook/main.yml
@@ -54,8 +54,10 @@
     # tbd: Need other actions performed first - mainly adding /usr/bin/bash
     # to the list of legal shells.
     - rbac
-    - jenkins_user
-    - zeus_user
+    - role: jenkins_user
+      tags: adoptopenjdk
+    - role: zeus_user
+      tags: adoptopenjdk
 
     # 5. Additional Software: both licensed and OSS
 
@@ -164,7 +166,7 @@
     - name: Include Nagios Playbook
       include_tasks: nagios/nagios_aix.yml
       when: Nagios_Plugins == "Enabled"
-      tags: nagios
+      tags: [nagios, adoptopenjdk]
 
   ###################
   # NTP Time Server #


### PR DESCRIPTION
Fixes: #1888 
Ref: #1870 (Hopefully a future enhancement we can do on the AIX PB)

Adds the adoptopenjdk tags, so people without Vendor_Files can run the playbooks without it failing.
@aixtools , I could only find 3 roles that used the Vendor_Files, let me know if there's any I missed :-)

##### Checklist
<!-- For completed items, change [ ] to [x]. Leave unchecked if not required -->

- [x] commit message has one of the [standard prefixes](https://github.com/AdoptOpenJDK/openjdk-infrastructure/blob/master/FAQ.md#commit-messages)
- [ ] [FAQ.md](https://github.com/AdoptOpenJDK/openjdk-infrastructure/blob/master/FAQ.md) updated if appropriate : N/A
- [ ] other documentation is changed or added (if applicable) : N/A
- [ ] playbook changes run through [VPC](https://ci.adoptopenjdk.net/view/Tooling/job/VagrantPlaybookCheck/) or [QPC](https://ci.adoptopenjdk.net/view/Tooling/job/QEMUPlaybookCheck/) (if you have access) : No AIX platform
- [ ] for inventory.yml changes, bastillion/nagios/jenkins updated accordingly : N/A
