### PR TITLE
pbTests: Ensure use of correct port when running Win build

### DIFF
--- a/ansible/pbTestScripts/vagrantPlaybookCheck.sh
+++ b/ansible/pbTestScripts/vagrantPlaybookCheck.sh
@@ -319,7 +319,7 @@ startVMPlaybookWin()
 		# Restarting the VM as the shared folder disappears after the playbook runs due to the restarts in the playbook
 		vagrant halt && vagrant up
 
-		# Restaring the VM may change the port Number
+		# Restarting the VM may change the port number
 		vagrantPort=$(vagrant port |  awk '/5985/ { print $4 }')
 
 		# Run a python script to start the build on the Windows VM to give live stdout/stderr

--- a/ansible/pbTestScripts/vagrantPlaybookCheck.sh
+++ b/ansible/pbTestScripts/vagrantPlaybookCheck.sh
@@ -320,14 +320,11 @@ startVMPlaybookWin()
 		vagrant halt && vagrant up
 
 		# Restaring the VM may change the port Number
-                vagrantPort=$(vagrant port |  awk '/5986/ { print $4 }')
-                # The port used by startScriptWin.sh must be the winRM port, not the winRM_ssl port
-                # See: https://github.com/AdoptOpenJDK/openjdk-infrastructure/issues/1504#issuecomment-673329953
-                local winRMPort=$(( vagrantPort -1 ))
+		vagrantPort=$(vagrant port |  awk '/5985/ { print $4 }')
 
 		# Run a python script to start the build on the Windows VM to give live stdout/stderr
 		# See: https://github.com/AdoptOpenJDK/openjdk-infrastructure/issues/1296
-		python pbTestScripts/startScriptWin.py -i "127.0.0.1:$winRMPort" -a "$buildFork $buildBranch $jdkToBuild $buildHotspot" -b 2>&1 | tee $buildLogPath
+		python pbTestScripts/startScriptWin.py -i "127.0.0.1:$vagrantPort" -a "$buildFork $buildBranch $jdkToBuild $buildHotspot" -b 2>&1 | tee $buildLogPath
 		echo The build finished at : `date +%T`
 		if grep -q '] Error' $buildLogPath || grep -q 'configure: error' $buildLogPath; then
 			echo BUILD FAILED
@@ -338,7 +335,7 @@ startVMPlaybookWin()
 			local testLogPath="$WORKSPACE/adoptopenjdkPBTests/logFiles/${gitFork}.${gitBranch}.$OS.test_log"
 			
 			# Run a python script to start a test for the built JDK on the Windows VM
-			python pbTestScripts/startScriptWin.py -i "127.0.0.1:$winRMPort" -t 2>&1 | tee $testLogPath
+			python pbTestScripts/startScriptWin.py -i "127.0.0.1:$vagrantPort" -t 2>&1 | tee $testLogPath
 			echo The test finished at : `date +%T`
 			if ! grep -q 'FAILED: 0' $testLogPath; then 
 				echo TEST FAILED


### PR DESCRIPTION
Fixes: #2056 

For awhile the Windows VPC run has been unstable - it seemed to be an issue with the Python script that starts builds/tests on the Windows VM, and I think it's the port numbers that the script is attempting to use. For some (stupid) reason, in #1509 , I thought it'd be better to find the `winrm_ssl` port using an arithmetic expression, instead of just.. looking up which port it was .. :facepalm: . I imagine this has caused some issues, in the cases where the `winrm_ssl` port wasn't `winrm_port - 1`. This, in conjunction with #2104 , seems to have made the Win VPC run more stable:

https://ci.adoptopenjdk.net/job/VagrantPlaybookCheck/1125/
https://ci.adoptopenjdk.net/job/VagrantPlaybookCheck/1124/
 


##### Checklist
<!-- For completed items, change [ ] to [x]. Leave unchecked if not required -->

- [x] commit message has one of the [standard prefixes](https://github.com/AdoptOpenJDK/openjdk-infrastructure/blob/master/CONTRIBUTING.md#commit-messages)
- [ ] [FAQ.md](https://github.com/AdoptOpenJDK/openjdk-infrastructure/blob/master/FAQ.md) updated if appropriate
- [ ] other documentation is changed or added (if applicable)
- [x] playbook changes run through [VPC](https://ci.adoptopenjdk.net/view/Tooling/job/VagrantPlaybookCheck/) or [QPC](https://ci.adoptopenjdk.net/view/Tooling/job/QEMUPlaybookCheck/) (if you have access) : See above
- [ ] for inventory.yml changes, bastillion/nagios/jenkins updated accordingly
