### PR TITLE
pbTests: Allow use of default values for make-adopt-build-farm.sh

### DIFF
--- a/ansible/pbTestScripts/buildJDK.sh
+++ b/ansible/pbTestScripts/buildJDK.sh
@@ -63,7 +63,6 @@ checkJDK() {
 		echo "i.e. The following formats will work for jdk8: 'jdk8u', 'jdk8' , '8'"
 		exit 1
 	fi
-	setBootJDK
 	if ((JAVA_TO_BUILD <= JDK_GA)); then
 		JAVA_TO_BUILD="jdk${JAVA_TO_BUILD}u"
 	elif ((JAVA_TO_BUILD == JDK_MAX)); then
@@ -71,32 +70,6 @@ checkJDK() {
 	else
 		JAVA_TO_BUILD="jdk${JAVA_TO_BUILD}"
 	fi
-}
-
-setBootJDK() {
-        local buildJDKNumber=$JAVA_TO_BUILD
-        local bootJDKNumber=$((buildJDKNumber - 1))
-        # Use latest GA as JDK_BOOT_DIR if building above JDK_GA
-        if ((bootJDKNumber > JDK_GA)); then bootJDKNumber=$JDK_GA; fi
-        # Refer to 8 as 'jdk8'. Anything else is 'jdk-XX'
-        [[ $bootJDKNumber != "8" ]] && bootJDKNumber="-$bootJDKNumber"
-        if [[ $buildJDKNumber -eq 8 ]]; then
-                # CentOS JDK7
-                export JDK_BOOT_DIR=$(find /usr/lib/jvm -maxdepth 1 -name java-1.7.0-openjdk.x86_64)
-                # Ubuntu JDK7
-                [[ -z "$JDK_BOOT_DIR" ]] && export JDK_BOOT_DIR=$(find /usr/lib/jvm/ -maxdepth 1 -name java-1.7.0-openjdk-\*)
-                # Zulu-7 for OSs without JDK7
-                [[ -z "$JDK_BOOT_DIR" ]] && export JDK_BOOT_DIR=$(find /usr/lib/jvm/ -maxdepth 1 -name zulu7)
-        else
-                export JDK_BOOT_DIR=/usr/lib/jvm/jdk${bootJDKNumber}
-        fi
-        # If JDK (jdkToBuild - 1) can't be found, look for equal boot and build jdk
-        if [ -z "${JDK_BOOT_DIR}" ]
-        then
-                [[ $buildJDKNumber != "8" ]] && buildJDKNumber="-$buildJDKNumber"
-                echo "Can't find jdk$bootJDKNumber to build JDK, looking for jdk$buildJDKNumber"
-                export JDK_BOOT_DIR=/usr/lib/jvm/jdk${buildJDKNumber}
-        fi
 }
 
 cloneRepo() {
@@ -123,11 +96,6 @@ cloneRepo() {
 }
 
 # Default values
-export JAVA_TO_BUILD=jdk8u
-export PATH=/usr/local/bin/:$PATH
-export TARGET_OS=linux
-export VARIANT=openj9
-export ARCHITECTURE=x64
 GIT_URL="https://github.com/adoptopenjdk/openjdk-build"
 CLEAN_WORKSPACE=false
 JDK_MAX=
@@ -135,15 +103,6 @@ JDK_GA=
 
 setJDKVars
 processArgs $*
-
-# All architectures are referred to in make-adopt-build-farm.sh, except x86_64, which is 'x64'
-unameOutput=$(uname -m)
-if [[ ${unameOutput} != "x86_64" ]]; then
-       export ARCHITECTURE=${unameOutput}
-fi
-
-# Use the JDK8 installed with the adoptopenjdk_install role to run Gradle with.
-export JAVA_HOME=/usr/lib/jvm/jdk8
 
 # Only build Hotspot on FreeBSD
 if [[ $(uname) == "FreeBSD" ]]; then
@@ -162,29 +121,26 @@ if grep 'buster' /etc/*-release >/dev/null 2>&1; then
 	export CXX=/usr/bin/g++-7
 fi
 
-if [[ "$ARCHITECTURE" == "aarch64" && "$JAVA_TO_BUILD" == "jdk8u" && $VARIANT == "openj9" ]]; then
-	echo "Can't build OpenJ9 JDK8 on AARCH64, Defaulting to jdk11"
+if [[ "$(uname -m)" == "aarch64" && "$JAVA_TO_BUILD" == "jdk8u" && $VARIANT == "openj9" ]]; then
+	echo "Can't build OpenJ9 JDK8 on AARCH64, Resetting JAVA_TO_BUILD to jdk11u"
 	JAVA_TO_BUILD=jdk11u
-	JDK_BOOT_DIR=/usr/lib/jvm/jdk-10
 fi
 
-if [[ "$ARCHITECTURE" == "armv7l" && "$VARIANT" == "openj9" ]]; then
-	echo "Can't build an OpenJ9 JDK on ARMv7l, Defaulting to Hotspot"
+if [[ "$(uname -m)" == "armv7l" && "$VARIANT" == "openj9" ]]; then
+	echo "OpenJ9 VM does not support armv7l - resetting VARIANT to hotspot"
 	export VARIANT=hotspot
 fi
 
-export FILENAME="${JAVA_TO_BUILD}_${VARIANT}_${ARCHITECTURE}"
-
-echo "DEBUG:
-        TARGET_OS=$TARGET_OS
-        ARCHITECTURE=$ARCHITECTURE
-        JAVA_TO_BUILD=$JAVA_TO_BUILD
-        VARIANT=$VARIANT
-        JDK_BOOT_DIR=$JDK_BOOT_DIR
-        JAVA_HOME=$JAVA_HOME
-        WORKSPACE=$WORKSPACE
-        GIT_URL=$GIT_URL
-        FILENAME=$FILENAME"
+echo "buildJDK.sh DEBUG:
+        TARGET_OS=${TARGET_OS:-}
+        ARCHITECTURE=${ARCHITECTURE:-}
+        JAVA_TO_BUILD=${JAVA_TO_BUILD:-}
+        VARIANT=${VARIANT:-}
+        JDK_BOOT_DIR=${JDK_BOOT_DIR:-}
+        JAVA_HOME=${JAVA_HOME:-}
+        WORKSPACE=${WORKSPACE:-}
+        GIT_URL=${GIT_URL:-}
+        FILENAME=${FILENAME:-}"
 
 cloneRepo 
 

--- a/ansible/pbTestScripts/buildJDKWin.sh
+++ b/ansible/pbTestScripts/buildJDKWin.sh
@@ -67,7 +67,6 @@ checkJDK() {
 		exit 1
 	fi
 	if ((JAVA_TO_BUILD == 8)); then
-		export JDK_BOOT_DIR=/cygdrive/c/openjdk/jdk-7
 		export JAVA_TO_BUILD="jdk8u"
 	elif ((JAVA_TO_BUILD > JDK_GA)); then
 		export JDK_BOOT_DIR=/cygdrive/c/openjdk/jdk-${JDK_GA}
@@ -77,7 +76,6 @@ checkJDK() {
 			export JAVA_TO_BUILD="jdk${JAVA_TO_BUILD}"
 		fi
 	else
-		export JDK_BOOT_DIR=/cygdrive/c/openjdk/jdk-$((JAVA_TO_BUILD - 1))
 		export JAVA_TO_BUILD="jdk${JAVA_TO_BUILD}u"
 	fi
 }
@@ -105,12 +103,6 @@ cloneRepo() {
 	fi
 }
 # Set defaults
-export JAVA_TO_BUILD=jdk8
-export JDK_BOOT_DIR=/cygdrive/c/openjdk/jdk-7
-export VARIANT=openj9
-export PATH=/usr/bin/:$PATH
-export TARGET_OS=windows
-export ARCHITECTURE=x64
 export JAVA_HOME=/cygdrive/c/openjdk/jdk-8
 
 GIT_URL=https://github.com/adoptopenjdk/openjdk-build
@@ -122,17 +114,16 @@ setJDKVars
 processArgs $*
 cloneRepo
 
-export FILENAME="${JAVA_TO_BUILD}_${VARIANT}_${ARCHITECTURE}"
-echo "DEBUG:
-	TARGET_OS=$TARGET_OS
-	ARCHITECTURE=$ARCHITECTURE
-	JAVA_TO_BUILD=$JAVA_TO_BUILD
-	VARIANT=$VARIANT
-	JDK_BOOT_DIR=$JDK_BOOT_DIR
-	JAVA_HOME=$JAVA_HOME
-	WORKSPACE=$WORKSPACE
-	GIT_URL=$GIT_URL
-	FILENAME=$FILENAME"
+echo "buildJDKWin.sh DEBUG:
+	TARGET_OS=${TARGET_OS:-}
+	ARCHITECTURE=${ARCHITECTURE:-}
+	JAVA_TO_BUILD=${JAVA_TO_BUILD:-}
+	VARIANT=${VARIANT:-}
+	JDK_BOOT_DIR=${JDK_BOOT_DIR:-}
+	JAVA_HOME=${JAVA_HOME:-}
+	WORKSPACE=${WORKSPACE:-}
+	GIT_URL=${GIT_URL:-}
+	FILENAME=${FILENAME:-}"
 
 echo "Running $WORKSPACE/openjdk-build/build-farm/make-adopt-build-farm.sh"
 $WORKSPACE/openjdk-build/build-farm/make-adopt-build-farm.sh


### PR DESCRIPTION
Not a clue if I've stripped too much out or not, but might as well give it a shot ... Now possible thanks to https://github.com/AdoptOpenJDK/openjdk-build/pull/2167 https://github.com/AdoptOpenJDK/openjdk-build/pull/2479 https://github.com/AdoptOpenJDK/openjdk-build/pull/2482 but requires https://github.com/AdoptOpenJDK/openjdk-build/pull/2478 but weill require https://github.com/AdoptOpenJDK/openjdk-build/pull/2478 to be merged before testing

Signed-off-by: Stewart X Addison <sxa@redhat.com>


##### Checklist
<!-- For completed items, change [ ] to [x]. Leave unchecked if not required -->

- [x] commit message has one of the [standard prefixes](https://github.com/AdoptOpenJDK/openjdk-infrastructure/blob/master/FAQ.md#commit-messages)
- [ ] [FAQ.md](https://github.com/AdoptOpenJDK/openjdk-infrastructure/blob/master/FAQ.md) updated if appropriate
- [ ] other documentation is changed or added (if applicable)
- [ ] playbook changes run through [VPC](https://ci.adoptopenjdk.net/view/Tooling/job/VagrantPlaybookCheck/) or [QPC](https://ci.adoptopenjdk.net/view/Tooling/job/QEMUPlaybookCheck/) (if you have access) [VPC](https://ci.adoptopenjdk.net/view/Tooling/job/VagrantPlaybookCheck/1069/) [QPC](https://ci.adoptopenjdk.net/job/QEMUPlaybookCheck/208/)
- [ ] for inventory.yml changes, bastillion/nagios/jenkins updated accordingly
