### PR TITLE
unixPB: add adoptopenjdk tag to Get_Vendor_Files role

### DIFF
--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Get_Vendor_Files/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Get_Vendor_Files/tasks/main.yml
@@ -8,6 +8,7 @@
   register: local_vendor_files
   delegate_to: localhost
   run_once: true
+  tags: adoptopenjdk
 
 - name: Check out AdoptOpenJDK/secrets
   git: repo=git@github.com:AdoptOpenJDK/secrets.git dest=vendor_files force=true
@@ -15,6 +16,7 @@
   when:
     - not local_vendor_files.stat.exists
   run_once: true
+  tags: adoptopenjdk
 
 - name: Check if dotgpg is installed
   shell: command -v dotgpg
@@ -22,6 +24,7 @@
   when:
     - not local_vendor_files.stat.exists
   run_once: true
+  tags: adoptopenjdk
 
 - name: Generate list of remote vendor_files
   command: dotgpg cat {{ item }}
@@ -31,6 +34,7 @@
     - not local_vendor_files.stat.exists
   loop: "{{ lookup('fileglob', 'vendor_files/vendor_files/*', wantlist=True) }}"
   run_once: true
+  tags: adoptopenjdk
 
 - name: Generate list of local vendor_files
   command: cat {{ item }}
@@ -40,6 +44,7 @@
     - local_vendor_files.stat.exists
   loop: "{{ lookup('fileglob', '/Vendor_Files/*', wantlist=True) }}"
   run_once: true
+  tags: adoptopenjdk
 
 - name: Set facts from output of dotgpg
   set_fact: {"{{ item.item | basename | replace('.gpg','') | replace('.','_') }}":"{{ item.stdout }}"}
@@ -47,6 +52,7 @@
   when:
     - not local_vendor_files.stat.exists
   run_once: true
+  tags: adoptopenjdk
 
 - name: Set facts from output of local vendor_files
   set_fact: {"{{ item.item | basename | replace('.','_') }}":"{{ item.stdout }}"}
@@ -54,3 +60,4 @@
   when:
     - local_vendor_files.stat.exists
   run_once: true
+  tags: adoptopenjdk


### PR DESCRIPTION
Signed-off-by: Stewart X Addison <sxa@redhat.com>

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.
-->

##### Checklist
<!-- For completed items, change [ ] to [x]. Leave unchecked if not required -->

- [x] commit message has one of the [standard prefixes](https://github.com/AdoptOpenJDK/openjdk-infrastructure/blob/master/FAQ.md#commit-messages)
- [ ] [FAQ.md](https://github.com/AdoptOpenJDK/openjdk-infrastructure/blob/master/FAQ.md) updated if appropriate
- [ ] other documentation is changed or added (if applicable)
- [x] playbook changes run through [VPC](https://ci.adoptopenjdk.net/view/Tooling/job/VagrantPlaybookCheck/) or [QPC](https://ci.adoptopenjdk.net/view/Tooling/job/QEMUPlaybookCheck/) (if you have access)
- [ ] for inventory.yml changes, bastillion/nagios/jenkins updated accordingly
NOTE: Cannot fully test in VPC because this affects a role which is not executed if `adoptopenjdk` is skipped, but here it is anyway: https://ci.adoptopenjdk.net/view/Tooling/job/VagrantPlaybookCheck/1009/ - I've verified that the role can be run in isolation via AWX.