### PR TITLE
winPB: List Jenkins user groups

### DIFF
--- a/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/roles/Jenkins/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/roles/Jenkins/tasks/main.yml
@@ -15,7 +15,9 @@
     state: present
     password_never_expires: true
     groups:
-      - Users, Remote Desktop Users, Performance Log Users
+      - Users
+      - Remote Desktop Users
+      - Performance Log Users
   tags: jenkins
 
 


### PR DESCRIPTION
Ref: https://github.com/AdoptOpenJDK/openjdk-infrastructure/issues/1884#issuecomment-784008308

Although this is the case for Ansible 2.10.6, the problem may have no occur with earlier versions of ansible (and may be why I didn't see this issue when setting up machines for #1932 ). This is the formatting suggested in the documentation (https://docs.ansible.com/ansible/latest/collections/ansible/windows/win_user_module.html#examples) so I doubt it would be an issue for earlier versions of Ansible.

##### Checklist
<!-- For completed items, change [ ] to [x]. Leave unchecked if not required -->

- [x] commit message has one of the [standard prefixes](https://github.com/AdoptOpenJDK/openjdk-infrastructure/blob/master/FAQ.md#commit-messages)
- [ ] [FAQ.md](https://github.com/AdoptOpenJDK/openjdk-infrastructure/blob/master/FAQ.md) updated if appropriate
- [ ] other documentation is changed or added (if applicable)
- [ ] playbook changes run through [VPC](https://ci.adoptopenjdk.net/view/Tooling/job/VagrantPlaybookCheck/) or [QPC](https://ci.adoptopenjdk.net/view/Tooling/job/QEMUPlaybookCheck/) (if you have access) : VPC doesn't check the Jenkins tag, so can't be tested. It worked on the new machine in the referenced issue.
- [ ] for inventory.yml changes, bastillion/nagios/jenkins updated accordingly
