### PR TITLE
UnixPB: Install Zulu-7 on Ubuntu1604

### DIFF
--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/vars/Ubuntu.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/vars/Ubuntu.yml
@@ -68,8 +68,6 @@ Additional_Packages_Ubuntu16:
   - xserver-xorg-legacy                 # Not actually sure if this is still needed
   - libgstreamer0.10-dev                # OpenJFX prereq
   - libgstreamer-plugins-base0.10-dev   # OpenJFX prereq
-  - openjdk-7-jdk
-  - openjdk-8-jdk
   - libmpfr4
   - libmpfr4-dbg
 

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/zulu7/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/zulu7/tasks/main.yml
@@ -28,7 +28,7 @@
   when:
     - ansible_architecture == "x86_64"
     - ((ansible_distribution == "Redhat" or ansible_distribution == "CentOS") and (ansible_distribution_major_version|int >= 8)) or
-      (ansible_distribution == "Ubuntu" and ansible_distribution_major_version|int >= 16) or
+      (ansible_distribution == "Ubuntu") or
       (ansible_distribution == "Debian" and ansible_distribution_major_version|int >= 10)
   tags: zulu7
 
@@ -40,7 +40,7 @@
   when:
     - ansible_architecture == "x86_64"
     - ((ansible_distribution == "Redhat" or ansible_distribution == "CentOS") and (ansible_distribution_major_version|int >= 8)) or
-      (ansible_distribution == "Ubuntu" and ansible_distribution_major_version|int >= 16) or
+      (ansible_distribution == "Ubuntu") or
       (ansible_distribution == "Debian" and ansible_distribution_major_version|int >= 10)
     - zulu7_installed.rc != 0
   tags: zulu7
@@ -53,7 +53,7 @@
   when:
     - ansible_architecture == "x86_64"
     - ((ansible_distribution == "Redhat" or ansible_distribution == "CentOS") and (ansible_distribution_major_version|int >= 8)) or
-      (ansible_distribution == "Ubuntu" and ansible_distribution_major_version|int >= 16) or
+      (ansible_distribution == "Ubuntu") or
       (ansible_distribution == "Debian" and ansible_distribution_major_version|int >= 10)
     - zulu7_installed.rc != 0
   tags: zulu7

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/zulu7/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/zulu7/tasks/main.yml
@@ -4,7 +4,7 @@
 ##########
 
 # Install zulu-7 for OSs that don't have openjdk-7 available in their package manager:
-#  CentOS/RHEL 8, Debian 10, Ubuntu1804, openSUSE/SLES 12 (only tested for x86_64)
+#  CentOS/RHEL 8, Debian 10, Ubuntu1604+, openSUSE/SLES 12 (only tested for x86_64)
 
 - name: Checking for /usr/lib/jvm
   stat: path=/usr/lib/jvm
@@ -28,7 +28,7 @@
   when:
     - ansible_architecture == "x86_64"
     - ((ansible_distribution == "Redhat" or ansible_distribution == "CentOS") and (ansible_distribution_major_version|int >= 8)) or
-      (ansible_distribution == "Ubuntu" and ansible_distribution_major_version|int >= 18) or
+      (ansible_distribution == "Ubuntu" and ansible_distribution_major_version|int >= 16) or
       (ansible_distribution == "Debian" and ansible_distribution_major_version|int >= 10)
   tags: zulu7
 
@@ -40,7 +40,7 @@
   when:
     - ansible_architecture == "x86_64"
     - ((ansible_distribution == "Redhat" or ansible_distribution == "CentOS") and (ansible_distribution_major_version|int >= 8)) or
-      (ansible_distribution == "Ubuntu" and ansible_distribution_major_version|int >= 18) or
+      (ansible_distribution == "Ubuntu" and ansible_distribution_major_version|int >= 16) or
       (ansible_distribution == "Debian" and ansible_distribution_major_version|int >= 10)
     - zulu7_installed.rc != 0
   tags: zulu7
@@ -53,7 +53,7 @@
   when:
     - ansible_architecture == "x86_64"
     - ((ansible_distribution == "Redhat" or ansible_distribution == "CentOS") and (ansible_distribution_major_version|int >= 8)) or
-      (ansible_distribution == "Ubuntu" and ansible_distribution_major_version|int >= 18) or
+      (ansible_distribution == "Ubuntu" and ansible_distribution_major_version|int >= 16) or
       (ansible_distribution == "Debian" and ansible_distribution_major_version|int >= 10)
     - zulu7_installed.rc != 0
   tags: zulu7


### PR DESCRIPTION
Fixes: #1983 

Adds U16 to the list of OSs that install Zulu-7. This PR also removes the unnecessary `openjdk-8-jdk` in the `Ubuntu1604 Only` package list, as it's already in the Common build packages list.

##### Checklist
<!-- For completed items, change [ ] to [x]. Leave unchecked if not required -->

- [x] commit message has one of the [standard prefixes](https://github.com/AdoptOpenJDK/openjdk-infrastructure/blob/master/FAQ.md#commit-messages)
- [ ] [FAQ.md](https://github.com/AdoptOpenJDK/openjdk-infrastructure/blob/master/FAQ.md) updated if appropriate
- [ ] other documentation is changed or added (if applicable)
- [ ] playbook changes run through [VPC](https://ci.adoptopenjdk.net/view/Tooling/job/VagrantPlaybookCheck/) or [QPC](https://ci.adoptopenjdk.net/view/Tooling/job/QEMUPlaybookCheck/) (if you have access) 
- [ ] for inventory.yml changes, bastillion/nagios/jenkins updated accordingly
