### PR TITLE
unixPB: Check Nagios Plugins folder for RedHat

### DIFF
--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Nagios_Plugins/tasks/nagios_RedHat.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Nagios_Plugins/tasks/nagios_RedHat.yml
@@ -49,11 +49,18 @@
     - not (ansible_distribution_major_version == "7" and ansible_architecture == "s390x")
   tags: nagios_plugins
 
+- name: Check if plugins folder is where its expected
+  stat:
+    path: /usr/local/nagios/libexec/check_by_ssh
+  register: plugins_folder
+  tags: nagios_plugins
+
 - name: Create symlink to plugins
   file: src=/usr/lib64/nagios/plugins dest=/usr/local/nagios/libexec state=link
   when:
     - ansible_distribution_major_version != "6"
     - not (ansible_distribution_major_version == "7" and ansible_architecture == "s390x")
+    - not plugins_folder.stat.exists
   tags: nagios_plugins
 
 #############################


### PR DESCRIPTION
Ref: https://github.com/AdoptOpenJDK/openjdk-infrastructure/issues/1990#issuecomment-792649133

The reason this task failed was because the plugins for RHEL8 were already there. Therefore, it should be checked if the plugins are already there, before we make the symlinks. I didn't make this specific to any one distribution, as I don't know if this will change depending on various architectures (or different versions of the `nagios-plugins` package).

##### Checklist
<!-- For completed items, change [ ] to [x]. Leave unchecked if not required -->

- [x] commit message has one of the [standard prefixes](https://github.com/AdoptOpenJDK/openjdk-infrastructure/blob/master/FAQ.md#commit-messages)
- [ ] [FAQ.md](https://github.com/AdoptOpenJDK/openjdk-infrastructure/blob/master/FAQ.md) updated if appropriate
- [ ] other documentation is changed or added (if applicable)
- [ ] playbook changes run through [VPC](https://ci.adoptopenjdk.net/view/Tooling/job/VagrantPlaybookCheck/) or [QPC](https://ci.adoptopenjdk.net/view/Tooling/job/QEMUPlaybookCheck/) (if you have access) : Don't have any RHEL distributions in VPC or QPC.
- [ ] for inventory.yml changes, bastillion/nagios/jenkins updated accordingly
