### PR TITLE
inventory: Quote IPV6 addresss since adoptopenjdk_yaml.py cannot parse inventory

### DIFF
--- a/ansible/inventory.yml
+++ b/ansible/inventory.yml
@@ -163,8 +163,8 @@ hosts:
 
       # Nine machines are behind a firewall. Please contact @sxa or @gdams for access
       - nine:
-          macos1015-x64-1: {ip: 10.0.40.10, ipv6: 2a02:418:3001:40::10, user: administrator}
-          macos1015-x64-2: {ip: 10.0.40.11, ipv6: 2a02:418:3001:40::11, user: administrator}
+          macos1015-x64-1: {ip: 10.0.40.10, ipv6: "2a02:418:3001:40::10", user: administrator}
+          macos1015-x64-2: {ip: 10.0.40.11, ipv6: "2a02:418:3001:40::11", user: administrator}
 
       - scaleway:
           ubuntu1604-x64-1: {ip: 51.15.76.107}


### PR DESCRIPTION
inventory file cannot be parsed due to the presence of `:` characters in the ipv6 field - I thought we had a check for this somewhere - if not we should create one
```
[sxa@sainz ansible]$ ./plugins/inventory/adoptopenjdk_yaml.py
while scanning a plain scalar
  in "/home/sxa/git/openjdk-infrastructure/ansible/inventory.yml", line 166, column 51
found unexpected ':'
  in "/home/sxa/git/openjdk-infrastructure/ansible/inventory.yml", line 166, column 55
Please check http://pyyaml.org/wiki/YAMLColonInFlowContext for details.
Traceback (most recent call last):
  File "./plugins/inventory/adoptopenjdk_yaml.py", line 223, in <module>
    main()
  File "./plugins/inventory/adoptopenjdk_yaml.py", line 63, in main
    export = parse_yaml(load_yaml_file(inventory_path), config)
  File "./plugins/inventory/adoptopenjdk_yaml.py", line 110, in parse_yaml
    for host_types in hosts['hosts']:
KeyError: 'hosts'
```
Signed-off-by: Stewart X Addison <sxa@redhat.com>

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.
-->

##### Checklist
<!-- For completed items, change [ ] to [x]. Leave unchecked if not required -->

- [x] commit message has one of the [standard prefixes](https://github.com/AdoptOpenJDK/openjdk-infrastructure/blob/master/FAQ.md#commit-messages)
- [ ] [FAQ.md](https://github.com/AdoptOpenJDK/openjdk-infrastructure/blob/master/FAQ.md) updated if appropriate
- [ ] other documentation is changed or added (if applicable)
- [ ] playbook changes run through [VPC](https://ci.adoptopenjdk.net/view/Tooling/job/VagrantPlaybookCheck/) or [QPC](https://ci.adoptopenjdk.net/view/Tooling/job/QEMUPlaybookCheck/) (if you have access)
- [ ] for inventory.yml changes, bastillion/nagios/jenkins updated accordingly
