### PR TITLE
inventory: Remove final AWS Windows machine

### DIFF
--- a/ansible/inventory.yml
+++ b/ansible/inventory.yml
@@ -110,7 +110,6 @@ hosts:
           rhel76-armv8-1: {ip: 18.202.36.216, user: ec2-user}
           rhel8-x64-1: {ip: 54.246.216.49}
           ubuntu1804-armv8-1: {ip: 34.243.202.254}
-          win2019-x64-1: {ip: 34.244.74.139, user: Administrator}
 
       - gdams:
           debian10-riscv64-1: {ip: gdams.ddns.net}


### PR DESCRIPTION
Follow on to https://github.com/AdoptOpenJDK/openjdk-infrastructure/pull/1861 now that https://github.com/AdoptOpenJDK/openjdk-infrastructure/issues/1932 has been completed to replace both AWS windows systems that we had.

Signed-off-by: Stewart X Addison <sxa@redhat.com>

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.
-->

##### Checklist
<!-- For completed items, change [ ] to [x]. Leave unchecked if not required -->

- [x] commit message has one of the [standard prefixes](https://github.com/AdoptOpenJDK/openjdk-infrastructure/blob/master/CONTRIBUTING.md#commit-messages)
- [ ] [FAQ.md](https://github.com/AdoptOpenJDK/openjdk-infrastructure/blob/master/FAQ.md) updated if appropriate
- [ ] other documentation is changed or added (if applicable)
- [ ] playbook changes run through [VPC](https://ci.adoptopenjdk.net/view/Tooling/job/VagrantPlaybookCheck/) or [QPC](https://ci.adoptopenjdk.net/view/Tooling/job/QEMUPlaybookCheck/) (if you have access)
- [x] for inventory.yml changes, bastillion/nagios/jenkins updated accordingly
