### PR TITLE
pbTests: Fixup buildJDK arguments in QPC & export buildJDK vars

### DIFF
--- a/ansible/pbTestScripts/buildJDK.sh
+++ b/ansible/pbTestScripts/buildJDK.sh
@@ -15,9 +15,9 @@ processArgs() {
 		case "$opt" in
 			"--version" | "-v" )
 				if [ $1 == "jdk" ]; then
-					JAVA_TO_BUILD=$JDK_MAX
+					export JAVA_TO_BUILD=$JDK_MAX
 				else
-					JAVA_TO_BUILD=$(echo $1 | tr -d [:alpha:])
+					export JAVA_TO_BUILD=$(echo $1 | tr -d [:alpha:])
 				fi
 				checkJDK
 				shift;;
@@ -91,6 +91,7 @@ GIT_FORK="adoptopenjdk"
 CLEAN_WORKSPACE=false
 JDK_MAX=
 JDK_GA=
+export VARIANT=openj9
 
 setJDKVars
 processArgs $*
@@ -114,7 +115,7 @@ fi
 
 if [[ "$(uname -m)" == "aarch64" && "$JAVA_TO_BUILD" == "jdk8u" && $VARIANT == "openj9" ]]; then
 	echo "Can't build OpenJ9 JDK8 on AARCH64, Resetting JAVA_TO_BUILD to jdk11u"
-	JAVA_TO_BUILD=jdk11u
+	export JAVA_TO_BUILD=jdk11u
 fi
 
 if [[ "$(uname -m)" == "armv7l" && "$VARIANT" == "openj9" ]]; then

--- a/ansible/pbTestScripts/qemuPlaybookCheck.sh
+++ b/ansible/pbTestScripts/qemuPlaybookCheck.sh
@@ -3,7 +3,7 @@
 ARCHITECTURE=""
 OS=""
 skipFullSetup=""
-gitURL="https://github.com/adoptopenjdk/openjdk-infrastructure"
+gitFork="adoptopenjdk"
 gitBranch="master"
 PORTNO=10022
 if [ "$EXECUTOR_NUMBER" ]; then
@@ -13,7 +13,7 @@ current_dir=false
 cleanWorkspace=false
 retainVM=false
 buildJDK=false
-buildURL="https://github.com/adoptopenjdk/openjdk-build"
+buildFork="adoptopenjdk"
 buildBranch="master"
 buildVariant=""
 testJDK=false
@@ -30,8 +30,8 @@ processArgs() {
 				ARCHITECTURE="$1"; shift;;			
 			"--build" | "-b" )
 				buildJDK=true;;
-			"--build-repo" | "-br" )
-				buildURL="$1"; shift;;
+			"--build-fork" | "-bf" )
+				buildFork="$1"; shift;;
 			"--build-branch" | "-bb" )
 				buildBranch="$1"; shift;;
 			"--build-hotspot" | "-hs" )
@@ -46,8 +46,8 @@ processArgs() {
 				retainVM=true;;
 			"--test" | "-t" )
 				testJDK=true;;
-			"--infra-repo" | "-ir" )
-				gitURL="$1"; shift;;
+			"--infra-fork" | "-if" )
+				gitFork="$1"; shift;;
 			"--infra-branch" | "-ib" )
 				gitBranch=$1; shift;;
 			"--skip-more" | "-sm" )
@@ -65,13 +65,13 @@ usage() {
 	echo "Usage: ./qemu_test_script.sh (<options>) -a <architecture> -o <os>
 		--architecture | -a		Specifies the architecture to build the OS on
 		--build | -b			Build a JDK on the qemu VM
-		--build-repo | -br		Which openjdk-build to retrieve the build scripts from
+		--build-fork | -bf		Which openjdk-build to retrieve the build scripts from
 		--build-branch | -bb		Specify the branch of the build-repo (default: master)
 		--build-hotspot | -hs			Build a JDK with a Hotspot JVM instead of an OpenJ9 one
 		--currentDir | -c		Set Workspace to directory of this script
 		--clean-workspace | -cw		Removes the old work folder (including logs)
 		--help | -h 			Shows this help message
-		--infra-repo | -ir		Which openjdk-infrastructure to retrieve the playbooks (default: www.github.com/adoptopenjdk/openjdk-infrastructure)
+		--infra-fork | -if		Which openjdk-infrastructure to retrieve the playbooks (default: adoptopenjdk)
 		--infra-branch | -ib		Specify the branch of the infra-repo (default: master)
 		--jdk-version | -v		Specify which JDK to build if '-b' is used (default: jdk8u)
 		--retainVM | -r			Retain the VM once running the playbook
@@ -259,6 +259,7 @@ runPlaybook() {
 	local workFolder="$WORKSPACE"/qemu_pbCheck
 	local pbLogPath="$workFolder/logFiles/$OS.$ARCHITECTURE.log"
 	local extraAnsibleArgs=""
+        local gitURL="https://github.com/$gitFork/openjdk-infrastructure"
 
 	# RISCV requires this be specified
 	if [[ $ARCHITECTURE == "RISCV" ]]; then
@@ -281,8 +282,9 @@ runPlaybook() {
 
 	if [[ "$buildJDK" == true ]]; then
 		local buildLogPath="$workFolder/logFiles/$OS.$ARCHITECTURE.build_log"
+		local buildRepoArgs="-f $buildFork -b $buildBranch"
 		
-		ssh linux@localhost -p "$PORTNO" -i "$workFolder"/id_rsa "git clone -b "$gitBranch" "$gitURL" \$HOME/openjdk-infrastructure && \$HOME/openjdk-infrastructure/ansible/pbTestScripts/buildJDK.sh --version $jdkToBuild $buildVariant --URL $buildURL/tree/$buildBranch" 2>&1 | tee "$buildLogPath"
+		ssh linux@localhost -p "$PORTNO" -i "$workFolder"/id_rsa "git clone -b "$gitBranch" "$gitURL" \$HOME/openjdk-infrastructure && \$HOME/openjdk-infrastructure/ansible/pbTestScripts/buildJDK.sh --version $jdkToBuild $buildVariant $buildRepoArgs" 2>&1 | tee "$buildLogPath"
 		if grep -q '] Error' "$buildLogPath" || grep -q 'configure: error' "$buildLogPath"; then
 			echo BUILD FAILED
 			destroyVM


### PR DESCRIPTION
ref: #2121 

Currently QPC is failing on a few platforms that should be stable. It was due to #1962 not updating the script to reflect `buildJDK.sh`'s arguments. Amazing how the author of that PR didn't realise .. :eyes: .

In my testing, I noticed that often the `make-adopt-build-farm.sh` wouldn't pickup on variables that were being set as part of `buildJDK.sh`. When the build scripts started defaulting most arguments,  This just needed those variables exported. I've gone back to making `openj9` the default as this tests more dependencies for our playbooks.

##### Checklist
<!-- For completed items, change [ ] to [x]. Leave unchecked if not required -->

- [x] commit message has one of the [standard prefixes](https://github.com/AdoptOpenJDK/openjdk-infrastructure/blob/master/CONTRIBUTING.md#commit-messages)
- [ ] [FAQ.md](https://github.com/AdoptOpenJDK/openjdk-infrastructure/blob/master/FAQ.md) updated if appropriate
- [ ] other documentation is changed or added (if applicable)
- [x] playbook changes run through [VPC](https://ci.adoptopenjdk.net/view/Tooling/job/VagrantPlaybookCheck/) or [QPC](https://ci.adoptopenjdk.net/view/Tooling/job/QEMUPlaybookCheck/) (if you have access) [QPC](https://ci.adoptopenjdk.net/job/QEMUPlaybookCheck/242/)
- [ ] for inventory.yml changes, bastillion/nagios/jenkins updated accordingly
