### PR TITLE
inventory: add AMD dockerhost system

### DIFF
--- a/ansible/inventory.yml
+++ b/ansible/inventory.yml
@@ -87,6 +87,8 @@ hosts:
       - packet:
           ubuntu1604-armv8-1: {ip: 147.75.77.146, description: D05}
           ubuntu2004-armv8-1: {ip: 139.178.82.146, description: Ampere eMag}
+          ubuntu2004-x64-1: {ip: 139.178.85.251, description: AMD EPYC}
+
 
       - scaleway:
           ubuntu1604-armv7-1: {ip: 51.158.73.136}


### PR DESCRIPTION
I may split these out from regular "docker" systems in the future, but this is one of the x64 machines that is hosted docker containers as per https://github.com/AdoptOpenJDK/openjdk-infrastructure/issues/1809

Signed-off-by: Stewart X Addison <sxa@redhat.com>

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.
-->

##### Checklist
<!-- For completed items, change [ ] to [x]. Leave unchecked if not required -->

- [x] commit message has one of the [standard prefixes](https://github.com/AdoptOpenJDK/openjdk-infrastructure/blob/master/FAQ.md#commit-messages)
- [ ] [FAQ.md](https://github.com/AdoptOpenJDK/openjdk-infrastructure/blob/master/FAQ.md) updated if appropriate
- [ ] other documentation is changed or added (if applicable)
- [ ] playbook changes run through [VPC](https://ci.adoptopenjdk.net/view/Tooling/job/VagrantPlaybookCheck/) or [QPC](https://ci.adoptopenjdk.net/view/Tooling/job/QEMUPlaybookCheck/) (if you have access)
- [ ] for inventory.yml changes, bastillion/nagios/jenkins updated accordingly
