### PR TITLE
aixPB: Stop overwriting /usr/bin/perl with freeware on

### DIFF
--- a/ansible/playbooks/AdoptOpenJDK_AIX_Playbook/roles/yum/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_AIX_Playbook/roles/yum/tasks/main.yml
@@ -98,13 +98,6 @@
     - rpm_install
     - yum
 
-- name: Ensure perl from /opt/freeware/bin is the default in /usr/bin
-  shell: mv /usr/bin/perl /usr/bin/perl.old && ln -s /opt/freeware/bin/perl /usr/bin/
-  ignore_errors: True
-  tags:
-    - rpm_install
-    - yum
-
 # Create zlib.h and zconf.h links - See https://github.com/AdoptOpenJDK/openjdk-infrastructure/issues/1952
 
 - name: Checking for /opt/freeware/include/zlib.h


### PR DESCRIPTION
Draft PR to document what I've done for my own purposes if nothing else in case I forget :-)

By default AIX has `/usr/bin/perl` pointing to `/usr/opt/perl5/bin/perl5.28.1`. Our playbooks currently override this to the `/opt/freeware` one - this PR reverts that in order to use a standard AIX setup as far as possible. Particularly with the removal of perl as a requirement for the overall test frameworks I believe this may not be necessary. I have reset the symlink on [test-osuosl-aix71-ppc64-1](https://ci.adoptopenjdk.net/computer/test-osuosl-aix71-ppc64-1/) to see if it causes any problems - we need to make sure it doesn't before merging this (at which point we'll need to manually switch all the machines back to using the default. Some test Grinders as follows (although obviously it can run other stuff from the main pipelines) as it has the `ci.role.test` label:
- [sanity.system JDK8/J9](https://ci.adoptopenjdk.net/job/Grinder/7263)
- [extended.system JDK11/HotSpot](https://ci.adoptopenjdk.net/job/Grinder/7264)
- [sanity.openjdk JDK11/J9](https://ci.adoptopenjdk.net/job/Grinder/7284)
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.
-->

##### Checklist
<!-- For completed items, change [ ] to [x]. Leave unchecked if not required -->

- [ ] commit message has one of the [standard prefixes](https://github.com/AdoptOpenJDK/openjdk-infrastructure/blob/master/FAQ.md#commit-messages)
- [ ] [FAQ.md](https://github.com/AdoptOpenJDK/openjdk-infrastructure/blob/master/FAQ.md) updated if appropriate
- [ ] other documentation is changed or added (if applicable)
- [ ] playbook changes run through [VPC](https://ci.adoptopenjdk.net/view/Tooling/job/VagrantPlaybookCheck/) or [QPC](https://ci.adoptopenjdk.net/view/Tooling/job/QEMUPlaybookCheck/) (if you have access)
- [ ] for inventory.yml changes, bastillion/nagios/jenkins updated accordingly
