### PR TITLE
UnixPb: add stdout of registered variable

### DIFF
--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/tasks/MacOSX.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/tasks/MacOSX.yml
@@ -96,7 +96,7 @@
   homebrew: "name={{ item }} state=present"
   with_items: "{{ Build_Tool_Packages_NOT_10_12 }}"
   when:
-    - not macos_version.stdout | regex_search("10.12")
+    - not (macos_version.stdout | regex_search("10.12"))
   tags: build_tools
 
 - name: Install Build Tool Casks

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/tasks/MacOSX.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/tasks/MacOSX.yml
@@ -96,7 +96,7 @@
   homebrew: "name={{ item }} state=present"
   with_items: "{{ Build_Tool_Packages_NOT_10_12 }}"
   when:
-    - not macos_version | regex_search("10.12")
+    - not macos_version.stdout | regex_search("10.12")
   tags: build_tools
 
 - name: Install Build Tool Casks


### PR DESCRIPTION
Ref https://github.com/AdoptOpenJDK/openjdk-infrastructure/issues/1910#issuecomment-795907758

The condition should compare the stdout of the variable, not the whole variable. Else it fails with this error

```
fatal: [test-macstadium-macos1014-x64-1]: FAILED! => {"msg": "The conditional check 'not macos_version | regex_search(\"10.12\")' failed. 
The error was: Unexpected templating type error occurred on ({% if not macos_version | 
regex_search(\"10.12\") %} True {% else %} False {% endif %}): expected string or bytes-like object\n\n
The error appears to be in '/tmp/awx_763_m5aop2n8/project/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/tasks/MacOSX.yml': 
line 93, column 3, but may\nbe elsewhere in the file depending on the exact syntax problem.\n\n
The offending line appears to be:\n\n\n- name: Install Build Tool Packages NOT macOS 10.12\n  ^ here\n"}
```