### PR TITLE
unixPB: disable macOS keychain timeout

### DIFF
--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/macos_codesign/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/macos_codesign/tasks/main.yml
@@ -103,6 +103,14 @@
     - not macos_version | regex_search("10.10")
     - installer_cert.stderr | regex_search("no identity found") or installer_cert.stderr | regex_search("Could not find appropriate signing identity for")
 
+- name: Disable keychain timeout
+  shell: |
+    security unlock-keychain -p `cat ~/.password` login.keychain-db
+    security set-keychain-settings /Users/jenkins/Library/Keychains/login.keychain-db
+  become_user: jenkins
+  when:
+    - not macos_version | regex_search("10.10")
+
 - name: Allow codesign via ssh
   shell: |
     security unlock-keychain -p `cat ~/.password` login.keychain-db


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.
-->

##### Checklist
<!-- For completed items, change [ ] to [x]. Leave unchecked if not required -->

- [x] commit message has one of the [standard prefixes](https://github.com/AdoptOpenJDK/openjdk-infrastructure/blob/master/CONTRIBUTING.md#commit-messages)
- [ ] [FAQ.md](https://github.com/AdoptOpenJDK/openjdk-infrastructure/blob/master/FAQ.md) updated if appropriate
- [ ] other documentation is changed or added (if applicable)
- [ ] playbook changes run through [VPC](https://ci.adoptopenjdk.net/view/Tooling/job/VagrantPlaybookCheck/) or [QPC](https://ci.adoptopenjdk.net/view/Tooling/job/QEMUPlaybookCheck/) (if you have access)
- [ ] for inventory.yml changes, bastillion/nagios/jenkins updated accordingly


Fixes: https://github.com/AdoptOpenJDK/openjdk-infrastructure/issues/2120