### PR TITLE
pbTests: Stop build debug images on Unix

### DIFF
--- a/ansible/Vagrantfile.Debian10
+++ b/ansible/Vagrantfile.Debian10
@@ -4,7 +4,11 @@
 $script = <<SCRIPT
 sudo apt-get install tree -y
 sudo apt-get install software-properties-common -y
-sudo apt-get install gpg -y	
+sudo apt-get install gpg -y
+
+# The Debian10 VM needs to upgrade grub-pc, which causes a pop-up, breaking VPC
+# See: https://github.com/AdoptOpenJDK/openjdk-infrastructure/issues/1980
+sudo apt-mark hold grub-pc
 sudo apt-get update
 # Put the host machine's IP into the authorised_keys file on the VM
 if [ -r /vagrant/id_rsa.pub ]; then

--- a/ansible/pbTestScripts/buildJDK.sh
+++ b/ansible/pbTestScripts/buildJDK.sh
@@ -122,6 +122,10 @@ if [[ "$(uname -m)" == "armv7l" && "$VARIANT" == "openj9" ]]; then
 	export VARIANT=hotspot
 fi
 
+# Don't build the debug-images as it takes too much space, and doesn't benefit VPC
+# See: https://github.com/AdoptOpenJDK/openjdk-infrastructure/issues/2033
+export CONFIGURE_ARGS="--with-native-debug-symbols=none --custom-cacerts false"
+
 echo "buildJDK.sh DEBUG:
         TARGET_OS=${TARGET_OS:-}
         ARCHITECTURE=${ARCHITECTURE:-}

--- a/ansible/pbTestScripts/buildJDK.sh
+++ b/ansible/pbTestScripts/buildJDK.sh
@@ -124,7 +124,8 @@ fi
 
 # Don't build the debug-images as it takes too much space, and doesn't benefit VPC
 # See: https://github.com/AdoptOpenJDK/openjdk-infrastructure/issues/2033
-export CONFIGURE_ARGS="--with-native-debug-symbols=none --custom-cacerts false"
+export CONFIGURE_ARGS="--with-native-debug-symbols=none"
+export BUILD_ARGS="--custom-cacerts false"
 
 echo "buildJDK.sh DEBUG:
         TARGET_OS=${TARGET_OS:-}


### PR DESCRIPTION
Fixes: #2033

Stops building the debug images when running the Unix playbooks, as it just takes up unnecessary space, and doesn't require any more deps for VPC to test.

##### Checklist
<!-- For completed items, change [ ] to [x]. Leave unchecked if not required -->

- [x] commit message has one of the [standard prefixes](https://github.com/AdoptOpenJDK/openjdk-infrastructure/blob/master/FAQ.md#commit-messages)
- [ ] [FAQ.md](https://github.com/AdoptOpenJDK/openjdk-infrastructure/blob/master/FAQ.md) updated if appropriate
- [x] other documentation is changed or added (if applicable) : Comments have been added
- [x] playbook changes run through [VPC](https://ci.adoptopenjdk.net/view/Tooling/job/VagrantPlaybookCheck/) or [QPC](https://ci.adoptopenjdk.net/view/Tooling/job/QEMUPlaybookCheck/) (if you have access) VPC: https://ci.adoptopenjdk.net/job/VagrantPlaybookCheck/OS=Debian10,label=vagrant/1110/console 
- [ ] for inventory.yml changes, bastillion/nagios/jenkins updated accordingly
