### PR TITLE
unixPB: Update Checksum for Docker CentOS/RHEL7 x64

### DIFF
--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Docker/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Docker/tasks/main.yml
@@ -121,7 +121,7 @@
     owner: root
     group: root
     mode: 0644
-    checksum: sha256:6650718e0fe5202ae7618521f695d43a8bc051c539d7570f0edbfa5b4916f218
+    checksum: sha256:8ab5599eef0afcac10cbd3e8670873efee20fcceb5fb3526a62edeade603cec7
   when:
     - docker_installed.rc != 0
     - (ansible_distribution == "RedHat" or ansible_distribution == "CentOS")


### PR DESCRIPTION
Ref: https://ci.adoptopenjdk.net/job/VagrantPlaybookCheck/1005/OS=CentOS6,label=vagrant/console

Docker repo checksum is wrong.

##### Checklist
<!-- For completed items, change [ ] to [x]. Leave unchecked if not required -->

- [x] commit message has one of the [standard prefixes](https://github.com/AdoptOpenJDK/openjdk-infrastructure/blob/master/FAQ.md#commit-messages)
- [ ] [FAQ.md](https://github.com/AdoptOpenJDK/openjdk-infrastructure/blob/master/FAQ.md) updated if appropriate
- [ ] other documentation is changed or added (if applicable)
- [x] playbook changes run through [VPC](https://ci.adoptopenjdk.net/view/Tooling/job/VagrantPlaybookCheck/) or [QPC](https://ci.adoptopenjdk.net/view/Tooling/job/QEMUPlaybookCheck/) (if you have access) : In progress: [VPC](https://ci.adoptopenjdk.net/job/VagrantPlaybookCheck/1008/)
- [ ] for inventory.yml changes, bastillion/nagios/jenkins updated accordingly
