### PR TITLE
UnixPB: change conditions to include Ubuntu versions greater and equal to 20

### DIFF
--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/tasks/Ubuntu.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/tasks/Ubuntu.yml
@@ -86,7 +86,7 @@
   with_items: "{{ gcc_compiler }}"
   when:
     - (ansible_distribution_major_version != "9" and ansible_architecture != "armv7l")
-    - ansible_distribution_major_version >= "20"
+    - not (ansible_distribution_major_version >= "20")
   tags: build_tools
 
 - name: Install additional build tools for x86

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/tasks/Ubuntu.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/tasks/Ubuntu.yml
@@ -86,7 +86,7 @@
   with_items: "{{ gcc_compiler }}"
   when:
     - (ansible_distribution_major_version != "9" and ansible_architecture != "armv7l")
-    - ansible_distribution_major_version != "20"
+    - ansible_distribution_major_version >= "20"
   tags: build_tools
 
 - name: Install additional build tools for x86

--- a/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/NTP_TIME/tasks/main.yml
+++ b/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/NTP_TIME/tasks/main.yml
@@ -6,7 +6,7 @@
   command: timedatectl set-ntp no
   when:
     - (ansible_distribution == "RedHat" and ansible_distribution_major_version == "7") or (ansible_distribution == "Ubuntu") or ((ansible_distribution == "SLES" or ansible_distribution == "openSUSE") and ansible_distribution_major_version == "12") or (ansible_distribution == "centos" and ansible_distribution_major_version == "7" )
-    - not (ansible_distribution == "Ubuntu" and ansible_distribution_major_version == "20")
+    - not (ansible_distribution == "Ubuntu" and ansible_distribution_major_version >= "20")
   tags: ntp_time
 
 - name: Ensure systemd-timesyncd service is disabled


### PR DESCRIPTION
ref https://github.com/AdoptOpenJDK/openjdk-infrastructure/issues/2143

The tasks https://github.com/AdoptOpenJDK/openjdk-infrastructure/blob/a4d8543253f2cf3edbe9b606b809a3ad5fd6beab/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/Common/tasks/Ubuntu.yml#L84 and https://github.com/AdoptOpenJDK/openjdk-infrastructure/blob/a4d8543253f2cf3edbe9b606b809a3ad5fd6beab/ansible/playbooks/AdoptOpenJDK_Unix_Playbook/roles/NTP_TIME/tasks/main.yml#L5 fail on ubuntu versions 20.04 and 21.04, and so need to be skipped on these versions