### PR TITLE
inventory: add m1 build macOS machines + playbook support for m1

### DIFF
--- a/ansible/inventory.yml
+++ b/ansible/inventory.yml
@@ -50,6 +50,8 @@ hosts:
           macos1014-x64-1: {ip: 208.83.1.170, user: Administrator}
           macos1014-x64-2: {ip: 207.254.28.76, user: Administrator}
           macos1014-x64-3: {ip: 207.254.71.202, user: Administrator}
+          macos11-arm64-1: {ip: 207.254.31.15, user: Administrator}
+          macos11-arm64-2: {ip: 207.254.31.16, user: Administrator}
 
       - marist:
           rhel77-s390x-1: {ip: 148.100.86.102, user: linux1}

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/main.yml
@@ -13,7 +13,7 @@
         - name: Load AdoptOpenJDKs variable file
           include_vars: group_vars/all/adoptopenjdk_variables.yml
   environment:
-    PATH: "/opt/csw/bin/:/usr/local/bin:{{ ansible_env.PATH }}"
+    PATH: "/opt/csw/bin/:/usr/local/bin:/opt/homebrew/bin:{{ ansible_env.PATH }}"
 
   #########
   # Roles #

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/scripts/install-fiddle.sh
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/scripts/install-fiddle.sh
@@ -1,5 +1,0 @@
-git clone https://github.com/ruby/fiddle
-cd fiddle
-bundle install --path vendor/bundle
-bundle exec rake build
-sudo gem install pkg/fiddle-1.0.1.gem

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/tasks/MacOSX.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/tasks/MacOSX.yml
@@ -36,18 +36,18 @@
   tags:
     - skip_ansible_lint
 
+# Currently required to install packages. This can be removed once it installs on arm64
+- name: Install Rosetta 2
+  command: /usr/sbin/softwareupdate --install-rosetta --agree-to-license
+  when:
+    - ansible_architecture == "arm64"
+  tags:
+    - rosetta
+
 - name: Check if Homebrew is already installed
   stat:
     path: /usr/local/bin/brew
   register: brew
-
-- name: Fix broken fiddle install (Apple Silicon)
-  become: yes
-  become_user: "{{ ansible_user }}"
-  script: scripts/install-fiddle.sh
-  when:
-    - ansible_architecture == "arm64"
-    - not brew.stat.exists
 
 - name: Install Homebrew
   become: yes
@@ -82,6 +82,19 @@
   become: yes
   become_user: "{{ ansible_user }}"
   command: /usr/local/bin/brew cu
+  when:
+    - ansible_architecture != "arm64"
+  tags:
+    - brew_cu
+    - skip_ansible_lint
+
+# Skipping linting as no situation where this can't run (lint error 301)
+- name: Update Casks (Arm64)
+  become: yes
+  become_user: "{{ ansible_user }}"
+  command: /opt/homebrew/bin/brew cu
+  when:
+    - ansible_architecture == "arm64"
   tags:
     - brew_cu
     - skip_ansible_lint
@@ -91,15 +104,6 @@
   become_user: "{{ ansible_user }}"
   homebrew: "name={{ item }} state=present"
   with_items: "{{ Build_Tool_Packages }}"
-  tags: build_tools
-
-- name: Install Build Tool Packages NOT arm64
-  become: yes
-  become_user: "{{ ansible_user }}"
-  homebrew: "name={{ item }} state=present"
-  with_items: "{{ Build_Tool_Packages_NOT_arm64 }}"
-  when:
-    - ansible_architecture != "arm64"
   tags: build_tools
 
 - name: Install Build Tool Packages NOT macOS 10.12
@@ -116,8 +120,6 @@
   become_user: "{{ ansible_user }}"
   homebrew_cask: "name={{ item }} state=present"
   with_items: "{{ Build_Tool_Casks }}"
-  when:
-    - ansible_architecture != "arm64"
   tags: build_tools
 
 - name: Install Test Tool Packages
@@ -127,22 +129,11 @@
   with_items: "{{ Test_Tool_Packages }}"
   tags: test_tools
 
-- name: Install Test Tool Packages NOT arm64
-  become: yes
-  become_user: "{{ ansible_user }}"
-  homebrew: "name={{ item }} state=present"
-  with_items: "{{ Test_Tool_Packages_NOT_arm64 }}"
-  when:
-    - ansible_architecture != "arm64"
-  tags: test_tools
-
 - name: Install Test Tool Casks
   become: yes
   become_user: "{{ ansible_user }}"
   homebrew_cask: "name={{ item }} state=present"
   with_items: "{{ Test_Tool_Casks }}"
-  when:
-    - ansible_architecture != "arm64"
   tags: test_tools
 
 # As per https://github.com/eclipse/openj9/issues/3790

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/vars/MacOSX.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/vars/MacOSX.yml
@@ -13,8 +13,6 @@ Build_Tool_Packages:
   - gnu-tar
   - nasm # openj9 jdk13+
   - wget
-
-Build_Tool_Packages_NOT_arm64:
   - bash # OpenJ9 needs bash v4 or later
 
 Build_Tool_Packages_NOT_10_12:
@@ -26,8 +24,6 @@ Build_Tool_Casks:
 
 Test_Tool_Packages:
   - mercurial
-
-Test_Tool_Packages_NOT_arm64:
   - pulseaudio
 
 Test_Tool_Casks:

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Xcode/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Xcode/tasks/main.yml
@@ -7,6 +7,8 @@
 # See https://xcodereleases.com for an Xcode support matrix.
 ---
 - name: Ensure Ruby is installed for xcode-install
+  become: yes
+  become_user: "{{ ansible_user }}"
   homebrew:
     name: ruby@2.7 # no 3.0 yet for fastlane (https://github.com/fastlane/fastlane/issues/17931)
     state: present
@@ -34,35 +36,49 @@
     name: "{{ item }}"
     state: latest
     user_install: no
+  environment:
+    PATH: /usr/local/opt/ruby@2.7/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin
   loop:
     - fastlane # explicitly list fastlane to get latest version
     - xcode-install
+  
+- name: Set xcversion location for x86_64
+  set_fact:
+    xcversion: /usr/local/lib/ruby/gems/2.7.0/bin/xcversion
+  when:
+    - ansible_architecture == "x86_64"
+
+- name: Set xcversion location for arm64
+  set_fact:
+    xcversion: xcversion
+  when:
+    - ansible_architecture == "arm64"
 
 # On ARM, we can use 12.x because compiling on ARM requires at least Xcode 12.
 - name: Install Xcode on Apple Silicon Macs
-  shell: "xcversion install 12.4 --retry-download-count=10"
-  when: ansible_architecture is "arm64"
+  shell: "{{ xcversion }} install 12.4 --retry-download-count=10"
+  when: ansible_architecture == "arm64"
   environment:
     XCODE_INSTALL_USER: "{{ Apple_ID_User }}"
     XCODE_INSTALL_PASSWORD: "{{ Apple_ID_Password }}"
-    SPACESHIP_SKIP_2FA_UPGRADE: 1
+    FASTLANE_SESSION: "{{ FASTLANE_SESSION }}"
     FASTLANE_DONT_STORE_PASSWORD: 1
 
 # 10.x is our default version on Intel. It requires 10.14.3+. As a consequence, some test machines
 # with older macOS won't have Xcode installed.
 - name: Install Xcode on Intel Macs
-  shell: "xcversion install 10.3 --retry-download-count=10"
-  when: ansible_architecture is "x86_64" and ansible_distribution_version is version('10.14.3', operator='>=')
+  shell: "{{ xcversion }} install 10.3 --retry-download-count=10"
+  when: ansible_architecture == "x86_64" and ansible_distribution_version is version('10.14.3', operator='>=')
   environment:
     XCODE_INSTALL_USER: "{{ Apple_ID_User }}"
     XCODE_INSTALL_PASSWORD: "{{ Apple_ID_Password }}"
-    SPACESHIP_SKIP_2FA_UPGRADE: 1
+    FASTLANE_SESSION: "{{ FASTLANE_SESSION }}"
     FASTLANE_DONT_STORE_PASSWORD: 1
 
 - name: Cleanup Xcode installation files
-  shell: "xcversion cleanup"
+  shell: "{{ xcversion }} cleanup"
   environment:
     XCODE_INSTALL_USER: "{{ Apple_ID_User }}"
     XCODE_INSTALL_PASSWORD: "{{ Apple_ID_Password }}"
-    SPACESHIP_SKIP_2FA_UPGRADE: 1
+    FASTLANE_SESSION: "{{ FASTLANE_SESSION }}"
     FASTLANE_DONT_STORE_PASSWORD: 1

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Xcode/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Xcode/tasks/main.yml
@@ -41,7 +41,7 @@
   loop:
     - fastlane # explicitly list fastlane to get latest version
     - xcode-install
-  
+
 - name: Set xcversion location for x86_64
   set_fact:
     xcversion: /usr/local/lib/ruby/gems/2.7.0/bin/xcversion

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/adoptopenjdk_install/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/adoptopenjdk_install/tasks/main.yml
@@ -29,6 +29,11 @@
   when: ansible_distribution == "MacOSX"
   tags: adoptopenjdk_install
 
+- name: Set api_architecture variable
+  set_fact:
+    api_architecture: "{{ ansible_architecture }}"
+  tags: adoptopenjdk_install
+
 - name: Set api_architecture variable for x86_64
   set_fact:
     api_architecture: x64
@@ -44,20 +49,20 @@
     - ansible_architecture == "i386"
   tags: adoptopenjdk_install
 
+# Download x64 binaries until we have arm64 binaries available
+- name: Set api_architecture variable for macOS Arm64
+  set_fact:
+    api_architecture: x64
+  when:
+    - ansible_os_family == "Darwin"
+    - ansible_architecture == "arm64"
+  tags: adoptopenjdk_install
+
 - name: Set api_architecture variable for armv7l
   set_fact:
     api_architecture: arm
   when:
     - ansible_architecture == "armv7l"
-  tags: adoptopenjdk_install
-
-- name: Set api_architecture variable for everything else
-  set_fact:
-    api_architecture: "{{ ansible_architecture }}"
-  when:
-    - ansible_architecture != "armv7l" and
-      ansible_architecture != "x86_64" and
-      ansible_architecture != "i386"
   tags: adoptopenjdk_install
 
 - name: Print api_architecture var


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.
-->

##### Checklist
<!-- For completed items, change [ ] to [x]. Leave unchecked if not required -->

- [x] commit message has one of the [standard prefixes](https://github.com/AdoptOpenJDK/openjdk-infrastructure/blob/master/CONTRIBUTING.md#commit-messages)
- [ ] [FAQ.md](https://github.com/AdoptOpenJDK/openjdk-infrastructure/blob/master/FAQ.md) updated if appropriate
- [ ] other documentation is changed or added (if applicable)
- [ ] playbook changes run through [VPC](https://ci.adoptopenjdk.net/view/Tooling/job/VagrantPlaybookCheck/) or [QPC](https://ci.adoptopenjdk.net/view/Tooling/job/QEMUPlaybookCheck/) (if you have access)
- [x] for inventory.yml changes, bastillion/nagios/jenkins updated accordingly
