### PR TITLE
inventory: Replace build-macstadium-macos1010-x64-1 with build-macstadium-macos10104-x64-3

### DIFF
--- a/ansible/inventory.yml
+++ b/ansible/inventory.yml
@@ -47,9 +47,9 @@ hosts:
           solaris10u11-sparcv9-2: {}
 
       - macstadium:
-          macos1010-x64-1: {ip: 207.254.50.138, user: Administrator}
           macos1014-x64-1: {ip: 208.83.1.170, user: Administrator}
           macos1014-x64-2: {ip: 207.254.28.76, user: Administrator}
+          macos1014-x64-3: {ip: 207.254.71.202, user: Administrator}
 
       - marist:
           rhel77-s390x-1: {ip: 148.100.86.102, user: linux1}

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Nagios_Plugins/tasks/nagios_MacOSX.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Nagios_Plugins/tasks/nagios_MacOSX.yml
@@ -13,7 +13,7 @@
 # Install Nagios dependencies packages #
 ########################################
 - name: Install additional packages used by Nagios
-  package: "name={{ item }} state=latest"
+  homebrew: "name={{ item }} state=present"
   become: yes
   become_user: "{{ ansible_user }}"
   with_items:


### PR DESCRIPTION
##### Checklist
<!-- For completed items, change [ ] to [x]. Leave unchecked if not required -->

- [x] commit message has one of the [standard prefixes](https://github.com/AdoptOpenJDK/openjdk-infrastructure/blob/master/FAQ.md#commit-messages)
- [ ] [FAQ.md](https://github.com/AdoptOpenJDK/openjdk-infrastructure/blob/master/FAQ.md) updated if appropriate
- [ ] other documentation is changed or added (if applicable)
- [ ] playbook changes run through [VPC](https://ci.adoptopenjdk.net/view/Tooling/job/VagrantPlaybookCheck/) or [QPC](https://ci.adoptopenjdk.net/view/Tooling/job/QEMUPlaybookCheck/) (if you have access)
- [x] for inventory.yml changes, bastillion/nagios/jenkins updated accordingly

closes: https://github.com/AdoptOpenJDK/openjdk-infrastructure/issues/1290