### PR TITLE
pbTests: Log console output of QEMU VM on first boot

### DIFF
--- a/ansible/pbTestScripts/qemuPlaybookCheck.sh
+++ b/ansible/pbTestScripts/qemuPlaybookCheck.sh
@@ -235,11 +235,12 @@ done
 	  $SSH_CMD \
 	  $DRIVE \
      	  $EXTRA_ARGS \
-	  -nographic) > /dev/null 2>&1 &
+	  -nographic) > "$workFolder/${OS}.${ARCHITEFCTURE}.startlog" 2>&1 &
 
-	echo "Machine is booting; Please be patient"
+	echo "Machine is booting; logging console to $workFolder/${OS}.${ARCHITEFCTURE}.startlog Please be patient"
 	sleep 120
-	echo "Machine has started"
+	tail "$workFolder/${OS}.${ARCHITEFCTURE}.startlog" | sed ;s/^/CONSOLE > /g'
+	echo "Machine has started, unless the above log shows otherwise ..."
 
 	# Remove old ssh key and create a new one
 	rm -f "$workFolder"/id_rsa*

--- a/ansible/pbTestScripts/qemuPlaybookCheck.sh
+++ b/ansible/pbTestScripts/qemuPlaybookCheck.sh
@@ -237,7 +237,7 @@ done
      	  $EXTRA_ARGS \
 	  -nographic) > "$workFolder/${OS}.${ARCHITEFCTURE}.startlog" 2>&1 &
 
-	echo "Machine is booting; logging console to $workFolder/${OS}.${ARCHITEFCTURE}.startlog Please be patient"
+	echo "Machine is booting; logging console to $workFolder/${OS}.${ARCHITECTURE}.startlog Please be patient"
 	sleep 120
 	tail "$workFolder/${OS}.${ARCHITEFCTURE}.startlog" | sed ;s/^/CONSOLE > /g'
 	echo "Machine has started, unless the above log shows otherwise ..."

--- a/ansible/pbTestScripts/qemuPlaybookCheck.sh
+++ b/ansible/pbTestScripts/qemuPlaybookCheck.sh
@@ -235,7 +235,7 @@ done
 	  $SSH_CMD \
 	  $DRIVE \
      	  $EXTRA_ARGS \
-	  -nographic) > "$workFolder/${OS}.${ARCHITEFCTURE}.startlog" 2>&1 &
+	  -nographic) > "$workFolder/${OS}.${ARCHITECTURE}.startlog" 2>&1 &
 
 	echo "Machine is booting; logging console to $workFolder/${OS}.${ARCHITECTURE}.startlog Please be patient"
 	sleep 120

--- a/ansible/pbTestScripts/qemuPlaybookCheck.sh
+++ b/ansible/pbTestScripts/qemuPlaybookCheck.sh
@@ -239,7 +239,7 @@ done
 
 	echo "Machine is booting; logging console to $workFolder/${OS}.${ARCHITECTURE}.startlog Please be patient"
 	sleep 120
-	tail "$workFolder/${OS}.${ARCHITEFCTURE}.startlog" | sed ;s/^/CONSOLE > /g'
+	tail "$workFolder/${OS}.${ARCHITECTURE}.startlog" | sed 's/^/CONSOLE > /g'
 	echo "Machine has started, unless the above log shows otherwise ..."
 
 	# Remove old ssh key and create a new one


### PR DESCRIPTION
No reason to hide the logs - it can assist with debugging if the machine hasn't started for some reason

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.
-->

##### Checklist
<!-- For completed items, change [ ] to [x]. Leave unchecked if not required -->

- [x] commit message has one of the [standard prefixes](https://github.com/AdoptOpenJDK/openjdk-infrastructure/blob/master/FAQ.md#commit-messages)
- [ ] [FAQ.md](https://github.com/AdoptOpenJDK/openjdk-infrastructure/blob/master/FAQ.md) updated if appropriate
- [ ] other documentation is changed or added (if applicable)
- [ ] playbook changes run through [VPC](https://ci.adoptopenjdk.net/view/Tooling/job/VagrantPlaybookCheck/) or [QPC](https://ci.adoptopenjdk.net/view/Tooling/job/QEMUPlaybookCheck/) (if you have access)
- [ ] for inventory.yml changes, bastillion/nagios/jenkins updated accordingly
