### PR TITLE
unixPB: Find Locale-list based on RHEL major_version

### DIFF
--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/tasks/RedHat.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/tasks/RedHat.yml
@@ -199,17 +199,20 @@
     name: locales
     state: present
   when:
-    - not (ansible_distribution_major_version == "7")
+    - (ansible_distribution_major_version is version_compare('7', operator='lt'))
   tags: locales
 
-- name: Set locale list command
-  set_fact:
-    locale_list_command: "{% if ansible_distribution_major_version=='7' %}localectl list-locales{% else %}locale -a{% endif %}"
+- name: Install 'glibc-common' package
+  package:
+    name: glibc-common
+    state: present
+  when:
+    - (ansible_distribution_major_version is version_compare('7', operator='ge'))
   tags: locales
 
 # Skipping linting as no alternative to shell can be used (lint error 305)
 - name: Get locale list
-  shell: "{{ locale_list_command }}"
+  shell: locale -a
   register: localeList
   changed_when: False
   tags:

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/tasks/RedHat.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/tasks/RedHat.yml
@@ -198,11 +198,18 @@
   package:
     name: locales
     state: present
+  when:
+    - not (ansible_distribution_major_version == "7")
+  tags: locales
+
+- name: Set locale list command
+  set_fact:
+    locale_list_command: "{% if ansible_distribution_major_version=='7' %}localectl list-locales{% else %}locale -a{% endif %}"
   tags: locales
 
 # Skipping linting as no alternative to shell can be used (lint error 305)
 - name: Get locale list
-  shell: locale -a
+  shell: "{{ locale_list_command }}"
   register: localeList
   changed_when: False
   tags:


### PR DESCRIPTION
Fixes: #1915 

Sets the locale list command based on the `ansible_major_distribution_version`. The `if` statement is required because ansible will register variables even if a task is skipped - otherwise I would have had 2 separate tasks that register to `localeList`, as that'd be easier to read.

- [x] commit message has one of the [standard prefixes](https://github.com/AdoptOpenJDK/openjdk-infrastructure/blob/master/FAQ.md#commit-messages)
- [ ] [FAQ.md](https://github.com/AdoptOpenJDK/openjdk-infrastructure/blob/master/FAQ.md) updated if appropriate : N/A
- [ ] other documentation is changed or added (if applicable) : N/A
- [x] playbook changes run through [VPC](https://ci.adoptopenjdk.net/view/Tooling/job/VagrantPlaybookCheck/) or [QPC](https://ci.adoptopenjdk.net/view/Tooling/job/QEMUPlaybookCheck/) (if you have access) : Not required as we don't test the RHEL branch in VPC
- [ ] for inventory.yml changes, bastillion/nagios/jenkins updated accordingly : N/A
