### PR TITLE
winPB: Ignore Program Files (x86) shortname errors

### DIFF
--- a/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/roles/Common/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/roles/Common/tasks/main.yml
@@ -27,8 +27,11 @@
   win_shell: "fsutil behavior set disable8dot3 0;"
   tags: basic_config
 
+# Ignores errors to ensure the playbook can be run on an already setup machine
+# See: https://github.com/AdoptOpenJDK/openjdk-infrastructure/issues/1945
 - name: Ensure 'Program Files (x86)' has a shortname
   win_shell: "fsutil file setshortname \"C:\\Program Files (x86)\" \"PROGRA~2\""
   args:
     executable: cmd
+  ignore_errors: yes
   tags: basic_config


### PR DESCRIPTION
Fixes: #1945 

Ignores the errors when creating shortnames. Reasoning for this is that, if the playbook is run on a machine that's already setup, the task in question will fail as there will be processes running in the Program Files (x86) folder. This will occur, even if the folder already has it's shortname. 
If, on an initial playbook run, the task fails and is ignored, the problem will be evident when the machine is tested, and manual intervention would be required anyway. 

##### Checklist
<!-- For completed items, change [ ] to [x]. Leave unchecked if not required -->

- [ ] commit message has one of the [standard prefixes](https://github.com/AdoptOpenJDK/openjdk-infrastructure/blob/master/FAQ.md#commit-messages)
- [ ] [FAQ.md](https://github.com/AdoptOpenJDK/openjdk-infrastructure/blob/master/FAQ.md) updated if appropriate
- [ ] other documentation is changed or added (if applicable)
- [ ] playbook changes run through [VPC](https://ci.adoptopenjdk.net/view/Tooling/job/VagrantPlaybookCheck/) or [QPC](https://ci.adoptopenjdk.net/view/Tooling/job/QEMUPlaybookCheck/) (if you have access)
- [ ] for inventory.yml changes, bastillion/nagios/jenkins updated accordingly
