### PR TITLE
Add musl-dev to Alpine static docker containers

### DIFF
--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/DockerStatic/Dockerfiles/Dockerfile.alp311
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/DockerStatic/Dockerfiles/Dockerfile.alp311
@@ -1,7 +1,7 @@
 FROM alpine:3.11
 
 # Install OpenJDK 8 from Alpine because AdoptOpenJDK is 16+, only (February, 2021).
-RUN apk --update add bash shadow openssh-server openssh-client unzip wget openjdk8 git curl make gcc perl xvfb libxrender libxi libxtst procps
+RUN apk --update add bash shadow openssh-server openssh-client unzip wget openjdk8 git curl make gcc musl-dev perl xvfb libxrender libxi libxtst procps
 RUN ssh-keygen -t rsa -f /etc/ssh/ssh_host_rsa_key -P ""
 
 # Install ant and ant-contrib.

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/DockerStatic/Dockerfiles/Dockerfile.alp312
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/DockerStatic/Dockerfiles/Dockerfile.alp312
@@ -1,7 +1,7 @@
 FROM alpine:3.12
 
 # Install OpenJDK 8 from Alpine because AdoptOpenJDK is 16+, only (February, 2021).
-RUN apk --update add bash shadow openssh-server openssh-client unzip wget openjdk8 git curl make gcc perl xvfb libxrender libxi libxtst procps
+RUN apk --update add bash shadow openssh-server openssh-client unzip wget openjdk8 git curl make gcc musl-dev perl xvfb libxrender libxi libxtst procps
 RUN ssh-keygen -t rsa -f /etc/ssh/ssh_host_rsa_key -P ""
 
 # Install ant and ant-contrib.


### PR DESCRIPTION
Fixes the issue with missing `<stdio.h>` on the machines which prevents compilation of the system test suites (Ref [slack conversation](https://adoptopenjdk.slack.com/archives/CLCFNV2JG/p1615469905017800?thread_ts=1615456719.007700&cid=CLCFNV2JG) where it was raised and verified by @Mesbah-Alam - thanks!)

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.
-->

##### Checklist
<!-- For completed items, change [ ] to [x]. Leave unchecked if not required -->

- [x] commit message has one of the [standard prefixes](https://github.com/AdoptOpenJDK/openjdk-infrastructure/blob/master/FAQ.md#commit-messages)
- [ ] [FAQ.md](https://github.com/AdoptOpenJDK/openjdk-infrastructure/blob/master/FAQ.md) updated if appropriate
- [ ] other documentation is changed or added (if applicable)
- [ ] playbook changes run through [VPC](https://ci.adoptopenjdk.net/view/Tooling/job/VagrantPlaybookCheck/) or [QPC](https://ci.adoptopenjdk.net/view/Tooling/job/QEMUPlaybookCheck/) (if you have access)
- [ ] for inventory.yml changes, bastillion/nagios/jenkins updated accordingly
