### PR TITLE
QPC: Remove image files after run

### DIFF
--- a/ansible/pbTestScripts/qemuPlaybookCheck.sh
+++ b/ansible/pbTestScripts/qemuPlaybookCheck.sh
@@ -170,7 +170,7 @@ setupWorkspace() {
 		echo "Copying new disk image"
 		# Copy disk image and tools from imageLocation to workFolder
 		cp -r $imageLocation/$OS.$ARCHITECTURE/. $workFolder
-		xz -cd "$workFolder"/"$OS.$ARCHITECTURE".dsk.xz > "$workFolder"/"$OS.$ARCHITECTURE".dsk
+		xz -d "$workFolder"/"$OS.$ARCHITECTURE".dsk.xz
 	else
 		echo "Using old disk image"
 	fi
@@ -301,6 +301,8 @@ runPlaybook() {
 	fi
 	if [[ "$retainVM" == false ]]; then
 		destroyVM
+		echo "Removing disk image"
+		rm -f ${workFolder}/${OS}.${ARCHITECTURE}.dsk
 	fi
 }
 


### PR DESCRIPTION
Ref: #1966 

Another problem I found when clearing the infra-vagrant box was that QPC runs didn't clear up their images once they were finished. These build up fast! The images won't be removed if the VM isn't intended to be destroyed. 
This also removes the archive from the workspace once it's been extracted, as that's more space that doesn't need to be used.

##### Checklist
<!-- For completed items, change [ ] to [x]. Leave unchecked if not required -->

- [x] commit message has one of the [standard prefixes](https://github.com/AdoptOpenJDK/openjdk-infrastructure/blob/master/FAQ.md#commit-messages)
- [ ] [FAQ.md](https://github.com/AdoptOpenJDK/openjdk-infrastructure/blob/master/FAQ.md) updated if appropriate
- [ ] other documentation is changed or added (if applicable)
- [x] playbook changes run through [VPC](https://ci.adoptopenjdk.net/view/Tooling/job/VagrantPlaybookCheck/) or [QPC](https://ci.adoptopenjdk.net/view/Tooling/job/QEMUPlaybookCheck/) (if you have access) : The QPC job has been reconfigured to pull from this branch if to test this : https://ci.adoptopenjdk.net/job/QEMUPlaybookCheck/209/console
- [ ] for inventory.yml changes, bastillion/nagios/jenkins updated accordingly
