### PR TITLE
inventory: Remove DTK machines

### DIFF
--- a/ansible/inventory.yml
+++ b/ansible/inventory.yml
@@ -150,8 +150,6 @@ hosts:
           macos1014-x64-2: {ip: 207.254.29.44, user: administrator}
           macos1014-x64-3: {ip: 207.254.28.237, user: administrator}
           macos1015-x64-1: {ip: 207.254.28.171, user: administrator}
-          macos11-arm64-1: {ip: 199.7.163.51, user: Administrator}
-          macos11-arm64-2: {ip: 199.7.163.52, user: Administrator}
 
       - marist:
           sles12-s390x-1: {ip: 148.100.86.128}


### PR DESCRIPTION
The DTK program has ended and Macstadium sent them back. See
https://www.macrumors.com/2021/02/03/apple-asks-developers-to-return-dtk/.

##### Checklist
<!-- For completed items, change [ ] to [x]. Leave unchecked if not required -->

- [x] commit message has one of the [standard prefixes](https://github.com/AdoptOpenJDK/openjdk-infrastructure/blob/master/FAQ.md#commit-messages)
- [ ] [FAQ.md](https://github.com/AdoptOpenJDK/openjdk-infrastructure/blob/master/FAQ.md) updated if appropriate
- [ ] other documentation is changed or added (if applicable)
- [ ] playbook changes run through [VPC](https://ci.adoptopenjdk.net/view/Tooling/job/VagrantPlaybookCheck/) or [QPC](https://ci.adoptopenjdk.net/view/Tooling/job/QEMUPlaybookCheck/) (if you have access)
- [ ] for inventory.yml changes, bastillion/nagios/jenkins updated accordingly
