### PR TITLE
Remove JDK13/14, Add JDK15 to the machines for bootstrapping current releases

### DIFF
--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/main.yml
@@ -85,12 +85,8 @@
       jdk_version: 11
       when: ansible_distribution != "Alpine" and ansible_distribution != "Solaris"
       tags: build_tools
-    - role: adoptopenjdk_install  # JDK14 Build Bootstrap
-      jdk_version: 13
-      when: ansible_distribution != "Alpine" and ansible_distribution != "Solaris"
-      tags: build_tools
-    - role: adoptopenjdk_install  # JDK15 Build Bootstrap
-      jdk_version: 14
+    - role: adoptopenjdk_install  # JDK16 Build Bootstrap
+      jdk_version: 15
       when: ansible_distribution != "Alpine" and ansible_distribution != "Solaris"
       tags: build_tools
     - OpenSSL102                  # OpenJ9

--- a/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/main.yml
@@ -57,10 +57,8 @@
       jdk_version: 10
     - role: Java_install          # For Gradle
       jdk_version: 11
-    - role: Java_install          # JDK14 build bootstrap
-      jdk_version: 13
-    - role: Java_install          # JDK15 build bootstrap
-      jdk_version: 14
+    - role: Java_install          # JDK16 build bootstrap
+      jdk_version: 15
     - ANT                         # Testing
     - MSVS_2013
     - MSVS_2017                   # OpenJ9


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.
-->

##### Checklist
<!-- For completed items, change [ ] to [x]. Leave unchecked if not required -->

- [x] commit message has one of the [standard prefixes](https://github.com/AdoptOpenJDK/openjdk-infrastructure/blob/master/FAQ.md#commit-messages)
- [ ] [FAQ.md](https://github.com/AdoptOpenJDK/openjdk-infrastructure/blob/master/FAQ.md) updated if appropriate
- [ ] other documentation is changed or added (if applicable)
- [ ] playbook changes run through [VPC](https://ci.adoptopenjdk.net/view/Tooling/job/VagrantPlaybookCheck/) or [QPC](https://ci.adoptopenjdk.net/view/Tooling/job/QEMUPlaybookCheck/) (if you have access) [VPC](https://ci.adoptopenjdk.net/view/Tooling/job/VagrantPlaybookCheck/1051/) [QPC](https://ci.adoptopenjdk.net/view/Tooling/job/QEMUPlaybookCheck/198/)
- [ ] for inventory.yml changes, bastillion/nagios/jenkins updated accordingly

We no longer require the boot JDKs for previous releases to be on the machines