### PR TITLE
unixPB: Install Python2.7 on C6; Use it to install JDKs

### DIFF
--- a/ansible/Dockerfile.CentOS6
+++ b/ansible/Dockerfile.CentOS6
@@ -14,6 +14,7 @@ RUN sed -i -e 's!mirrorlist!#mirrorlist!g' /etc/yum.repos.d/CentOS-Base.repo; \
     ./configure --enable-optimizations; \
     make install; \
     rm /usr/src/Python-3.6.10.tgz; \
+    pip3 install --upgrade pip; \
     pip3 install ansible
 
 COPY . /ansible

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/main.yml
@@ -25,6 +25,7 @@
     - Version
     - adopt_etc
     - Common
+    - Python2.7                   # CentOS6
     - Providers                   # AdoptOpenJDK Infrastructure
     - autoconf
     - curl

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Python2.7/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Python2.7/tasks/main.yml
@@ -3,7 +3,7 @@
 # Python Bootstrap #
 ####################
 
-# Check if Python is installed, and its version. If Python isn't installed, or it's at a version below 2.7.9, install Python 2.7.9.
+# Check if Python is installed, and its version. If Python isn't installed, or it's at a version below 2.7.18, install Python 2.7.18.
 # Currently only for CentOS6. See: https://github.com/AdoptOpenJDK/openjdk-infrastructure/issues/1877
 
 - name: Check for Python 2's version
@@ -12,46 +12,21 @@
   ignore_errors: yes
   when:
     - (ansible_distribution == "CentOS") and (ansible_distribution_major_version == "6")
-  tags: 
-    - python2.7
-
-- name: Yum install prerequisites to build Python 2.7.9
-  package:
-    name: '{{ item }}'
-    state: latest
-  with_items:
-    - zlib-devel
-    - bzip2-devel
-    - openssl-devel
-    - xz-libs
-    - wget
-  when: 
-    - (ansible_distribution == "CentOS") and (ansible_distribution_major_version == "6")
-    - (python_version.rc != 0) or (python_version.rc == 0 and python_version.stdout is version_compare('2.7.9', operator='lt') )
   tags:
     - python2.7
 
-- name: Download & extract Python 2.7.9 source
-  unarchive: 
-    src: http://www.python.org/ftp/python/2.7.9/Python-2.7.9.tar.xz 
-    dest: /tmp/
+- name: Install Python2.7 to /usr/local/python2
+  unarchive:
+    src: https://ci.adoptopenjdk.net/userContent/usrlocalPython27.tar.xz
+    dest: /usr/local/
     remote_src: yes
     mode: 0755
-  retries: 3 
+  retries: 3
   delay: 5
   register: python_download
   until: python_download is not failed
-  when: 
-    - (ansible_distribution == "CentOS") and (ansible_distribution_major_version == "6")
-    - (python_version.rc != 0) or (python_version.rc == 0 and python_version.stdout is version_compare('2.7.9', operator='lt') )
-  tags:
-    - python2.7
-
-- name: Configure, build & make/make altinstall
-  shell: |
-    cd /tmp/Python-2.7.9 && ./configure --prefix=/usr/local && make && make altinstall
   when:
     - (ansible_distribution == "CentOS") and (ansible_distribution_major_version == "6")
-    - (python_version.rc != 0) or (python_version.rc == 0 and python_version.stdout is version_compare('2.7.9', operator='lt') )
+    - (python_version.rc != 0) or (python_version.rc == 0 and python_version.stdout is version_compare('2.7.18', operator='lt'))
   tags:
     - python2.7

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Python2.7/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Python2.7/tasks/main.yml
@@ -1,0 +1,57 @@
+---
+####################
+# Python Bootstrap #
+####################
+
+# Check if Python is installed, and its version. If Python isn't installed, or it's at a version below 2.7.9, install Python 2.7.9.
+# Currently only for CentOS6. See: https://github.com/AdoptOpenJDK/openjdk-infrastructure/issues/1877
+
+- name: Check for Python 2's version
+  shell: python -V 2>&1 | grep -Po '(?<=Python )(.+)'
+  register: python_version
+  ignore_errors: yes
+  when:
+    - (ansible_distribution == "CentOS") and (ansible_distribution_major_version == "6")
+  tags: 
+    - python2.7
+
+- name: Yum install prerequisites to build Python 2.7.9
+  package:
+    name: '{{ item }}'
+    state: latest
+  with_items:
+    - zlib-devel
+    - bzip2-devel
+    - openssl-devel
+    - xz-libs
+    - wget
+  when: 
+    - (ansible_distribution == "CentOS") and (ansible_distribution_major_version == "6")
+    - (python_version.rc != 0) or (python_version.rc == 0 and python_version.stdout is version_compare('2.7.9', operator='lt') )
+  tags:
+    - python2.7
+
+- name: Download & extract Python 2.7.9 source
+  unarchive: 
+    src: http://www.python.org/ftp/python/2.7.9/Python-2.7.9.tar.xz 
+    dest: /tmp/
+    remote_src: yes
+    mode: 0755
+  retries: 3 
+  delay: 5
+  register: python_download
+  until: python_download is not failed
+  when: 
+    - (ansible_distribution == "CentOS") and (ansible_distribution_major_version == "6")
+    - (python_version.rc != 0) or (python_version.rc == 0 and python_version.stdout is version_compare('2.7.9', operator='lt') )
+  tags:
+    - python2.7
+
+- name: Configure, build & make/make altinstall
+  shell: |
+    cd /tmp/Python-2.7.9 && ./configure --prefix=/usr/local && make && make altinstall
+  when:
+    - (ansible_distribution == "CentOS") and (ansible_distribution_major_version == "6")
+    - (python_version.rc != 0) or (python_version.rc == 0 and python_version.stdout is version_compare('2.7.9', operator='lt') )
+  tags:
+    - python2.7

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/adoptopenjdk_install/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/adoptopenjdk_install/tasks/main.yml
@@ -114,7 +114,7 @@
     dest: /usr/lib/jvm
     remote_src: yes
   vars:
-    - ansible_python_interpreter: /usr/local/bin/python2.7
+    - ansible_python_interpreter: /usr/local/python2/bin/python2.7
   retries: 3
   delay: 5
   register: adoptopenjdk_download

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/adoptopenjdk_install/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/adoptopenjdk_install/tasks/main.yml
@@ -106,6 +106,8 @@
     - adoptopenjdk_installed.rc != 0
   tags: adoptopenjdk_install
 
+# CentOS6 needs it's own task so it can use a different python interpreter.
+# See: https://github.com/AdoptOpenJDK/openjdk-infrastructure/issues/1877
 - name: Install latest release if not already installed (CentOS6)
   unarchive:
     src: https://api.adoptopenjdk.net/v3/binary/latest/{{ jdk_version }}/ga/linux/{{ api_architecture }}/jdk/{{ bootjdk }}/normal/adoptopenjdk?project=jdk

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/adoptopenjdk_install/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/adoptopenjdk_install/tasks/main.yml
@@ -101,7 +101,24 @@
   until: adoptopenjdk_download is not failed
   when:
     - ansible_distribution != "MacOSX"
+    - not (ansible_distribution == "CentOS" and ansible_distribution_major_version == "6")
     - ansible_os_family != "Solaris"
+    - adoptopenjdk_installed.rc != 0
+  tags: adoptopenjdk_install
+
+- name: Install latest release if not already installed (CentOS6)
+  unarchive:
+    src: https://api.adoptopenjdk.net/v3/binary/latest/{{ jdk_version }}/ga/linux/{{ api_architecture }}/jdk/{{ bootjdk }}/normal/adoptopenjdk?project=jdk
+    dest: /usr/lib/jvm
+    remote_src: yes
+  vars:
+    - ansible_python_interpreter: /usr/local/bin/python2.7
+  retries: 3
+  delay: 5
+  register: adoptopenjdk_download
+  until: adoptopenjdk_download is not failed
+  when:
+    - ansible_distribution == "CentOS" and ansible_distribution_major_version == "6"
     - adoptopenjdk_installed.rc != 0
   tags: adoptopenjdk_install
 


### PR DESCRIPTION
Fixes: #1877 

IT WORKS! (in VPC at least: https://ci.adoptopenjdk.net/job/VagrantPlaybookCheck/1067/ )

Installs Python 2.7 on CentOS6 and then uses that Python to run the `adoptopenjdk_install` tasks. See the referenced issue for what other things were tried or suggested. This solution also adds some future proofing somewhat, in that we can just use the Python2.7 whenever we have another `unarchive` / `get_url` cert issue because CentOS6 is old.

##### Checklist
<!-- For completed items, change [ ] to [x]. Leave unchecked if not required -->

- [x] commit message has one of the [standard prefixes](https://github.com/AdoptOpenJDK/openjdk-infrastructure/blob/master/FAQ.md#commit-messages)
- [ ] [FAQ.md](https://github.com/AdoptOpenJDK/openjdk-infrastructure/blob/master/FAQ.md) updated if appropriate
- [ ] other documentation is changed or added (if applicable)
- [x] playbook changes run through [VPC](https://ci.adoptopenjdk.net/view/Tooling/job/VagrantPlaybookCheck/) or [QPC](https://ci.adoptopenjdk.net/view/Tooling/job/QEMUPlaybookCheck/) (if you have access) : See above
- [ ] for inventory.yml changes, bastillion/nagios/jenkins updated accordingly
