### PR TITLE
unixPB: Add static Alpine containers for tests

### DIFF
--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Crontab/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Crontab/tasks/main.yml
@@ -15,6 +15,12 @@
   when: (ansible_distribution == "Debian" or ansible_distribution == "Ubuntu")
   tags: crontab
 
+- name: Add cron job to apply OS updates on apk-based systems
+  cron: name="Check for updates everyday at 2:32am" weekday="*" minute="32" hour="2" user=root state=present
+        job="/sbin/apk update && /sbin/apk upgrade"
+  when: (ansible_distribution == "Alpine")
+  tags: crontab
+
 - name: Add cron job to apply OS updates on zypper-based systems
   cron: name="Check for updates everyday at 1am" weekday="*" minute="0" hour="1" user=root state=present
         job="/usr/bin/zypper refresh && /usr/bin/zypper -n up"

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/DockerStatic/Dockerfiles/Dockerfile.alp311
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/DockerStatic/Dockerfiles/Dockerfile.alp311
@@ -1,7 +1,7 @@
 FROM alpine:3.11
 
 # Install OpenJDK 8 from Alpine because AdoptOpenJDK is 16+, only (February, 2021).
-RUN apk --update add bash shadow openssh-server unzip wget openjdk8 git curl make gcc perl xvfb libxrender libxi libxtst procps
+RUN apk --update add bash shadow openssh-server openssh-client unzip wget openjdk8 git curl make gcc perl xvfb libxrender libxi libxtst procps
 RUN ssh-keygen -t rsa -f /etc/ssh/ssh_host_rsa_key -P ""
 
 # Install ant and ant-contrib.

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/DockerStatic/Dockerfiles/Dockerfile.alp311
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/DockerStatic/Dockerfiles/Dockerfile.alp311
@@ -1,0 +1,31 @@
+FROM alpine:3.11
+
+# Install OpenJDK 8 from Alpine because AdoptOpenJDK is 16+, only (February, 2021).
+RUN apk --update add bash shadow openssh-server unzip wget openjdk8 git curl make gcc perl xvfb libxrender libxi libxtst procps
+RUN ssh-keygen -t rsa -f /etc/ssh/ssh_host_rsa_key -P ""
+
+# Install ant and ant-contrib.
+RUN wget -O /tmp/ant.zip 'https://archive.apache.org/dist/ant/binaries/apache-ant-1.10.9-bin.zip'
+RUN wget -O /tmp/ant-contrib.tgz  https://sourceforge.net/projects/ant-contrib/files/ant-contrib/ant-contrib-1.0b2/ant-contrib-1.0b2-bin.tar.gz
+RUN echo "d085f59349edf22a93d835aa30aea2521ed39bdb99d57d941f1ebd8d115a561bb28aecc781915ff2a0d9f7caf7bae536cdda0910bb432b2a4bce8b7b90c2903b  /tmp/ant.zip" > /tmp/ant.sha512
+RUN echo "0fd2771dca2b8b014a4cb3246715b32e20ad5d26754186d82eee781507a183d5e63064890b95eb27c091c93c1209528a0b18a6d7e6901899319492a7610e74ad  /tmp/ant-contrib.tgz" >> /tmp/ant.sha512
+RUN sha512sum -c /tmp/ant.sha512
+RUN unzip -q -d /usr/local /tmp/ant.zip 
+RUN tar xpfz /tmp/ant-contrib.tgz -C /usr/local/apache-ant-1.10.9/lib --strip-components=2 ant-contrib/lib/ant-contrib.jar
+RUN ln -s /usr/local/apache-ant-1.10.9/bin/ant /usr/bin/ant
+
+# Create user jenkins with random password. Prevents locked user account that makes SSH'ing into
+# the container impossible.
+RUN groupadd -g 10001 jenkins
+RUN useradd -p $(tr -dc A-Za-z0-9 </dev/urandom | head -c 16) -s /bin/bash -m -d /home/jenkins -u 10000 -g 10001 jenkins
+RUN mkdir /home/jenkins/.ssh
+RUN echo "Jenkins_User_SSHKey" > /home/jenkins/.ssh/authorized_keys
+RUN chown -R jenkins:jenkins /home/jenkins/.ssh
+RUN chmod -R "g=,o=" /home/jenkins/.ssh
+
+# Remove temporary files.
+RUN rm -rf /tmp/ant* /tmp/ant-contrib*
+
+# Start container with docker run -p 2222:22 UUID.
+CMD ["/usr/sbin/sshd","-D"]
+EXPOSE 22

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/DockerStatic/Dockerfiles/Dockerfile.alp312
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/DockerStatic/Dockerfiles/Dockerfile.alp312
@@ -1,0 +1,31 @@
+FROM alpine:3.12
+
+# Install OpenJDK 8 from Alpine because AdoptOpenJDK is 16+, only (February, 2021).
+RUN apk --update add bash shadow openssh-server unzip wget openjdk8 git curl make gcc perl xvfb libxrender libxi libxtst procps
+RUN ssh-keygen -t rsa -f /etc/ssh/ssh_host_rsa_key -P ""
+
+# Install ant and ant-contrib.
+RUN wget -O /tmp/ant.zip 'https://archive.apache.org/dist/ant/binaries/apache-ant-1.10.9-bin.zip'
+RUN wget -O /tmp/ant-contrib.tgz  https://sourceforge.net/projects/ant-contrib/files/ant-contrib/ant-contrib-1.0b2/ant-contrib-1.0b2-bin.tar.gz
+RUN echo "d085f59349edf22a93d835aa30aea2521ed39bdb99d57d941f1ebd8d115a561bb28aecc781915ff2a0d9f7caf7bae536cdda0910bb432b2a4bce8b7b90c2903b  /tmp/ant.zip" > /tmp/ant.sha512
+RUN echo "0fd2771dca2b8b014a4cb3246715b32e20ad5d26754186d82eee781507a183d5e63064890b95eb27c091c93c1209528a0b18a6d7e6901899319492a7610e74ad  /tmp/ant-contrib.tgz" >> /tmp/ant.sha512
+RUN sha512sum -c /tmp/ant.sha512
+RUN unzip -q -d /usr/local /tmp/ant.zip 
+RUN tar xpfz /tmp/ant-contrib.tgz -C /usr/local/apache-ant-1.10.9/lib --strip-components=2 ant-contrib/lib/ant-contrib.jar
+RUN ln -s /usr/local/apache-ant-1.10.9/bin/ant /usr/bin/ant
+
+# Create user jenkins with random password. Prevents locked user account that makes SSH'ing into
+# the container impossible.
+RUN groupadd -g 10001 jenkins
+RUN useradd -p $(tr -dc A-Za-z0-9 </dev/urandom | head -c 16) -s /bin/bash -m -d /home/jenkins -u 10000 -g 10001 jenkins
+RUN mkdir /home/jenkins/.ssh
+RUN echo "Jenkins_User_SSHKey" > /home/jenkins/.ssh/authorized_keys
+RUN chown -R jenkins:jenkins /home/jenkins/.ssh
+RUN chmod -R "g=,o=" /home/jenkins/.ssh
+
+# Remove temporary files.
+RUN rm -rf /tmp/ant* /tmp/ant-contrib*
+
+# Start container with docker run -p 2222:22 UUID.
+CMD ["/usr/sbin/sshd","-D"]
+EXPOSE 22

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/DockerStatic/Dockerfiles/Dockerfile.alp312
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/DockerStatic/Dockerfiles/Dockerfile.alp312
@@ -1,7 +1,7 @@
 FROM alpine:3.12
 
 # Install OpenJDK 8 from Alpine because AdoptOpenJDK is 16+, only (February, 2021).
-RUN apk --update add bash shadow openssh-server unzip wget openjdk8 git curl make gcc perl xvfb libxrender libxi libxtst procps
+RUN apk --update add bash shadow openssh-server openssh-client unzip wget openjdk8 git curl make gcc perl xvfb libxrender libxi libxtst procps
 RUN ssh-keygen -t rsa -f /etc/ssh/ssh_host_rsa_key -P ""
 
 # Install ant and ant-contrib.

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/DockerStatic/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/DockerStatic/tasks/main.yml
@@ -33,6 +33,8 @@
     - u2004
     - u2010
     - f33
+    - alp311
+    - alp312
 
 ##############################################################
 # Start the containers                                       #
@@ -66,6 +68,16 @@
 
 - name: Start fedora 33 container if not already started
   command: docker run --restart unless-stopped -p 2227:22 --cpus=2.0 --memory=6G --detach --name   f33.2227 aqa_f33
+  tags: startcontainers
+  ignore_errors: yes
+
+- name: Start Alpine 3.11 container if not already started
+  command: docker run --restart unless-stopped -p 2228:22 --cpus=2.0 --memory=6G --detach --name alp311.2228 aqa_alp311
+  tags: startcontainers
+  ignore_errors: yes
+
+- name: Start Alpine 3.12 container if not already started
+  command: docker run --restart unless-stopped -p 2229:22 --cpus=2.0 --memory=6G --detach --name alp312.2228 aqa_alp312
   tags: startcontainers
   ignore_errors: yes
 

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/DockerStatic/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/DockerStatic/tasks/main.yml
@@ -73,7 +73,7 @@
 
 - name: Start Alpine 3.11 container if not already started
   command: docker run --restart unless-stopped -p 2228:22 --cpus=2.0 --memory=6G --detach --name alp311.2228 aqa_alp311
-  tags: startcontainers
+  tags: startcontainers, startallcontainers
   ignore_errors: yes
 
 - name: Start Alpine 3.12 container if not already started


### PR DESCRIPTION
I've largely followed #1925. I copy and pasted the CPU/RAM config. Please adjust as you see fit. 

The SSH key and the password are baked into the container image (as it's done in #1925). If we want to change that, I'd rather do it for all containers in a separate PR. I did a test run with `_sanity.openjdk`.

Fixes #1929.

##### Checklist
- [x] commit message has one of the [standard prefixes](https://github.com/AdoptOpenJDK/openjdk-infrastructure/blob/master/FAQ.md#commit-messages)
- [ ] [FAQ.md](https://github.com/AdoptOpenJDK/openjdk-infrastructure/blob/master/FAQ.md) updated if appropriate
- [ ] other documentation is changed or added (if applicable)
- [ ] playbook changes run through [VPC](https://ci.adoptopenjdk.net/view/Tooling/job/VagrantPlaybookCheck/) or [QPC](https://ci.adoptopenjdk.net/view/Tooling/job/QEMUPlaybookCheck/) (if you have access)
- [ ] for inventory.yml changes, bastillion/nagios/jenkins updated accordingly
