### PR TITLE
winPB: Ensure hostnames don't end in a hyphen

### DIFF
--- a/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/roles/Common/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Windows_Playbook/roles/Common/tasks/main.yml
@@ -35,3 +35,33 @@
     executable: cmd
   ignore_errors: yes
   tags: basic_config
+
+# Some providers of machines set invalid hostnames with a hyphen at the end.
+# See: https://github.com/AdoptOpenJDK/openjdk-infrastructure/issues/2133
+- name: Check hostname doesn't end in '-'
+  win_shell: "hostname | Where {$_ -Match '\\-$'}"
+  args:
+    executable: powershell
+  register: hostname_output
+  tags: basic_config
+
+- name: Print new hostname
+  debug:
+    msg: "{{ hostname_output.stdout | replace('-','') | trim }}"
+  when:
+    - not (hostname_output.stdout == "")
+  tags: basic_config
+
+- name: Remove stray '-' from hostname
+  win_shell: Rename-Computer -NewName "{{ hostname_output.stdout | replace('-','') | trim }}"
+  args:
+    executable: powershell
+  when:
+    - not (hostname_output.stdout == "")
+  tags: basic_config
+
+- name: Reboot machine for hostname changes to take effect
+  win_reboot:
+    reboot_timeout: 1800
+  when: not (hostname_output.stdout == "")
+  tags: basic_config


### PR DESCRIPTION
Fixes: #2133 

Tested on the Windows 2012 VM. These tasks will check to ensure that the hostname doesn't end in a hyphen. If it does, it will remove the hyphen and restart the machine so those changes take effect.

ping @lumpfish

##### Checklist
<!-- For completed items, change [ ] to [x]. Leave unchecked if not required -->

- [x] commit message has one of the [standard prefixes](https://github.com/AdoptOpenJDK/openjdk-infrastructure/blob/master/CONTRIBUTING.md#commit-messages)
- [ ] [FAQ.md](https://github.com/AdoptOpenJDK/openjdk-infrastructure/blob/master/FAQ.md) updated if appropriate
- [ ] other documentation is changed or added (if applicable)
- [x] playbook changes run through [VPC](https://ci.adoptopenjdk.net/view/Tooling/job/VagrantPlaybookCheck/) or [QPC](https://ci.adoptopenjdk.net/view/Tooling/job/QEMUPlaybookCheck/) (if you have access): [VPC](https://ci.adoptopenjdk.net/job/VagrantPlaybookCheck/1140/)
- [ ] for inventory.yml changes, bastillion/nagios/jenkins updated accordingly

EDIT: The VPC run got through the hostname changes fine (so this is an example of where the tasks are skipped when they're meant to).
