### PR TITLE
unixPB: Various small fixes to get AWX running cleanly

### DIFF
--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/tasks/RedHat.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/tasks/RedHat.yml
@@ -38,8 +38,8 @@
     packages:
       - http://mirror.centos.org/altarch/7/os/aarch64/Packages/libdwarf-devel-20130207-4.el7.aarch64.rpm
       - http://mirror.centos.org/altarch/7/os/aarch64/Packages/libmpc-devel-1.0.1-3.el7.aarch64.rpm
-      - http://mirror.centos.org/altarch/7/os/aarch64/Packages/xorg-x11-server-common-1.20.4-7.el7.aarch64.rpm
-      - http://mirror.centos.org/altarch/7/os/aarch64/Packages/xorg-x11-server-Xvfb-1.20.4-7.el7.aarch64.rpm
+      - http://mirror.centos.org/altarch/7/os/aarch64/Packages/xorg-x11-server-common-1.20.4-10.el7.aarch64.rpm
+      - http://mirror.centos.org/altarch/7/os/aarch64/Packages/xorg-x11-server-Xvfb-1.20.4-10.el7.aarch64.rpm
   when:
     - (ansible_distribution_major_version == "7" and ansible_architecture == "aarch64")
   tags: build_tools, test_tools

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/tasks/RedHat.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/tasks/RedHat.yml
@@ -194,20 +194,10 @@
 # Locales #
 ###########
 
-- name: Install 'locales' package
-  package:
-    name: locales
-    state: present
-  when:
-    - (ansible_distribution_major_version is version_compare('7', operator='lt'))
-  tags: locales
-
 - name: Install 'glibc-common' package
   package:
     name: glibc-common
     state: present
-  when:
-    - (ansible_distribution_major_version is version_compare('7', operator='ge'))
   tags: locales
 
 # Skipping linting as no alternative to shell can be used (lint error 305)

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Nagios_Plugins/tasks/nagios_RedHat.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Nagios_Plugins/tasks/nagios_RedHat.yml
@@ -28,6 +28,15 @@
   when:
     - ansible_distribution_major_version != "6"
     - not (ansible_distribution_major_version == "7" and ansible_architecture == "s390x")
+    - not (ansible_distribution_major_version == "8" and ansible_architecture == "x86_64")
+  tags: nagios_plugins
+
+- name: Install nagios-plugins (RHEL8/x64)
+  yum:
+    name: nagios-plugins
+    state: latest
+  when:
+    - ansible_distribution_major_version == "8" and ansible_architecture == "x86_64"
   tags: nagios_plugins
 
 ##########


### PR DESCRIPTION
Ref: https://github.com/AdoptOpenJDK/openjdk-infrastructure/issues/1990#issuecomment-790422413

Various issues found when running the playbooks on all the machines:
  - Remove installation of locales for RHEL, entirely. `glibc-common` provides the locale specific functions now, it seems.
  - Update some URLs for dependencies for RHEL7 aarch64 (The version has been updated in the package repo)
  - Install `nagios-plugins` for RHEL8/x64, as opposed to `nagios-plugins-all`, as the latter has some dependencies that can be fulfilled.

I'm sure there will be more once I've done the AWX `test*centos*` and `test*ubuntu*` runs, so I'll keep this in draft for now. 

##### Checklist
<!-- For completed items, change [ ] to [x]. Leave unchecked if not required -->

- [x] commit message has one of the [standard prefixes](https://github.com/AdoptOpenJDK/openjdk-infrastructure/blob/master/FAQ.md#commit-messages)
- [ ] [FAQ.md](https://github.com/AdoptOpenJDK/openjdk-infrastructure/blob/master/FAQ.md) updated if appropriate
- [ ] other documentation is changed or added (if applicable)
- [ ] playbook changes run through [VPC](https://ci.adoptopenjdk.net/view/Tooling/job/VagrantPlaybookCheck/) or [QPC](https://ci.adoptopenjdk.net/view/Tooling/job/QEMUPlaybookCheck/) (if you have access)
- [ ] for inventory.yml changes, bastillion/nagios/jenkins updated accordingly
