### PR TITLE
UnixPB: Install Python 2.7.18 on RHEL6

### DIFF
--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Python2.7/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Python2.7/tasks/main.yml
@@ -11,7 +11,7 @@
   register: python_version
   ignore_errors: yes
   when:
-    - (ansible_distribution == "CentOS") and (ansible_distribution_major_version == "6")
+    - (ansible_distribution == "CentOS" or ansible_distribution == "RedHat") and (ansible_distribution_major_version == "6")
   tags:
     - python2.7
 
@@ -26,7 +26,7 @@
   register: python_download
   until: python_download is not failed
   when:
-    - (ansible_distribution == "CentOS") and (ansible_distribution_major_version == "6")
+    - (ansible_distribution == "CentOS" or ansible_distribution == "RedHat") and (ansible_distribution_major_version == "6")
     - (python_version.rc != 0) or (python_version.rc == 0 and python_version.stdout is version_compare('2.7.18', operator='lt'))
   tags:
     - python2.7


### PR DESCRIPTION
ref: https://github.com/AdoptOpenJDK/openjdk-infrastructure/issues/1990#issuecomment-792653280

RHEL6 needs Python 2.7.* on it too, for the `adoptopenjdk_install` role.

##### Checklist
<!-- For completed items, change [ ] to [x]. Leave unchecked if not required -->

- [x] commit message has one of the [standard prefixes](https://github.com/AdoptOpenJDK/openjdk-infrastructure/blob/master/FAQ.md#commit-messages)
- [ ] [FAQ.md](https://github.com/AdoptOpenJDK/openjdk-infrastructure/blob/master/FAQ.md) updated if appropriate
- [ ] other documentation is changed or added (if applicable)
- [ ] playbook changes run through [VPC](https://ci.adoptopenjdk.net/view/Tooling/job/VagrantPlaybookCheck/) or [QPC](https://ci.adoptopenjdk.net/view/Tooling/job/QEMUPlaybookCheck/) : No RHEL6 platform to test on.
- [ ] for inventory.yml changes, bastillion/nagios/jenkins updated accordingly
