### PR TITLE
unixPB: Fix Swapfile detection

### DIFF
--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Swap_File/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Swap_File/tasks/main.yml
@@ -9,14 +9,6 @@
 # Not installed: When swap_root.rc or swap_tmp.rc does NOT equal 0
 # Assume swap path of /swapfile override where applicable
 
-- name: Test if swapfile exists
-  command: grep swap /etc/fstab
-  ignore_errors: yes
-  register: swap_exists
-  tags:
-    - swap_file
-    - skip_ansible_lint
-
 - name: Set Swapfile path - /swapfile
   set_fact:
     swap_path: /swapfile
@@ -29,10 +21,16 @@
     - (ansible_distribution_major_version == "9" and ansible_architecture == "armv7l")
   tags: swap_file
 
+- name: Check if Swapfile exists
+  stat:
+    path: "{{ swap_path }}"
+  register: swap_exists
+  tags: swap_file
+
 - name: Display swapfile Debug Information
   debug:
     msg:
-      - "swap_path: {{ swap_path | default('***Undefined***') }} "
+      - "swap_path: {{ swap_path.stat.exists | default('***Undefined***') }} "
       - "swap_exists: {{ swap_exists.rc | default('***Undefined***') }} "
   tags: swap_file
 
@@ -46,38 +44,37 @@
 - name: Create swap file - via DD
   command: "dd if=/dev/zero of=/{{ swap_path }} bs=250M count=8"
   when:
-    - (swap_exists.rc != 0)
+    - not (swap_exists.stat.exists)
   tags: swap_file
 
 - name: Set swap file permissions
-  file: path="{{ swap_path }}"
-        owner=root
-        group="{{ root_group }}"
-        mode=0600
+  file: 
+    path: "{{ swap_path }}"
+    owner: root
+    group: "{{ root_group }}"
+    mode: 0600
   when:
-    - (swap_exists.rc != 0)
+    - not (swap_exists.stat.exists)
   tags: swap_file
 
 - name: Create swap area device
   command: "mkswap {{ swap_path }}"
   when:
-    - (swap_exists.rc != 0)
+    - not (swap_exists.stat.exists)
   tags: swap_file
 
 - name: Mount swap file
   command: "swapon {{ swap_path }}"
   when:
-    - (swap_exists.rc != 0)
+    - not (swap_exists.stat.exists)
   tags: swap_file
 
 - name: Add swap to fstab
-  mount: src="{{ swap_path }}"
-    name=none
-    fstype=swap
-    opts=sw
-    passno=0
-    dump=0
-    state=present
+  mount: 
+    src: "{{ swap_path }}"
+    fstype: swap
+    opts: sw
+    state: present
   when:
     - (swap_exists.rc != 0)
   tags: swap_file

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Swap_File/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Swap_File/tasks/main.yml
@@ -76,5 +76,5 @@
     opts: sw
     state: present
   when:
-    - (swap_exists.rc != 0)
+    - not (swap_exists.stat.exists)
   tags: swap_file

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Swap_File/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Swap_File/tasks/main.yml
@@ -69,8 +69,11 @@
     - not (swap_exists.stat.exists)
   tags: swap_file
 
+# 'path' is apparently required, as is 'src' when 'state: present'
+# See: https://docs.ansible.com/ansible/latest/collections/ansible/posix/mount_module.html
 - name: Add swap to fstab
   mount:
+    path: none
     src: "{{ swap_path }}"
     fstype: swap
     opts: sw


### PR DESCRIPTION
Ref: https://github.com/AdoptOpenJDK/openjdk-infrastructure/issues/1990#issuecomment-789549739

This _should_ fix the Swap File issue we're having, see the referenced issue. The issue for the affected machine(s) (`build-scaleway-ubuntu1604-armv7-*`) was that when running `$ cat /etc/fstab`, this was being returned: `# UNCONFIGURED FSTAB FOR BASE SYSTEM` - so the `grep` check failed, so the tasks following attempted to create the swapfile whilst it's in use.

I also changed some of the tasks to fit the format we have for the rest of the playbooks.   

##### Checklist
<!-- For completed items, change [ ] to [x]. Leave unchecked if not required -->

- [x] commit message has one of the [standard prefixes](https://github.com/AdoptOpenJDK/openjdk-infrastructure/blob/master/FAQ.md#commit-messages)
- [ ] [FAQ.md](https://github.com/AdoptOpenJDK/openjdk-infrastructure/blob/master/FAQ.md) updated if appropriate
- [ ] other documentation is changed or added (if applicable)
- [x] playbook changes run through [VPC](https://ci.adoptopenjdk.net/view/Tooling/job/VagrantPlaybookCheck/) or [QPC](https://ci.adoptopenjdk.net/view/Tooling/job/QEMUPlaybookCheck/) (if you have access) : https://ci.adoptopenjdk.net/job/VagrantPlaybookCheck/1092/
- [ ] for inventory.yml changes, bastillion/nagios/jenkins updated accordingly
