### PR TITLE
UnixPB: Temporarily fix CentOS6 Adoptopenjdk_install role

### DIFF
--- a/ansible/Dockerfile.CentOS6
+++ b/ansible/Dockerfile.CentOS6
@@ -14,7 +14,7 @@ RUN sed -i -e 's!mirrorlist!#mirrorlist!g' /etc/yum.repos.d/CentOS-Base.repo; \
     ./configure --enable-optimizations; \
     make install; \
     rm /usr/src/Python-3.6.10.tgz; \
-    pip3 install --upgrade pip
+    pip3 install --upgrade pip; \
     pip3 install ansible
 
 COPY . /ansible

--- a/ansible/Dockerfile.CentOS6
+++ b/ansible/Dockerfile.CentOS6
@@ -14,6 +14,7 @@ RUN sed -i -e 's!mirrorlist!#mirrorlist!g' /etc/yum.repos.d/CentOS-Base.repo; \
     ./configure --enable-optimizations; \
     make install; \
     rm /usr/src/Python-3.6.10.tgz; \
+    pip3 install --upgrade pip
     pip3 install ansible
 
 COPY . /ansible

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/adoptopenjdk_install/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/adoptopenjdk_install/tasks/main.yml
@@ -90,11 +90,14 @@
     - adoptopenjdk_install
     - skip_ansible_lint
 
+# Currenlty not checking certs due to a CentOS6 error
+# See: https://github.com/AdoptOpenJDK/openjdk-infrastructure/issues/1877
 - name: Install latest release if one not already installed
   unarchive:
     src: https://api.adoptopenjdk.net/v3/binary/latest/{{ jdk_version }}/ga/linux/{{ api_architecture }}/jdk/{{ bootjdk }}/normal/adoptopenjdk?project=jdk
     dest: /usr/lib/jvm
     remote_src: yes
+    validate_certs: no
   retries: 3
   delay: 5
   register: adoptopenjdk_download


### PR DESCRIPTION
ref: #1877 

This is a temporary fix, to get the Docker C6 and VPC checks working for now- given that the requests are to our API server, I'm less scared about not validating those certs.

##### Checklist
<!-- For completed items, change [ ] to [x]. Leave unchecked if not required -->

- [x] commit message has one of the [standard prefixes](https://github.com/AdoptOpenJDK/openjdk-infrastructure/blob/master/FAQ.md#commit-messages)
- [ ] [FAQ.md](https://github.com/AdoptOpenJDK/openjdk-infrastructure/blob/master/FAQ.md) updated if appropriate : N/A
- [ ] other documentation is changed or added (if applicable) : N/A
- [x] playbook changes run through [VPC](https://ci.adoptopenjdk.net/view/Tooling/job/VagrantPlaybookCheck/) or [QPC](https://ci.adoptopenjdk.net/view/Tooling/job/QEMUPlaybookCheck/) (if you have access) : https://ci.adoptopenjdk.net/job/VagrantPlaybookCheck/1012/console
- [ ] for inventory.yml changes, bastillion/nagios/jenkins updated accordingly : N/A
