### PR TITLE
inv: Add gdams RISC-V machines

### DIFF
--- a/ansible/inventory.yml
+++ b/ansible/inventory.yml
@@ -110,6 +110,10 @@ hosts:
           ubuntu1804-armv8-1: {ip: 34.243.202.254}
           win2019-x64-1: {ip: 34.244.74.139, user: Administrator}
 
+      - gdams:
+          debian10-riscv64-1: {ip: gdams.ddns.net}
+          debian10-riscv64-2: {ip: gdams.ddns.net, port: 2222}
+
       - ibm:
           aix71-ppc64-1: {ip: 129.33.196.209, user: b9s010a}
           aix71-ppc64-2: {ip: 129.33.196.210, user: b9s010a}

--- a/ansible/plugins/inventory/adoptopenjdk_yaml.py
+++ b/ansible/plugins/inventory/adoptopenjdk_yaml.py
@@ -48,7 +48,7 @@ valid = {
   'provider': ('alibaba', 'azure', 'marist', 'osuosl', 'scaleway',
         'macstadium', 'macincloud', 'ibmcloud', 'spearhead',
         'packet', 'linaro','digitalocean', 'ibm', 'godaddy',
-        'aws', 'inspira', 'packet_esxi', 'nine')
+        'aws', 'inspira', 'packet_esxi', 'nine', 'gdams')
 }
 
 def main():

--- a/ansible/plugins/inventory/adoptopenjdk_yaml.py
+++ b/ansible/plugins/inventory/adoptopenjdk_yaml.py
@@ -39,7 +39,7 @@ except ImportError:
 
 valid = {
   # taken from nodejs/node.git: ./configure
-  'arch': ('armv7', 'armv8', 'ppc64le', 'ppc64', 'x64', 's390x', 'arm64', 'sparcv9'),
+  'arch': ('armv7', 'armv8', 'ppc64le', 'ppc64', 'x64', 's390x', 'arm64', 'sparcv9' , 'riscv64'),
 
   # valid roles - add as necessary
   'type': ('build', 'test', 'infrastructure', 'docker'),


### PR DESCRIPTION
Split off from #1483 

As we have the machines connected in Jenkins, for the inventory to continue reflecting what we actually have, these should be added now, before the playbooks fully support the RISC-V platform. 

##### Checklist
<!-- For completed items, change [ ] to [x]. Leave unchecked if not required -->

- [x] commit message has one of the [standard prefixes](https://github.com/AdoptOpenJDK/openjdk-infrastructure/blob/master/CONTRIBUTING.md#commit-messages)
- [ ] [FAQ.md](https://github.com/AdoptOpenJDK/openjdk-infrastructure/blob/master/FAQ.md) updated if appropriate : N/A
- [ ] other documentation is changed or added (if applicable) : N/A
- [ ] playbook changes run through [VPC](https://ci.adoptopenjdk.net/view/Tooling/job/VagrantPlaybookCheck/) or [QPC](https://ci.adoptopenjdk.net/view/Tooling/job/QEMUPlaybookCheck/) (if you have access) : N/A
- [ ] for inventory.yml changes, bastillion/nagios/jenkins updated accordingly : Jenkins has these machines, I will attempt to add these to Nagios, and I'm not sure of the process of adding them to Bastillion (ping @sxa)
