### PR TITLE
inventory: add dockerhost systems

### DIFF
--- a/ansible/inventory.yml
+++ b/ansible/inventory.yml
@@ -95,6 +95,16 @@ hosts:
       - scaleway:
           ubuntu1604-armv7-1: {ip: 51.158.73.136}
 
+  - dockerhost:
+
+      - equinix:
+          ubuntu2004-x64-1: {ip: 139.178.85.251, description: AMD EPYC 2.8GHz 24 core, 64Gb}
+          ubuntu2004-x64-2: {ip: 147.75.79.143, description: Xeon GOLD 5120 28 core, 380Gb}
+          ubuntu1604-armv8-1: {ip: 147.75.35.203, description: Ampere Altra 160 core, 512Gb}
+
+      - osuosl:
+          ubuntu2004-ppc64le-1: {ip: 140.211.168.214}
+
   - test:
 
       - alibaba:

--- a/ansible/plugins/inventory/adoptopenjdk_yaml.py
+++ b/ansible/plugins/inventory/adoptopenjdk_yaml.py
@@ -42,12 +42,12 @@ valid = {
   'arch': ('armv7', 'armv8', 'ppc64le', 'ppc64', 'x64', 's390x', 'arm64', 'sparcv9' , 'riscv64'),
 
   # valid roles - add as necessary
-  'type': ('build', 'test', 'infrastructure', 'docker'),
+  'type': ('build', 'docker', 'dockerhost', 'infrastructure', 'test'),
 
   # providers - validated for consistency
   'provider': ('alibaba', 'azure', 'marist', 'osuosl', 'scaleway',
         'macstadium', 'macincloud', 'ibmcloud', 'spearhead',
-        'packet', 'linaro','digitalocean', 'ibm', 'godaddy',
+        'packet', 'equinix', 'linaro','digitalocean', 'ibm', 'godaddy',
         'aws', 'inspira', 'packet_esxi', 'nine', 'gdams')
 }
 


### PR DESCRIPTION
These systems warrant a separate category as unlike the others (including `docker`) we will generall not be running things on the host so they will not have the full playbooks deployed. See the FAQ for more details and links on how these systems are used.

Resolves https://github.com/AdoptOpenJDK/openjdk-infrastructure/issues/2046

Signed-off-by: Stewart X Addison <sxa@redhat.com>

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.
-->

##### Checklist
<!-- For completed items, change [ ] to [x]. Leave unchecked if not required -->

- [x] commit message has one of the [standard prefixes](https://github.com/AdoptOpenJDK/openjdk-infrastructure/blob/master/CONTRIBUTING.md#commit-messages)
- [ ] [FAQ.md](https://github.com/AdoptOpenJDK/openjdk-infrastructure/blob/master/FAQ.md) updated if appropriate
- [ ] other documentation is changed or added (if applicable)
- [ ] playbook changes run through [VPC](https://ci.adoptopenjdk.net/view/Tooling/job/VagrantPlaybookCheck/) or [QPC](https://ci.adoptopenjdk.net/view/Tooling/job/QEMUPlaybookCheck/) (if you have access)
- [x] for inventory.yml changes, bastillion/nagios/jenkins updated accordingly

All but nagios set up ... Although I want to have a separate discussion on exactly how we monitor these in Nagios so it will be added later.