### PR TITLE
AixPB: increase jenkins user's data and stack limits to unlimited

### DIFF
--- a/ansible/playbooks/AdoptOpenJDK_AIX_Playbook/roles/jenkins_user/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_AIX_Playbook/roles/jenkins_user/tasks/main.yml
@@ -75,9 +75,9 @@
         - "fsize=-1"
         - "core=-1"
         - "cpu=-1"
-        - "data=262144"
+        - "data=-1"
         - "rss=65536"
-        - "stack=65536"
+        - "stack=-1"
         - "nofiles=-1"
       changed_when: False
   tags: jenkins_user


### PR DESCRIPTION
Often I find when running tests or builds on machines directly, im hit with a memory error such as
```
    [javac] # There is insufficient memory for the Java Runtime Environment to continue.
    [javac] # Native memory allocation (malloc) failed to allocate 744016 bytes for Chunk::new
    [javac] # An error report file with more information is saved as:
    [javac] # /home/jenkins/openjdk-tests/TKG/scripts/hs_err_pid12583092.log
```
Thanks to @aixtools I found that adjusting the limit settings for the jenkins user helped to resolve these errors

@sxa What do you think?

The machines on which I have recently hit this error are ojdk06 and build-osuosl-aix71-ppc64-2. However in the past I do recall hitting errors similar to https://stackoverflow.com/questions/14038074/git-pull-fatal-out-of-memory-malloc-failed on some of our aix machines when running builds/tests