### PR TITLE
unixPB: Use alt JDK install for RHEL6

### DIFF
--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/adoptopenjdk_install/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/adoptopenjdk_install/tasks/main.yml
@@ -101,7 +101,7 @@
   until: adoptopenjdk_download is not failed
   when:
     - ansible_distribution != "MacOSX"
-    - not (ansible_distribution == "CentOS" and ansible_distribution_major_version == "6")
+    - not ((ansible_distribution == "RedHat" or ansible_distribution == "CentOS") and ansible_distribution_major_version == "6")
     - ansible_os_family != "Solaris"
     - adoptopenjdk_installed.rc != 0
   tags: adoptopenjdk_install
@@ -120,7 +120,7 @@
   register: adoptopenjdk_download
   until: adoptopenjdk_download is not failed
   when:
-    - ansible_distribution == "CentOS" and ansible_distribution_major_version == "6"
+    - (ansible_distribution == "RedHat" or ansible_distribution == "CentOS") and ansible_distribution_major_version == "6"
     - adoptopenjdk_installed.rc != 0
   tags: adoptopenjdk_install
 


### PR DESCRIPTION
ref: https://github.com/AdoptOpenJDK/openjdk-infrastructure/issues/1990#issuecomment-793480995

As the comment says, RHEL6 needs to install AdoptOpenJDK with the same task that CentOS6 uses, so it can use the right interpreter.

##### Checklist
<!-- For completed items, change [ ] to [x]. Leave unchecked if not required -->

- [x] commit message has one of the [standard prefixes](https://github.com/AdoptOpenJDK/openjdk-infrastructure/blob/master/FAQ.md#commit-messages)
- [ ] [FAQ.md](https://github.com/AdoptOpenJDK/openjdk-infrastructure/blob/master/FAQ.md) updated if appropriate
- [ ] other documentation is changed or added (if applicable)
- [ ] playbook changes run through [VPC](https://ci.adoptopenjdk.net/view/Tooling/job/VagrantPlaybookCheck/) or [QPC](https://ci.adoptopenjdk.net/view/Tooling/job/QEMUPlaybookCheck/) (if you have access): No RHEL in VPC or QPC
- [ ] for inventory.yml changes, bastillion/nagios/jenkins updated accordingly
