### PR TITLE
doc: Update README with current list of machine admins

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,13 +51,16 @@ a new member? Please follow our [Onboarding Process](ONBOARDING.md).
 
 `*` Indicates access to the secrets repo
 
-## [@admin_infrastructure](https://github.com/orgs/AdoptOpenJDK/teams/admin_infrastructure)
+## [@infrastructure-core](https://github.com/orgs/AdoptOpenJDK/teams/infrastructure-core)
 
-Team that holds super user access to Infrastructure
+Team that holds super user access to our machines
 
 * [@gdams](https://github.com/gdams) - George Adams (Microsoft) - *
 * [@johnoliver](https://github.com/johnoliver) - John Oliver (Microsoft / LJC) - *
-* [@sxa555](https://github.com/sxa555) - Stewart X Addison (Red Hat) - *
+* [@sxa](https://github.com/sxa555) - Stewart X Addison (Red Hat) - *
+* [@willsparker](https://github.com/Willsparker) - Will Parker
+* [@Haroon-Khel](https://github.com/Haroon-Khel) - Haroon Khel (Red Hat)
+* [@aahlenst](https://github.com/aahlenst) - Andreas Ahlenstorf (ZHAW)
 
 ## [@infrastructure](https://github.com/orgs/AdoptOpenJDK/teams/infrastructure)
 


### PR DESCRIPTION
Signed-off-by: Stewart X Addison <sxa@redhat.com>

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.
-->

##### Checklist
<!-- For completed items, change [ ] to [x]. Leave unchecked if not required -->

- [x] commit message has one of the [standard prefixes](https://github.com/AdoptOpenJDK/openjdk-infrastructure/blob/master/FAQ.md#commit-messages)
- [ ] [FAQ.md](https://github.com/AdoptOpenJDK/openjdk-infrastructure/blob/master/FAQ.md) updated if appropriate
- [ x other documentation is changed or added (if applicable)
- [ ] playbook changes run through [VPC](https://ci.adoptopenjdk.net/view/Tooling/job/VagrantPlaybookCheck/) or [QPC](https://ci.adoptopenjdk.net/view/Tooling/job/QEMUPlaybookCheck/) (if you have access)
- [ ] for inventory.yml changes, bastillion/nagios/jenkins updated accordingly

The lists in here need a general cleanup bu this does the minimum to add the current admins ([including Andreas](https://github.com/AdoptOpenJDK/openjdk-infrastructure/issues/2074)) and fix the name of the github team :-)