### PR TITLE
UnixPB: symlink /usr/bin/java to /usr/java8_64/jre/bin/java

### DIFF
--- a/ansible/playbooks/AdoptOpenJDK_AIX_Playbook/roles/bootjdk8/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_AIX_Playbook/roles/bootjdk8/tasks/main.yml
@@ -37,7 +37,7 @@
 
 - name: Setting Java 8 as default
   file:
-    src: /usr/java8_64
+    src: /usr/java8_64/jre/bin/java
     dest: /usr/bin/java
     state: link
   tags: java8


### PR DESCRIPTION
The symlink should be pointing at /usr/java8_64/jre/bin/java not /usr/java8_64/, causing aix machines to use java6 as a default