### PR TITLE
unixPB: Add missing deps to Alpine for testing

### DIFF
--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/DockerStatic/Dockerfiles/Dockerfile.alp311
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/DockerStatic/Dockerfiles/Dockerfile.alp311
@@ -1,7 +1,8 @@
 FROM alpine:3.11
 
 # Install OpenJDK 8 from Alpine because AdoptOpenJDK is 16+, only (February, 2021).
-RUN apk --update add bash shadow openssh-server openssh-client unzip wget openjdk8 git curl make gcc perl xvfb libxrender libxi libxtst procps
+RUN apk --update add bash shadow openssh-server openssh-client unzip wget openjdk8 git curl make gcc perl xvfb \
+        libxrender libxi libxtst procps musl-dev perl-doc alsa-lib libx11 fontconfig libxext freetype zlib
 RUN ssh-keygen -t rsa -f /etc/ssh/ssh_host_rsa_key -P ""
 
 # Install ant and ant-contrib.

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/DockerStatic/Dockerfiles/Dockerfile.alp312
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/DockerStatic/Dockerfiles/Dockerfile.alp312
@@ -1,7 +1,8 @@
 FROM alpine:3.12
 
 # Install OpenJDK 8 from Alpine because AdoptOpenJDK is 16+, only (February, 2021).
-RUN apk --update add bash shadow openssh-server openssh-client unzip wget openjdk8 git curl make gcc perl xvfb libxrender libxi libxtst procps
+RUN apk --update add bash shadow openssh-server openssh-client unzip wget openjdk8 git curl make gcc perl xvfb \
+        libxrender libxi libxtst procps musl-dev perl-doc alsa-lib libx11 fontconfig libxext freetype zlib
 RUN ssh-keygen -t rsa -f /etc/ssh/ssh_host_rsa_key -P ""
 
 # Install ant and ant-contrib.


### PR DESCRIPTION
Adds missing dependencies to static Alpine containers for testing. Should resolve https://github.com/AdoptOpenJDK/openjdk-tests/issues/2223#issuecomment-801995589 and probably supersedes #2026.

##### Checklist
<!-- For completed items, change [ ] to [x]. Leave unchecked if not required -->

- [X] commit message has one of the [standard prefixes](https://github.com/AdoptOpenJDK/openjdk-infrastructure/blob/master/FAQ.md#commit-messages)
- [ ] [FAQ.md](https://github.com/AdoptOpenJDK/openjdk-infrastructure/blob/master/FAQ.md) updated if appropriate
- [ ] other documentation is changed or added (if applicable)
- [ ] playbook changes run through [VPC](https://ci.adoptopenjdk.net/view/Tooling/job/VagrantPlaybookCheck/) or [QPC](https://ci.adoptopenjdk.net/view/Tooling/job/QEMUPlaybookCheck/) (if you have access)
- [ ] for inventory.yml changes, bastillion/nagios/jenkins updated accordingly
