### PR TITLE
unixPB: Update Nagios_Plugins install for macOSX

### DIFF
--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Nagios_Plugins/tasks/nagios_MacOSX.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Nagios_Plugins/tasks/nagios_MacOSX.yml
@@ -14,6 +14,8 @@
 ########################################
 - name: Install additional packages used by Nagios
   package: "name={{ item }} state=latest"
+  become: yes
+  become_user: "{{ ansible_user }}"
   with_items:
     - nagios-plugins
 
@@ -25,9 +27,20 @@
     owner: nagios
   become: yes
 
-- name: Symlink to plugins
+- name: Symlink to plugins (x86_64)
   file:
     src: /usr/local/Cellar/nagios-plugins/2.3.3/libexec/sbin
     dest: /usr/local/nagios/libexec
     state: link
   become: yes
+  when: ansible_architecture == "x86_64"
+
+# Arm64's Homebrew installation prefix is `/opt/homebrew/`, not `/usr/local/`
+# See: https://github.com/AdoptOpenJDK/openjdk-infrastructure/issues/1716#issuecomment-764713146
+- name: Symlink to plugins (arm64)
+  file:
+    src: /opt/homebrew/Cellar/nagios-plugins/2.3.3/sbin/
+    dest: /usr/local/nagios/libexec
+    state: link
+  become: yes
+  when: ansible_architecture == "arm64"


### PR DESCRIPTION
Ref: https://github.com/AdoptOpenJDK/openjdk-infrastructure/issues/1716#issuecomment-764713146

For some reason, `brew` doesn't like installing anything as the `administrator` user via ansible, without the `become: yes` and `become_user: "{{ ansible_user }}"` lines - I just copied what was done in the Common role for installing build/test tool packages.

I've also added an additional task for ARM64, to symlink to the plugins for ARM64. As ARM64 MacOSX requires homebrew to be installed in `/opt/homebrew/`, as opposed to `/usr/local/` for `x64` , the original symlink task doesn't work.

##### Checklist
<!-- For completed items, change [ ] to [x]. Leave unchecked if not required -->

- [x] commit message has one of the [standard prefixes](https://github.com/AdoptOpenJDK/openjdk-infrastructure/blob/master/FAQ.md#commit-messages)
- [ ] [FAQ.md](https://github.com/AdoptOpenJDK/openjdk-infrastructure/blob/master/FAQ.md) updated if appropriate : N/A
- [ ] other documentation is changed or added (if applicable) : N/A
- [ ] playbook changes run through [VPC](https://ci.adoptopenjdk.net/view/Tooling/job/VagrantPlaybookCheck/) or [QPC](https://ci.adoptopenjdk.net/view/Tooling/job/QEMUPlaybookCheck/) (if you have access) : They both skip `adoptopenjdk` tags, so wouldn't run the role
- [ ] for inventory.yml changes, bastillion/nagios/jenkins updated accordingly : N/A
