### PR TITLE
aixPB: Lock cmake from yum to 3.14.3

### DIFF
--- a/ansible/playbooks/AdoptOpenJDK_AIX_Playbook/roles/yum/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_AIX_Playbook/roles/yum/tasks/main.yml
@@ -45,6 +45,7 @@
     update_cache: yes
     name: '*'
     state: latest
+    exclude: cmake*
   tags:
     - yum
     #TODO: Package installs should not use latest
@@ -87,16 +88,34 @@
     - zsh
   tags: yum
 
-##############################################
-# Additional Tools not available through yum #
-##############################################
-- name: Install yum package support
-  yum: name={{ item }} state=present update_cache=yes
-  with_items:
-    - http://www.oss4aix.org/download/RPMS/cmake/cmake-3.7.2-1.aix6.1.ppc.rpm
+#######################################################
+# Additional Tools not available directly through yum #
+#######################################################
+- name: Confirm cmake prereqs have been installed
+  stat:
+    path: /opt/freeware/etc/rpm/macros.cmake
+  register: cmake_prereqs
   tags:
     - rpm_install
     - yum
+    - cmake
+
+# NOTE: Cannot use yum module here as it will pull in cmake 3.16 which we do not want
+- name: Install cmake 3.14.3 prerequisites if needed (Will generate yum warning)
+  command: rpm -i https://public.dhe.ibm.com/aix/freeSoftware/aixtoolbox/RPMS/ppc-7.1/cmake/cmake-rpm-macros-3.14.3-1.aix7.1.ppc.rpm  https://public.dhe.ibm.com/aix/freeSoftware/aixtoolbox/RPMS/ppc-7.1/cmake/cmake-filesystem-3.14.3-1.aix7.1.ppc.rpm
+  tags:
+    - rpm_install
+    - yum
+    - cmake
+  when: not cmake_prereqs.stat.exists
+
+# See https://github.com/AdoptOpenJDK/openjdk-build/issues/2492 for why we are locking this
+- name: Install cmake 3.14.3 (3.16 has problems)
+  yum: name=cmake-3.14.3 state=present update_cache=yes
+  tags:
+    - rpm_install
+    - yum
+    - cmake
 
 - name: Ensure perl from /opt/freeware/bin is the default in /usr/bin
   shell: mv /usr/bin/perl /usr/bin/perl.old && ln -s /opt/freeware/bin/perl /usr/bin/


### PR DESCRIPTION
Fixes https://github.com/AdoptOpenJDK/openjdk-build/issues/2492

Signed-off-by: Stewart X Addison <sxa@redhat.com>

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.
-->

##### Checklist
<!-- For completed items, change [ ] to [x]. Leave unchecked if not required -->

- [x] commit message has one of the [standard prefixes](https://github.com/AdoptOpenJDK/openjdk-infrastructure/blob/master/FAQ.md#commit-messages)
- [ ] [FAQ.md](https://github.com/AdoptOpenJDK/openjdk-infrastructure/blob/master/FAQ.md) updated if appropriate
- [ ] other documentation is changed or added (if applicable)
- [ ] playbook changes run through [VPC](https://ci.adoptopenjdk.net/view/Tooling/job/VagrantPlaybookCheck/) or [QPC](https://ci.adoptopenjdk.net/view/Tooling/job/QEMUPlaybookCheck/) (if you have access)
- [ ] for inventory.yml changes, bastillion/nagios/jenkins updated accordingly
