### PR TITLE
github: make linter use the correct file for checking AIX playbook

### DIFF
--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -56,9 +56,9 @@ jobs:
         # Check Playbook syntax.
         ansible-playbook playbooks/AdoptOpenJDK_Unix_Playbook/main.yml --syntax-check
         ansible-playbook playbooks/AdoptOpenJDK_Unix_Playbook/trss.yml --syntax-check
+        ansible-playbook playbooks/AdoptOpenJDK_AIX_Playbook/main.yml --syntax-check
         ansible-playbook playbooks/AdoptOpenJDK_Windows_Playbook/main.yml --syntax-check
         ansible-playbook playbooks/AdoptOpenJDK_Services_Playbooks/ubuntu-jckservices.yml --syntax-check
         ansible-playbook playbooks/AdoptOpenJDK_ITW_Playbook/main.yml --syntax-check
         ansible-playbook playbooks/vagrant.yml --syntax-check
-        ansible-playbook playbooks/aix.yml --syntax-check
         ansible-playbook playbooks/ubuntu-jck.yml --syntax-check


### PR DESCRIPTION
Required now that `aix.yml` no longer exists now that https://github.com/AdoptOpenJDK/openjdk-infrastructure/pull/2053 has been merged

Signed-off-by: Stewart X Addison <sxa@redhat.com>

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.
-->

##### Checklist
<!-- For completed items, change [ ] to [x]. Leave unchecked if not required -->

- [x] commit message has one of the [standard prefixes](https://github.com/AdoptOpenJDK/openjdk-infrastructure/blob/master/FAQ.md#commit-messages)
- [ ] [FAQ.md](https://github.com/AdoptOpenJDK/openjdk-infrastructure/blob/master/FAQ.md) updated if appropriate
- [ ] other documentation is changed or added (if applicable)
- [ ] playbook changes run through [VPC](https://ci.adoptopenjdk.net/view/Tooling/job/VagrantPlaybookCheck/) or [QPC](https://ci.adoptopenjdk.net/view/Tooling/job/QEMUPlaybookCheck/) (if you have access)
- [ ] for inventory.yml changes, bastillion/nagios/jenkins updated accordingly
