### PR TITLE
pbTests: Rearm Windows 2012 VF before playbook

### DIFF
--- a/ansible/pbTestScripts/vagrantPlaybookCheck.sh
+++ b/ansible/pbTestScripts/vagrantPlaybookCheck.sh
@@ -283,6 +283,11 @@ startVMPlaybookWin()
         # See https://github.com/AdoptOpenJDK/openjdk-infrastructure/issues/1287#issuecomment-625142917
 	BUILD_ID=dontKillMe vagrant up
 	
+	# Rearm the evaluation license for 180 days to stop the VMs shutting down
+	# See: https://github.com/AdoptOpenJDK/openjdk-infrastructure/issues/2056
+	vagrant winrm --shell cmd -c "slmgr.vbs /rearm //b"
+	vagrant reload
+
 	# 5986 refers to the winrm_ssl port on the guest
 	# See: https://github.com/AdoptOpenJDK/openjdk-infrastructure/issues/1504#issuecomment-672930832
 	vagrantPort=$(vagrant port |  awk '/5986/ { print $4 }')


### PR DESCRIPTION
Ref: #1504 

Rearms the Win 2012 VM before running the playbook on it. [As mentioned](https://github.com/AdoptOpenJDK/openjdk-infrastructure/issues/2056#issuecomment-806527619) this could be in the Vagrantfile, but this causes issues with the reboot that's required for the re-arm to take effect.

This is to go towards making the Win2012 VPC run more stable.

##### Checklist
<!-- For completed items, change [ ] to [x]. Leave unchecked if not required -->

- [x] commit message has one of the [standard prefixes](https://github.com/AdoptOpenJDK/openjdk-infrastructure/blob/master/CONTRIBUTING.md#commit-messages)
- [ ] [FAQ.md](https://github.com/AdoptOpenJDK/openjdk-infrastructure/blob/master/FAQ.md) updated if appropriate
- [ ] other documentation is changed or added (if applicable)
- [ ] playbook changes run through [VPC](https://ci.adoptopenjdk.net/view/Tooling/job/VagrantPlaybookCheck/) or [QPC](https://ci.adoptopenjdk.net/view/Tooling/job/QEMUPlaybookCheck/) (if you have access): See referenced issue for 4 VPC runs
- [ ] for inventory.yml changes, bastillion/nagios/jenkins updated accordingly
