### PR TITLE
inventory: Remove test-azure-win2012r2-x64-2

### DIFF
--- a/ansible/inventory.yml
+++ b/ansible/inventory.yml
@@ -101,7 +101,6 @@ hosts:
 
       - azure:
           win2012r2-x64-1: {ip: 13.68.134.204, user: adoptopenjdk}
-          win2012r2-x64-2: {ip: 40.121.164.56, user: adoptopenjdk}
           win2012r2-x64-3: {ip: 13.68.219.237, user: adoptopenjdk}
           win2016-x64-1: {ip: 52.149.211.210, user: adoptopenjdk}
           win2019-x64-1: {ip: 20.185.182.137, user: adoptopenjdk}


### PR DESCRIPTION
Ref: https://github.com/AdoptOpenJDK/openjdk-infrastructure/issues/1963#issuecomment-787903034

Signed-off-by: Stewart X Addison <sxa@redhat.com>

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.
-->

##### Checklist
<!-- For completed items, change [ ] to [x]. Leave unchecked if not required -->

- [x] commit message has one of the [standard prefixes](https://github.com/AdoptOpenJDK/openjdk-infrastructure/blob/master/FAQ.md#commit-messages)
- [ ] [FAQ.md](https://github.com/AdoptOpenJDK/openjdk-infrastructure/blob/master/FAQ.md) updated if appropriate
- [ ] other documentation is changed or added (if applicable)
- [ ] playbook changes run through [VPC](https://ci.adoptopenjdk.net/view/Tooling/job/VagrantPlaybookCheck/) or [QPC](https://ci.adoptopenjdk.net/view/Tooling/job/QEMUPlaybookCheck/) (if you have access)
- [x] for inventory.yml changes, ~bastillion/nagios/~ jenkins updated accordingly

