### PR TITLE
unixPB/winPB: Add ansible_version to debug info

### DIFF
--- a/ansible/playbooks/AdoptOpenJDK_AIX_Playbook/roles/debug/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_AIX_Playbook/roles/debug/tasks/main.yml
@@ -17,6 +17,7 @@
       - "ansible_architecture: {{ ansible_architecture | default('***Undefined***') }} "
       - "ansible_processor_vcpus: {{ ansible_processor_vcpus | default('***Undefined***') }} "
       - "ansible_processor_cores: {{ ansible_processor_cores | default('***Undefined***') }} "
+      - "ansible_version: {{ ansible_version | default('***Undefined***') }} "
       - "Domain: {{ Domain | default('***Undefined***') }} "
       - "Jenkins_Username: {{ Jenkins_Username | default('***Undefined***') }} "
       - "Superuser_Account: {{ Superuser_Account | default('***Undefined***') }}"

--- a/ansible/playbooks/AdoptOpenJDK_AIX_Playbook/roles/debug/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_AIX_Playbook/roles/debug/tasks/main.yml
@@ -17,7 +17,7 @@
       - "ansible_architecture: {{ ansible_architecture | default('***Undefined***') }} "
       - "ansible_processor_vcpus: {{ ansible_processor_vcpus | default('***Undefined***') }} "
       - "ansible_processor_cores: {{ ansible_processor_cores | default('***Undefined***') }} "
-      - "ansible_version: {{ ansible_version | default('***Undefined***') }} "
+      - "ansible_version.full: {{ ansible_version.full | default('***Undefined***') }} "
       - "Domain: {{ Domain | default('***Undefined***') }} "
       - "Jenkins_Username: {{ Jenkins_Username | default('***Undefined***') }} "
       - "Superuser_Account: {{ Superuser_Account | default('***Undefined***') }}"

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Debug/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Debug/tasks/main.yml
@@ -17,6 +17,7 @@
       - "ansible_architecture: {{ ansible_architecture | default('***Undefined***') }} "
       - "ansible_processor_vcpus: {{ ansible_processor_vcpus | default('***Undefined***') }} "
       - "ansible_processor_cores: {{ ansible_processor_cores | default('***Undefined***') }} "
+      - "ansible_version: {{ ansible_version | default('***Undefined***') }} "
       - "Domain: {{ Domain | default('***Undefined***') }} "
       - "Jenkins_Username: {{ Jenkins_Username | default('***Undefined***') }} "
       - "Superuser_Account: {{ Superuser_Account | default('***Undefined***') }}"

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Debug/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Debug/tasks/main.yml
@@ -17,7 +17,7 @@
       - "ansible_architecture: {{ ansible_architecture | default('***Undefined***') }} "
       - "ansible_processor_vcpus: {{ ansible_processor_vcpus | default('***Undefined***') }} "
       - "ansible_processor_cores: {{ ansible_processor_cores | default('***Undefined***') }} "
-      - "ansible_version: {{ ansible_version | default('***Undefined***') }} "
+      - "ansible_version.full: {{ ansible_version.full | default('***Undefined***') }} "
       - "Domain: {{ Domain | default('***Undefined***') }} "
       - "Jenkins_Username: {{ Jenkins_Username | default('***Undefined***') }} "
       - "Superuser_Account: {{ Superuser_Account | default('***Undefined***') }}"

--- a/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/roles/Debug/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/roles/Debug/tasks/main.yml
@@ -12,7 +12,7 @@
       - "ansible_architecture: {{ ansible_architecture | default('***Undefined***') }} "
       - "ansible_processor_vcpus: {{ ansible_processor_vcpus | default('***Undefined***') }} "
       - "ansible_processor_cores: {{ ansible_processor_cores | default('***Undefined***') }} "
-      - "ansible_version: {{ ansible_version | default('***Undefined***') }} "
+      - "ansible_version.full: {{ ansible_version.full | default('***Undefined***') }} "
       - "Jenkins_Username: {{ Jenkins_Username | default('***Undefined***') }} "
       - "Nagios_Plugins: {{ Nagios_Plugins | default('***Undefined***') }} "
       - "Superuser_Account: {{ Superuser_Account | default('***Undefined***') }}"

--- a/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/roles/Debug/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/roles/Debug/tasks/main.yml
@@ -12,6 +12,7 @@
       - "ansible_architecture: {{ ansible_architecture | default('***Undefined***') }} "
       - "ansible_processor_vcpus: {{ ansible_processor_vcpus | default('***Undefined***') }} "
       - "ansible_processor_cores: {{ ansible_processor_cores | default('***Undefined***') }} "
+      - "ansible_version: {{ ansible_version | default('***Undefined***') }} "
       - "Jenkins_Username: {{ Jenkins_Username | default('***Undefined***') }} "
       - "Nagios_Plugins: {{ Nagios_Plugins | default('***Undefined***') }} "
       - "Superuser_Account: {{ Superuser_Account | default('***Undefined***') }}"


### PR DESCRIPTION
Print `ansible_version` into the logs for debugging purposes

Signed-off-by: Stewart X Addison <sxa@redhat.com>

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.
-->

##### Checklist
<!-- For completed items, change [ ] to [x]. Leave unchecked if not required -->

- [x] commit message has one of the [standard prefixes](https://github.com/AdoptOpenJDK/openjdk-infrastructure/blob/master/FAQ.md#commit-messages)
- [ ] [FAQ.md](https://github.com/AdoptOpenJDK/openjdk-infrastructure/blob/master/FAQ.md) updated if appropriate
- [ ] other documentation is changed or added (if applicable)
- [x] playbook changes run through [VPC](https://ci.adoptopenjdk.net/view/Tooling/job/VagrantPlaybookCheck/) or [QPC](https://ci.adoptopenjdk.net/view/Tooling/job/QEMUPlaybookCheck/) (if you have access) - [VPC](https://ci.adoptopenjdk.net/view/Tooling/job/VagrantPlaybookCheck/1113)
- [ ] for inventory.yml changes, bastillion/nagios/jenkins updated accordingly
