### PR TITLE
actions: remove homebrew adopt cleanup block

### DIFF
--- a/.github/workflows/build_mac.yml
+++ b/.github/workflows/build_mac.yml
@@ -22,14 +22,6 @@ jobs:
     - name: Install dependencies
       run: brew install ansible
 
-    - name: Remove homebrew/cask-versions
-      run: | 
-        brew uninstall --cask adoptopenjdk8
-        brew uninstall --cask adoptopenjdk11
-        brew uninstall --cask adoptopenjdk12
-        brew uninstall --cask adoptopenjdk13
-        brew uninstall --cask adoptopenjdk14
-
     - name: Run Ansible Playbook
       run: |
         echo "localhost ansible_user=runner ansible_connection=local" > ansible/hosts


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.
-->

##### Checklist
<!-- For completed items, change [ ] to [x]. Leave unchecked if not required -->

- [ ] commit message has one of the [standard prefixes](https://github.com/AdoptOpenJDK/openjdk-infrastructure/blob/master/CONTRIBUTING.md#commit-messages)
- [ ] [FAQ.md](https://github.com/AdoptOpenJDK/openjdk-infrastructure/blob/master/FAQ.md) updated if appropriate
- [ ] other documentation is changed or added (if applicable)
- [ ] playbook changes run through [VPC](https://ci.adoptopenjdk.net/view/Tooling/job/VagrantPlaybookCheck/) or [QPC](https://ci.adoptopenjdk.net/view/Tooling/job/QEMUPlaybookCheck/) (if you have access)
- [ ] for inventory.yml changes, bastillion/nagios/jenkins updated accordingly


Recently GitHub changed its preinstalled environment to pull the adoptopenjdk binaries from the API rather than homebrew https://github.com/actions/virtual-environments/blob/main/images/macos/provision/core/openjdk.sh. This broke our PR tester because it was trying to remove the packages that didn't exist.

This PR simply removes the brew uninstall step.