### PR TITLE
aixPB: fix minimum size test to real minimum of 60G, exit 1 on fail

### DIFF
--- a/ansible/playbooks/scripts/AIX_filesystem_config.sh
+++ b/ansible/playbooks/scripts/AIX_filesystem_config.sh
@@ -20,9 +20,9 @@ Total_Disk_Size=`getconf DISK_SIZE /dev/hdisk0`    								          # Determine
 Total_Disk_in_GB=`expr $Total_Disk_Size / 1024`    								          # Convert to GB
 Maximum_Processes=`lsattr -E -l sys0 | grep maxuproc | awk '{print $2}'`
 #
-if [[ $Total_Disk_in_GB -lt "79" ]]; then									                  # Disk is too small for script
-	echo "Error: Disk is too small (less than 40GB), manually configuration is required. Exiting..."
-	exit
+if [[ $Total_Disk_in_GB -lt "60" ]]; then									                  # Disk is too small for script
+	echo "Error: Disk is too small (less than 60GB), manually configuration is required. Exiting..."
+	exit 1
 fi
 #
 # Determine the current size of the filesystems


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.
-->

##### Checklist
<!-- For completed items, change [ ] to [x]. Leave unchecked if not required -->

- [x] commit message has one of the [standard prefixes](https://github.com/AdoptOpenJDK/openjdk-infrastructure/blob/master/FAQ.md#commit-messages)
- [ ] [FAQ.md](https://github.com/AdoptOpenJDK/openjdk-infrastructure/blob/master/FAQ.md) updated if appropriate
- [ ] other documentation is changed or added (if applicable)
- [ ] playbook changes run through [VPC](https://ci.adoptopenjdk.net/view/Tooling/job/VagrantPlaybookCheck/) or [QPC](https://ci.adoptopenjdk.net/view/Tooling/job/QEMUPlaybookCheck/) (if you have access)
- [ ] for inventory.yml changes, bastillion/nagios/jenkins updated accordingly
