### PR TITLE
aixPB: Add crontab entries to ensure stale (jenkins) files and directories are removed

### DIFF
--- a/ansible/playbooks/AdoptOpenJDK_AIX_Playbook/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_AIX_Playbook/main.yml
@@ -34,6 +34,7 @@
     # 2. AIX BOS configuration
 
     - syslogs
+    - crontab
     # TBD: additional tasks below that need to be promoted to
     # or migrated into an AIX setup role - in paritcular -
     # the tasks that setup the legal shells needed for user configuration

--- a/ansible/playbooks/AdoptOpenJDK_AIX_Playbook/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_AIX_Playbook/main.yml
@@ -133,7 +133,8 @@
       register: freemarker
       tags: freemarker
 
-    - debug:
+    - name: "freemarker.jar found, skipping download"
+      debug:
         msg: "freemarker.jar found, skipping download"
       when: not freemarker.stat.exists
       tags: freemarker

--- a/ansible/playbooks/AdoptOpenJDK_AIX_Playbook/roles/crontab/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_AIX_Playbook/roles/crontab/tasks/main.yml
@@ -1,0 +1,14 @@
+---
+###########
+# crontab #
+###########
+
+- name: Add cron job to remove stale files from /tmp (owned by jenkins)
+  cron: name="Remove stale files from /tmp (jenkins)" weekday="*" minute="10" hour="0" user=root state=present
+        job="/usr/bin/find /tmp -user jenkins ! -type d -mtime +1 | xargs rm -f"
+  tags: crontab
+
+- name: Add cron job to remove stale directories from /tmp (owned by jenkins)
+  cron: name="Remove stale directories from /tmp (jenkins)" weekday="*" minute="10" hour="2" user=root state=present
+        job="/usr/bin/find /tmp -user jenkins -type d -mtime +1 | sort -r | xargs rm -f"
+  tags: crontab

--- a/ansible/playbooks/AdoptOpenJDK_AIX_Playbook/roles/crontab/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_AIX_Playbook/roles/crontab/tasks/main.yml
@@ -5,10 +5,10 @@
 
 - name: Add cron job to remove stale files from /tmp (owned by jenkins)
   cron: name="Remove stale files from /tmp (jenkins)" weekday="*" minute="10" hour="0" user=root state=present
-        job="/usr/bin/find /tmp -user jenkins ! -type d -mtime +1 | xargs rm -f"
+        job="/usr/bin/find /tmp -user jenkins ! -type d -mtime +4 | xargs rm -f"
   tags: crontab
 
 - name: Add cron job to remove stale directories from /tmp (owned by jenkins)
   cron: name="Remove stale directories from /tmp (jenkins)" weekday="*" minute="10" hour="2" user=root state=present
-        job="/usr/bin/find /tmp -user jenkins -type d -mtime +1 | sort -r | xargs rm -f"
+        job="/usr/bin/find /tmp -user jenkins -type d -mtime +4 | sort -r | xargs rmdir"
   tags: crontab


### PR DESCRIPTION
Fix: #2029 

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.
-->

##### Checklist
<!-- For completed items, change [ ] to [x]. Leave unchecked if not required -->

- [x] commit message has one of the [standard prefixes](https://github.com/AdoptOpenJDK/openjdk-infrastructure/blob/master/FAQ.md#commit-messages)
- [ ] [FAQ.md](https://github.com/AdoptOpenJDK/openjdk-infrastructure/blob/master/FAQ.md) updated if appropriate
- [ ] other documentation is changed or added (if applicable)
- [ ] playbook changes run through [VPC](https://ci.adoptopenjdk.net/view/Tooling/job/VagrantPlaybookCheck/) or [QPC](https://ci.adoptopenjdk.net/view/Tooling/job/QEMUPlaybookCheck/) (if you have access)
- [ ] for inventory.yml changes, bastillion/nagios/jenkins updated accordingly
