### PR TITLE
unixPB: Fix condition for numactl RHEL7/S390x

### DIFF
--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/tasks/RedHat.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/tasks/RedHat.yml
@@ -78,7 +78,7 @@
 - name: Install numactl-devel excluding RHEL 7 on s390x
   package: "name=numactl-devel state=latest"
   when:
-    - ! (ansible_distribution_major_version == "7" and ansible_architecture == "s390x")
+    - not (ansible_distribution_major_version == "7" and ansible_architecture == "s390x")
   tags: build_tools
 
 - name: Install additional build tools for RHEL on x86


### PR DESCRIPTION
Fixes: #1890 

`!` doesn't symbolize `not` in yaml, apparently. Testing on `build-maritst-rhel77-s390x-2`, the condition now skips as expected :-)

##### Checklist
<!-- For completed items, change [ ] to [x]. Leave unchecked if not required -->

- [x] commit message has one of the [standard prefixes](https://github.com/AdoptOpenJDK/openjdk-infrastructure/blob/master/FAQ.md#commit-messages)
- [ ] [FAQ.md](https://github.com/AdoptOpenJDK/openjdk-infrastructure/blob/master/FAQ.md) updated if appropriate : N/A
- [ ] other documentation is changed or added (if applicable) : N/A
- [ ] playbook changes run through [VPC](https://ci.adoptopenjdk.net/view/Tooling/job/VagrantPlaybookCheck/) or [QPC](https://ci.adoptopenjdk.net/view/Tooling/job/QEMUPlaybookCheck/) (if you have access) : No platform available
- [ ] for inventory.yml changes, bastillion/nagios/jenkins updated accordingly : N/A