### PR TITLE
inventory: Remove first set of Ubuntu 16.04 systems

### DIFF
--- a/ansible/inventory.yml
+++ b/ansible/inventory.yml
@@ -11,7 +11,7 @@ hosts:
   - infrastructure:
 
       - aws:
-          ubuntu1604-x64-1: {ip: 54.78.186.5, user: ubuntu, description: trss.adoptopenjdk.net}
+          ubuntu1804-x64-1: {ip: 54.78.186.5, user: ubuntu, description: trss.adoptopenjdk.net}
 
       - digitalocean:
           ubuntu2004-x64-1: {ip: 178.62.115.224, description: bastillion.adoptopenjdk.net}
@@ -129,20 +129,17 @@ hosts:
           aix72-ppc64-2: {ip: 140.211.9.36, description: p8-aix2-ojdk04.osuosl.org}
           centos74-ppc64le-1: {ip: 140.211.168.228, user: centos}
           centos74-ppc64le-2: {ip: 140.211.168.217, user: centos}
-          centos74-ppc64le-4: {ip: 140.211.168.245, user: centos}
           ubuntu1604-ppc64le-1: {ip: 140.211.168.227, user: ubuntu}
           ubuntu1604-ppc64le-2: {ip: 140.211.168.190, user: ubuntu}
-          ubuntu1604-ppc64le-3: {ip: 140.211.168.248, user: ubuntu}
-          ubuntu1604-ppc64le-4: {ip: 140.211.168.239, user: ubuntu}
           ubuntu1804-ppc64le-1: {ip: 140.211.168.5, user: ubuntu}
           ubuntu1804-ppc64le-2: {ip: 140.211.168.8, user: ubuntu}
+          ubuntu2004-ppc64le-1: {ip: 140.211.168.235, user: ubuntu}
 
       - packet:
           ubuntu1604-armv8-1: {ip: 147.75.74.50, description: ThunderX}
           ubuntu1604-armv8-2: {ip: 147.75.193.234, description: ThunderX}
           ubuntu1604-x64-1: {ip: 147.75.204.239}
           ubuntu1604-x64-2: {ip: 147.75.100.127}
-          ubuntu1604-x64-3: {ip: 147.75.83.133}
           win2012r2-x64-1: {ip: 147.75.32.146, user: Admin}
 
       - macincloud:
@@ -162,9 +159,9 @@ hosts:
       - marist:
           sles12-s390x-1: {ip: 148.100.86.128}
           ubuntu1604-s390x-1: {ip: 148.100.113.20, user: ubuntu}
-          ubuntu1604-s390x-2: {ip: 148.100.113.25, user: ubuntu}
-          ubuntu1604-s390x-3: {ip: 148.100.113.30, user: ubuntu}
-          ubuntu1604-s390x-4: {ip: 148.100.113.46, user: ubuntu}
+          ubuntu1804-s390x-1: {ip: 148.100.113.30, user: ubuntu}
+          ubuntu1804-s390x-2: {ip: 148.100.113.46, user: ubuntu}
+          ubuntu1804-s390x-3: {ip: 148.100.113.25, user: ubuntu}
 
 
       # Nine machines are behind a firewall. Please contact @sxa or @gdams for access


### PR DESCRIPTION
Signed-off-by: Stewart X Addison <sxa@redhat.com>

Part of https://github.com/AdoptOpenJDK/openjdk-infrastructure/issues/1986

NOTE: This also removes a centos build system from OSUOSL which no longer exists but was still in the inventory

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.
-->

##### Checklist
<!-- For completed items, change [ ] to [x]. Leave unchecked if not required -->

- [x] commit message has one of the [standard prefixes](https://github.com/AdoptOpenJDK/openjdk-infrastructure/blob/master/CONTRIBUTING.md#commit-messages)
- [ ] [FAQ.md](https://github.com/AdoptOpenJDK/openjdk-infrastructure/blob/master/FAQ.md) updated if appropriate
- [ ] other documentation is changed or added (if applicable)
- [ ] playbook changes run through [VPC](https://ci.adoptopenjdk.net/view/Tooling/job/VagrantPlaybookCheck/) or [QPC](https://ci.adoptopenjdk.net/view/Tooling/job/QEMUPlaybookCheck/) (if you have access)
- [x] for inventory.yml changes, bastillion/nagios/jenkins updated accordingly

More TBC - jenkins and bastillion updates done, nagios not yet updated with new hostnames