### PR TITLE
ansible: Add CentOS Altra from equinix

### DIFF
--- a/ansible/inventory.yml
+++ b/ansible/inventory.yml
@@ -64,6 +64,7 @@ hosts:
       - packet:
           centos74-armv8-1: {ip: 147.75.196.30, description: ThunderX}
           ubuntu1804-armv8-1: {ip: 139.178.82.234, description: D05}
+          centos8-armv8-1: {ip: 139.178.86.243, description: Altra}
 
       - scaleway:
           ubuntu1604-armv7-1: {ip: 212.47.233.28}


### PR DESCRIPTION
Adding just one for now in order to run some ansible deployments on it to verify whether the problems seen in https://github.com/AdoptOpenJDK/openjdk-infrastructure/issues/2119 are specific to docker containers. Not currently added to nagios as this may be a temporary installation.

Signed-off-by: Stewart X Addison <sxa@redhat.com>

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.
-->

##### Checklist
<!-- For completed items, change [ ] to [x]. Leave unchecked if not required -->

- [x] commit message has one of the [standard prefixes](https://github.com/AdoptOpenJDK/openjdk-infrastructure/blob/master/CONTRIBUTING.md#commit-messages)
- [ ] [FAQ.md](https://github.com/AdoptOpenJDK/openjdk-infrastructure/blob/master/FAQ.md) updated if appropriate
- [ ] other documentation is changed or added (if applicable)
- [ ] playbook changes run through [VPC](https://ci.adoptopenjdk.net/view/Tooling/job/VagrantPlaybookCheck/) or [QPC](https://ci.adoptopenjdk.net/view/Tooling/job/QEMUPlaybookCheck/) (if you have access)
- [x] for inventory.yml changes, bastillion/[jenkins](https://ci.adoptopenjdk.net/computer/build-equinix-centos8-armv8-1/) updated accordingly
