### PR TITLE
vagrant: apt-mark hold grub-pc on Debian10

### DIFF
--- a/ansible/Vagrantfile.Debian10
+++ b/ansible/Vagrantfile.Debian10
@@ -4,7 +4,11 @@
 $script = <<SCRIPT
 sudo apt-get install tree -y
 sudo apt-get install software-properties-common -y
-sudo apt-get install gpg -y	
+sudo apt-get install gpg -y
+
+# The Debian10 VM needs to upgrade grub-pc, which causes a pop-up, breaking VPC
+# See: https://github.com/AdoptOpenJDK/openjdk-infrastructure/issues/1980
+sudo apt-mark hold grub-pc
 sudo apt-get update
 # Put the host machine's IP into the authorised_keys file on the VM
 if [ -r /vagrant/id_rsa.pub ]; then


### PR DESCRIPTION
Fixes: #1980 

As mentioned in the issue, the Debian10 Vagrant VM wants to upgrade `grub-pc` when running the upgrade task from the playbook, however, that causes a popup, which Ansible can't handle. The reason I have specifically put in a Vagrantfile fix as opposed to a playbook fix is because if this were a _real_ machine, the `grub-pc` package could be installed manually - and I don't know of the complications that not upgrading `grub-pc` can cause - however, that doesn't matter on a VPC run.

##### Checklist
<!-- For completed items, change [ ] to [x]. Leave unchecked if not required -->

- [x] commit message has one of the [standard prefixes](https://github.com/AdoptOpenJDK/openjdk-infrastructure/blob/master/FAQ.md#commit-messages)
- [ ] [FAQ.md](https://github.com/AdoptOpenJDK/openjdk-infrastructure/blob/master/FAQ.md) updated if appropriate
- [ ] other documentation is changed or added (if applicable)
- [x] playbook changes run through [VPC](https://ci.adoptopenjdk.net/view/Tooling/job/VagrantPlaybookCheck/) or [QPC](https://ci.adoptopenjdk.net/view/Tooling/job/QEMUPlaybookCheck/) (if you have access) : https://ci.adoptopenjdk.net/job/VagrantPlaybookCheck/1103/
- [ ] for inventory.yml changes, bastillion/nagios/jenkins updated accordingly
