### PR TITLE
pbTests: Build bisheng as a test for RISC-V

### DIFF
--- a/ansible/pbTestScripts/qemuPlaybookCheck.sh
+++ b/ansible/pbTestScripts/qemuPlaybookCheck.sh
@@ -124,10 +124,15 @@ defaultVars() {
 		exit 1;
 	fi
 	if [[ "$buildJDK" == true && "$ARCHITECTURE" == "RISCV" ]]; then
-		echo "Currently unable to build a JDK on RISC-V natively"
-		echo "Skipping build/test"
-		buildJDK=false
-		testJDK=false
+		if [ "$buildVariant" = "hotspot" ]; then
+			echo "Cannot build the main hotspot directly on RISC-V so selecting Bisheng variant"
+			buildVariant=bisheng
+		else
+			echo "Currently unable to build a JDK on RISC-V natively"
+			echo "Skipping build/test"
+			buildJDK=false
+			testJDK=false
+		fi
 	fi
 
 }


### PR DESCRIPTION
Bisheng is a hotspot variant that builds natively on the platform for RISC-V, so select that if we're going a hotspot build test in qemuPlaybookCheck

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.
-->

##### Checklist
<!-- For completed items, change [ ] to [x]. Leave unchecked if not required -->

- [x] commit message has one of the [standard prefixes](https://github.com/AdoptOpenJDK/openjdk-infrastructure/blob/master/FAQ.md#commit-messages)
- [ ] [FAQ.md](https://github.com/AdoptOpenJDK/openjdk-infrastructure/blob/master/FAQ.md) updated if appropriate
- [ ] other documentation is changed or added (if applicable)
- [ ] playbook changes run through [VPC](https://ci.adoptopenjdk.net/view/Tooling/job/VagrantPlaybookCheck/) or [QPC](https://ci.adoptopenjdk.net/view/Tooling/job/QEMUPlaybookCheck/) (if you have access)
- [ ] for inventory.yml changes, bastillion/nagios/jenkins updated accordingly
