### PR TITLE
unixPB: Fix U20 condition in Nagios_Plugins

### DIFF
--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Nagios_Plugins/tasks/nagios_Ubuntu.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Nagios_Plugins/tasks/nagios_Ubuntu.yml
@@ -27,7 +27,7 @@
     state: latest
     update_cache: yes
     pkg: nagios-plugins-common
-  when: (ansible_distribution_major_version != 20)
+  when: not (ansible_distribution_major_version == "20")
 
 ##########
 # Layout #

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Nagios_Plugins/tasks/nagios_Ubuntu.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Nagios_Plugins/tasks/nagios_Ubuntu.yml
@@ -27,7 +27,7 @@
     state: latest
     update_cache: yes
     pkg: nagios-plugins-common
-  when: not (ansible_distribution_major_version == "20")
+  when: (ansible_distribution_version is version_compare('20', operator='ge'))
 
 ##########
 # Layout #


### PR DESCRIPTION
Ref: #1901 

The condition wasn't correctly skipping the role, which probably wasn't helping the referenced issue. @sxa , could you test this to see if this fixes the issue - If your `ansible_distribution_major_version` variable really was undefined, there would presumably be failures much sooner in the playbook than Nagios.


##### Checklist
<!-- For completed items, change [ ] to [x]. Leave unchecked if not required -->

- [ ] commit message has one of the [standard prefixes](https://github.com/AdoptOpenJDK/openjdk-infrastructure/blob/master/FAQ.md#commit-messages)
- [ ] [FAQ.md](https://github.com/AdoptOpenJDK/openjdk-infrastructure/blob/master/FAQ.md) updated if appropriate
- [ ] other documentation is changed or added (if applicable)
- [ ] playbook changes run through [VPC](https://ci.adoptopenjdk.net/view/Tooling/job/VagrantPlaybookCheck/) or [QPC](https://ci.adoptopenjdk.net/view/Tooling/job/QEMUPlaybookCheck/) (if you have access)
- [ ] for inventory.yml changes, bastillion/nagios/jenkins updated accordingly
