### PR TITLE
UnixPB: install perl-test-simple on rhel

### DIFF
--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/vars/CentOS.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/vars/CentOS.yml
@@ -86,6 +86,7 @@ Test_Tool_Packages:
   - openssl-devel
   - mercurial
   - perl
+  - perl-Test-Simple
   - xorg-x11-xauth
   - xorg-x11-server-Xorg
   - xorg-x11-server-Xvfb

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/vars/RedHat.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/vars/RedHat.yml
@@ -92,6 +92,7 @@ Test_Tool_Packages:
   - perl
   - perl-Digest-SHA
   - perl-Time-HiRes
+  - perl-Test-Simple
   - xorg-x11-xauth
   - xorg-x11-server-Xvfb
   - zlib-devel


### PR DESCRIPTION
ref https://github.com/AdoptOpenJDK/openjdk-infrastructure/issues/1856

Without Test::Simple, test-ibmcloud-rhel6-x64-1 and rhel7 will fail jdk 8 openj9 functional special tests (EDIT: on x86-64_xl), https://ci.adoptopenjdk.net/view/Test_grinder/job/Grinder/6736/console. (rhel6)
```
15:13:14  FAILED test targets:
15:13:14  	MBCS_Tests_pref_ja_JP_linux_0
15:13:14  	MBCS_Tests_pref_ko_KR_linux_0
15:13:14  	MBCS_Tests_pref_zh_CN_linux_0
15:13:14  	MBCS_Tests_pref_zh_TW_linux_0
15:13:14  	MBCS_Tests_coin_ja_JP_linux_0
15:13:14  	MBCS_Tests_coin_ko_KR_linux_0
15:13:14  	MBCS_Tests_coin_zh_CN_linux_0
15:13:14  	MBCS_Tests_coin_zh_TW_linux_0
```
After installing the module, the tests passed 
https://ci.adoptopenjdk.net/view/Test_grinder/job/Grinder/6737/console
