### PR TITLE
VPC: add MBCS test for vagrant playbook check job

### DIFF
--- a/ansible/pbTestScripts/testJDK.sh
+++ b/ansible/pbTestScripts/testJDK.sh
@@ -13,6 +13,7 @@ mkdir -p $HOME/testLocation
 [ ! -d $HOME/testLocation/openjdk-tests ] && git clone https://github.com/adoptopenjdk/openjdk-tests $HOME/testLocation/openjdk-tests
 $HOME/testLocation/openjdk-tests/get.sh -t $HOME/testLocation/openjdk-tests
 cd $HOME/testLocation/openjdk-tests/TKG || exit 1
-export BUILD_LIST=system
+export BUILD_LIST=functional
 $MAKE_COMMAND compile
-$MAKE_COMMAND _MachineInfo
+# Runs this test to check for prerequisite perl modules
+$MAKE_COMMAND _MBCS_Tests_pref_ja_JP_linux_0


### PR DESCRIPTION
ref https://github.com/AdoptOpenJDK/openjdk-infrastructure/pull/1927#issuecomment-778289501

I have added the MBCS_Tests_pref_ja_JP_linux_0 test as a quick test to ensure that the required perl modules are on a machine after the playbook runs on them, since installing perl from yum seems to sometimes omit certain perl modules.

I was initially going to add this test as something optional, but ive instead replaced the existing MachineInfo test altogether as the MachineInfo test's only purpose is to see if a test _can_ run

What do you think @Willsparker?