### PR TITLE
UnixPb: change ansible_default_ipv4.address variable to ansible_host

### DIFF
--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/tasks/main.yml
@@ -3,15 +3,6 @@
 # Main #
 ########
 
-###########################
-# Overide amd64 to x86_64 #
-###########################
-- name: If ansible_architecture is amd64 set it to x86_64
-  set_fact:
-    ansible_architecture: "x86_64"
-  when:
-    - ansible_architecture == "amd64"
-
 ###############################
 # Set ansible_processor_vcpus #
 ###############################
@@ -23,94 +14,6 @@
   tags:
     - cmake
     - git_source
-
-##################
-# Set root group #
-##################
-- name: Set default root group to root
-  set_fact:
-    root_group: "root"
-
-################
-# Set Hostname #
-################
-- name: Set hostname to inventory_hostname
-  hostname:
-    name: "{{ inventory_hostname }}.{{ Domain }}"
-  when:
-    - Domain == "adoptopenjdk.net" and ansible_distribution != "MacOSX" and ansible_distribution != "Solaris"
-    - inventory_hostname != ansible_default_ipv4.address
-    - inventory_hostname != "localhost"
-  tags: hostname,adoptopenjdk
-
-- name: Set hostname to inventory_hostname (macOS)
-  command: "{{ item }}"
-  with_items:
-    - "sudo scutil --set HostName {{ inventory_hostname }}.adoptopenjdk.net"
-    - "sudo scutil --set ComputerName {{ inventory_hostname }}.adoptopenjdk.net"
-    - "dscacheutil -flushcache"
-  when:
-    - Domain == "adoptopenjdk.net" and ansible_distribution == "MacOSX"
-    - inventory_hostname != ansible_default_ipv4.address
-    - inventory_hostname != "localhost"
-  tags: hostname,adoptopenjdk
-
-- name: Set hostname to inventory_hostname (Solaris)
-  shell: "{{ item }}"
-  with_items:
-    - echo "{{ inventory_hostname }}" > /etc/nodename
-    - echo "{{ inventory_hostname }}" > /etc/hostname.e1000g0
-    - uname -S "{{ inventory_hostname }}"
-  when: Domain == "adoptopenjdk.net" and ansible_distribution == "Solaris"
-  register: foo
-  tags: hostname,adoptopenjdk
-
-#####################
-# Update /etc/hosts #
-#####################
-- name: Update /etc/hosts file - IP FQDN hostname
-  lineinfile:
-    dest: /etc/hosts
-    regexp: "^(.*){{ ansible_hostname }}(.*)$"
-    line: "{{ ansible_default_ipv4.address }} {{ inventory_hostname }}.{{ Domain }} {{ inventory_hostname }}"
-    state: present
-  when:
-    - Domain == "adoptopenjdk.net"
-    - inventory_hostname != ansible_default_ipv4.address
-    - inventory_hostname != "localhost"
-  tags: hosts_file, adoptopenjdk
-
-- name: Update /etc/hosts file - IP FQDN hostname (Domain != "adoptopenjdk.net")
-  lineinfile:
-    dest: /etc/hosts
-    regexp: "^(.*){{ ansible_hostname }}(.*)$"
-    line: "{{ ansible_default_ipv4.address }} {{ ansible_fqdn }} {{ ansible_hostname }}"
-    state: present
-  when:
-    - Domain != "adoptopenjdk.net"
-    - inventory_hostname != ansible_default_ipv4.address
-    - inventory_hostname != "localhost"
-  tags: hosts_file, adoptopenjdk
-
-- debug:
-    msg: "Inventory_hostname is the same as the ip address or is localhost.
-    The fqdn has not been added to /etc/hosts.
-    The hostname of the machine has not been updated.
-    Manually add the fqdn to /etc/hosts
-    and manually update the hostname in /etc/hostname.
-    Or use the command line argument --extra-vars 'inventory_hostname=<realhostname>',
-    when running the playbook next time"
-  when: (inventory_hostname == ansible_default_ipv4.address) or (inventory_hostname == "localhost")
-  tags: hosts_file, hostname
-
-- name: Update /etc/hosts file - 127.0.0.1
-  lineinfile:
-    dest: /etc/hosts
-    regexp: "^(.*)127.0.0.1(.*)$"
-    line: "127.0.0.1   localhost  localhost.localdomain"
-    state: present
-    backup: yes
-  tags: hosts_file, adoptopenjdk
 
 ########################
 # Include OS variables #

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Debug/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Debug/tasks/main.yml
@@ -10,7 +10,7 @@
       - "ansible_fqdn: {{ ansible_fqdn | default('***Undefined***') }}"
       - "ansible_user: {{ ansible_user | default('***Undefined***') }}"
       - "ansible_default_ipv4.address: {{ ansible_default_ipv4.address | default('***Undefined***') }}"
-      - "ansible_ssh_host: {{ ansible_ssh_host }}"
+      - "ansible_host: {{ ansible_host }}"
       - "ansible_os_family: {{ ansible_os_family | default('***Undefined***') }} "
       - "ansible_distribution: {{ ansible_distribution | default('***Undefined***') }} "
       - "ansible_distribution_major_version: {{ ansible_distribution_major_version | default('***Undefined***') }} "

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Debug/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Debug/tasks/main.yml
@@ -10,6 +10,7 @@
       - "ansible_fqdn: {{ ansible_fqdn | default('***Undefined***') }}"
       - "ansible_user: {{ ansible_user | default('***Undefined***') }}"
       - "ansible_default_ipv4.address: {{ ansible_default_ipv4.address | default('***Undefined***') }}"
+      - "ansible_ssh_host: {{ ansible_ssh_host }}"
       - "ansible_os_family: {{ ansible_os_family | default('***Undefined***') }} "
       - "ansible_distribution: {{ ansible_distribution | default('***Undefined***') }} "
       - "ansible_distribution_major_version: {{ ansible_distribution_major_version | default('***Undefined***') }} "

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Debug/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Debug/tasks/main.yml
@@ -10,7 +10,7 @@
       - "ansible_fqdn: {{ ansible_fqdn | default('***Undefined***') }}"
       - "ansible_user: {{ ansible_user | default('***Undefined***') }}"
       - "ansible_default_ipv4.address: {{ ansible_default_ipv4.address | default('***Undefined***') }}"
-      - "ansible_host: {{ ansible_host }}"
+      - "ansible_host: {{ ansible_host | default('***Undefined***') }}"
       - "ansible_os_family: {{ ansible_os_family | default('***Undefined***') }} "
       - "ansible_distribution: {{ ansible_distribution | default('***Undefined***') }} "
       - "ansible_distribution_major_version: {{ ansible_distribution_major_version | default('***Undefined***') }} "

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/adopt_etc/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/adopt_etc/tasks/main.yml
@@ -28,7 +28,7 @@
   when:
     - Domain == "adoptopenjdk.net" and ansible_distribution != "MacOSX" and ansible_distribution != "Solaris"
     - inventory_hostname != ansible_default_ipv4.address
-    - inventory_hostname != ansible_ssh_host
+    - inventory_hostname != ansible_host
     - inventory_hostname != "localhost"
   tags: hostname,adoptopenjdk
 
@@ -61,12 +61,12 @@
   lineinfile:
     dest: /etc/hosts
     regexp: "^(.*){{ ansible_hostname }}(.*)$"
-    line: "{{ ansible_ssh_host }} {{ inventory_hostname }}.{{ Domain }} {{ inventory_hostname }}"
+    line: "{{ ansible_host }} {{ inventory_hostname }}.{{ Domain }} {{ inventory_hostname }}"
     state: present
   when:
     - Domain == "adoptopenjdk.net"
     - inventory_hostname != ansible_default_ipv4.address
-    - inventory_hostname != ansible_ssh_host
+    - inventory_hostname != ansible_host
     - inventory_hostname != "localhost"
   tags: hosts_file, adoptopenjdk
 
@@ -74,12 +74,12 @@
   lineinfile:
     dest: /etc/hosts
     regexp: "^(.*){{ ansible_hostname }}(.*)$"
-    line: "{{ ansible_ssh_host }} {{ ansible_fqdn }} {{ ansible_hostname }}"
+    line: "{{ ansible_host }} {{ ansible_fqdn }} {{ ansible_hostname }}"
     state: present
   when:
     - Domain != "adoptopenjdk.net"
     - inventory_hostname != ansible_default_ipv4.address
-    - inventory_hostname != ansible_ssh_host
+    - inventory_hostname != ansible_host
     - inventory_hostname != "localhost"
   tags: hosts_file, adoptopenjdk
 
@@ -91,7 +91,7 @@
     and manually update the hostname in /etc/hostname.
     Or use the command line argument --extra-vars 'inventory_hostname=<realhostname>',
     when running the playbook next time"
-  when: (inventory_hostname == ansible_default_ipv4.address) or (inventory_hostname == "localhost") or (inventory_hostname != ansible_ssh_host)
+  when: (inventory_hostname == ansible_default_ipv4.address) or (inventory_hostname == "localhost") or (inventory_hostname == ansible_host)
   tags: hosts_file, hostname
 
 - name: Update /etc/hosts file - 127.0.0.1

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/adopt_etc/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/adopt_etc/tasks/main.yml
@@ -27,7 +27,6 @@
     name: "{{ inventory_hostname }}.{{ Domain }}"
   when:
     - Domain == "adoptopenjdk.net" and ansible_distribution != "MacOSX" and ansible_distribution != "Solaris"
-    - inventory_hostname != ansible_default_ipv4.address
     - inventory_hostname != ansible_host
     - inventory_hostname != "localhost"
   tags: hostname,adoptopenjdk
@@ -40,7 +39,7 @@
     - "dscacheutil -flushcache"
   when:
     - Domain == "adoptopenjdk.net" and ansible_distribution == "MacOSX"
-    - inventory_hostname != ansible_default_ipv4.address
+    - inventory_hostname != ansible_host
     - inventory_hostname != "localhost"
   tags: hostname,adoptopenjdk
 
@@ -65,8 +64,8 @@
     state: present
   when:
     - Domain == "adoptopenjdk.net"
-    - inventory_hostname != ansible_default_ipv4.address
     - inventory_hostname != ansible_host
+    - ansible_host != "127.0.0.1"
     - inventory_hostname != "localhost"
   tags: hosts_file, adoptopenjdk
 
@@ -78,8 +77,8 @@
     state: present
   when:
     - Domain != "adoptopenjdk.net"
-    - inventory_hostname != ansible_default_ipv4.address
     - inventory_hostname != ansible_host
+    - ansible_host != "127.0.0.1"
     - inventory_hostname != "localhost"
   tags: hosts_file, adoptopenjdk
 
@@ -91,7 +90,7 @@
     and manually update the hostname in /etc/hostname.
     Or use the command line argument --extra-vars 'inventory_hostname=<realhostname>',
     when running the playbook next time"
-  when: (inventory_hostname == ansible_default_ipv4.address) or (inventory_hostname == "localhost") or (inventory_hostname == ansible_host)
+  when: (inventory_hostname == "localhost") or (inventory_hostname == ansible_host) or (ansible_host == "127.0.0.1")
   tags: hosts_file, hostname
 
 - name: Update /etc/hosts file - 127.0.0.1

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/adopt_etc/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/adopt_etc/tasks/main.yml
@@ -28,6 +28,7 @@
   when:
     - Domain == "adoptopenjdk.net" and ansible_distribution != "MacOSX" and ansible_distribution != "Solaris"
     - inventory_hostname != ansible_default_ipv4.address
+    - inventory_hostname != ansible_ssh_host
     - inventory_hostname != "localhost"
   tags: hostname,adoptopenjdk
 
@@ -60,11 +61,12 @@
   lineinfile:
     dest: /etc/hosts
     regexp: "^(.*){{ ansible_hostname }}(.*)$"
-    line: "{{ ansible_default_ipv4.address }} {{ inventory_hostname }}.{{ Domain }} {{ inventory_hostname }}"
+    line: "{{ ansible_ssh_host }} {{ inventory_hostname }}.{{ Domain }} {{ inventory_hostname }}"
     state: present
   when:
     - Domain == "adoptopenjdk.net"
     - inventory_hostname != ansible_default_ipv4.address
+    - inventory_hostname != ansible_ssh_host
     - inventory_hostname != "localhost"
   tags: hosts_file, adoptopenjdk
 
@@ -72,11 +74,12 @@
   lineinfile:
     dest: /etc/hosts
     regexp: "^(.*){{ ansible_hostname }}(.*)$"
-    line: "{{ ansible_default_ipv4.address }} {{ ansible_fqdn }} {{ ansible_hostname }}"
+    line: "{{ ansible_ssh_host }} {{ ansible_fqdn }} {{ ansible_hostname }}"
     state: present
   when:
     - Domain != "adoptopenjdk.net"
     - inventory_hostname != ansible_default_ipv4.address
+    - inventory_hostname != ansible_ssh_host
     - inventory_hostname != "localhost"
   tags: hosts_file, adoptopenjdk
 
@@ -88,7 +91,7 @@
     and manually update the hostname in /etc/hostname.
     Or use the command line argument --extra-vars 'inventory_hostname=<realhostname>',
     when running the playbook next time"
-  when: (inventory_hostname == ansible_default_ipv4.address) or (inventory_hostname == "localhost")
+  when: (inventory_hostname == ansible_default_ipv4.address) or (inventory_hostname == "localhost") or (inventory_hostname != ansible_ssh_host)
   tags: hosts_file, hostname
 
 - name: Update /etc/hosts file - 127.0.0.1


### PR DESCRIPTION
ref https://github.com/AdoptOpenJDK/openjdk-infrastructure/issues/1994

On some machines (build-scaleway-ubuntu1604-armv7-1 and -2) ansible_default_ipv4.address isnt able to detect the public ip, but instead detects the private ip.

This causes problems with the `hosts_file` tagged tasks which enter lines in `/etc/hosts` based on the ansible_default_ipv4.address variable. Therefore I have changed this variable to ansible_ssh_host, which I have found better detects the public ipv4 of a machine. 

The line that ive added to the `Debug` role will be removed after I have adequately tested this pr

Tests list:

- [x] Suitable for scaleway machine test case
- [x] Does `ansible_host` detect ip or hostname?
- [x] Localhost test case
- [x] `inventory_hostname != ansible_default_ipv4.address` redundant?