### PR TITLE
GHChecks: Ansible-lint Ignore variables file

### DIFF
--- a/.ansible-lint
+++ b/.ansible-lint
@@ -12,3 +12,6 @@ skip_list:
   - '501'  # Become_user requires become to work as expected
   - '601'  # Don't compare to literal True/False
   - '602'  # Don't compare to empty string
+
+exclude_paths:
+  - ./ansible/playbooks/adoptopenjdk_variables.yml # See: https://github.com/AdoptOpenJDK/openjdk-infrastructure/issues/1926

--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -4,6 +4,7 @@ on:
   pull_request:
     paths:
     - ansible/**
+    - .ansible-lint
     branches:         
     - master
   push:


### PR DESCRIPTION
Fixes: #1926 

I was able to recreate the issue locally - Something is making ansible-lint run `ansible-playbook --syntax-check adoptopenjdk_variables.yml` - which is wrong because adoptopenjdk_variables is not a playbook. When the file is renamed, it complains that it can't find it, so somewhere, it is hardcoded that adoptopenjdk_variables.yml is a playbook and it's in the playbooks directory. I couldn't find anywhere that would suggest this, unfortunately, but excluding the path to the variable file manually seems to stop the error anyway.


##### Checklist
<!-- For completed items, change [ ] to [x]. Leave unchecked if not required -->

- [x] commit message has one of the [standard prefixes](https://github.com/AdoptOpenJDK/openjdk-infrastructure/blob/master/FAQ.md#commit-messages)
- [ ] [FAQ.md](https://github.com/AdoptOpenJDK/openjdk-infrastructure/blob/master/FAQ.md) updated if appropriate
- [ ] other documentation is changed or added (if applicable)
- [ ] playbook changes run through [VPC](https://ci.adoptopenjdk.net/view/Tooling/job/VagrantPlaybookCheck/) or [QPC](https://ci.adoptopenjdk.net/view/Tooling/job/QEMUPlaybookCheck/) (if you have access)
- [ ] for inventory.yml changes, bastillion/nagios/jenkins updated accordingly
