### PR TITLE
pbTests: Add Ubuntu21.04 VPC support

### DIFF
--- a/ansible/Vagrantfile.Ubuntu2104
+++ b/ansible/Vagrantfile.Ubuntu2104
@@ -1,0 +1,26 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+$script = <<SCRIPT
+# Put the host machine's IP into the authorised_keys file on the VM
+if [ -r /vagrant/id_rsa.pub ]; then
+        mkdir -p $HOME/.ssh && cat /vagrant/id_rsa.pub >> $HOME/.ssh/authorized_keys
+fi
+SCRIPT
+
+# 2 = version of configuration file for Vagrant 1.1+ leading up to 2.0.x
+Vagrant.configure("2") do |config|
+
+  config.vm.define :adoptopenjdkU21 do |adoptopenjdkU21|
+    adoptopenjdkU21.vm.box = "bento/ubuntu-21.04"
+    adoptopenjdkU21.vm.synced_folder ".", "/vagrant"
+    adoptopenjdkU21.vm.hostname = "adoptopenjdkU21"
+    adoptopenjdkU21.vm.network :private_network, type: "dhcp"
+    adoptopenjdkU21.vm.provision "shell", inline: $script, privileged: false
+  end
+  config.vm.provider "virtualbox" do |v|
+    v.gui = false
+    v.memory = 2560
+    v.customize ["modifyvm", :id, "--cpuexecutioncap", "50"]
+  end
+end

--- a/ansible/pbTestScripts/vagrantPlaybookCheck.sh
+++ b/ansible/pbTestScripts/vagrantPlaybookCheck.sh
@@ -232,7 +232,7 @@ startVMPlaybook()
 
 	if [[ "$testNativeBuild" = true ]]; then
 		local buildLogPath="$WORKSPACE/adoptopenjdkPBTests/logFiles/${gitFork}.${gitBranch}.$OS.build_log"
-		ssh -p ${vagrantPORT} -i $PWD/id_rsa vagrant@127.0.0.1 "cd /vagrant/pbTestScripts && ./buildJDK.sh $buildBranch $buildFork $jdkToBuild $buildHotspot" 2>&1 | tee $buildLogPath
+		ssh -p ${vagrantPORT} -i $PWD/id_rsa vagrant@127.0.0.1 "cd /vagrant/pbTestScripts && bash buildJDK.sh $buildBranch $buildFork $jdkToBuild $buildHotspot" 2>&1 | tee $buildLogPath
 		echo The build finished at : `date +%T`
 		if grep -q '] Error' $buildLogPath || grep -q 'configure: error' $buildLogPath; then
 			echo BUILD FAILED
@@ -241,7 +241,7 @@ startVMPlaybook()
 
 		if [[ "$runTest" = true ]]; then
 			local testLogPath="$WORKSPACE/adoptopenjdkPBTests/logFiles/${gitFork}.${gitBranch}.$OS.test_log"
-			ssh -p ${vagrantPORT} -i $PWD/id_rsa vagrant@127.0.0.1 "cd /vagrant/pbTestScripts && ./testJDK.sh" 2>&1 | tee $testLogPath
+			ssh -p ${vagrantPORT} -i $PWD/id_rsa vagrant@127.0.0.1 "cd /vagrant/pbTestScripts && bash testJDK.sh" 2>&1 | tee $testLogPath
 			echo The test finished at : `date +%T`
 			if ! grep -q 'FAILED: 0' $testLogPath; then
 				echo TEST FAILED

--- a/ansible/pbTestScripts/vmDestroy.sh
+++ b/ansible/pbTestScripts/vmDestroy.sh
@@ -45,6 +45,8 @@ checkOS() {
                         osToDestroy="U18";;
                 "Ubuntu2004" | "U20" | "u20" )
                         osToDestroy="U20";;
+                "Ubuntu2104" | "U21" | "u21" )
+                        osToDestroy="U21";;
                 "CentOS6" | "centos6" | "C6" | "c6" )
                         osToDestroy="C6" ;;
                 "CentOS7" | "centos7" | "C7" | "c7" )
@@ -64,7 +66,7 @@ checkOS() {
 		"Windows2016" | "Win2016" | "W16" | "w16" )
                         osToDestroy="W2016";;
                 "all" )
-                        osToDestroy="U16 U18 U20 C6 C7 C8 D8 D10 FBSD12 Sol10 W2012" ;;
+                        osToDestroy="U16 U18 U20 U21 C6 C7 C8 D8 D10 FBSD12 Sol10 W2012" ;;
 		"")
 			echo "No OS detected. Did you miss the '-o' option?" ; usage; exit 1;;
 		*) echo "$OS is not a currently supported OS" ; listOS; exit 1;
@@ -77,6 +79,7 @@ listOS() {
 		- Ubuntu1604
 		- Ubuntu1804
 		- Ubuntu2004
+		- Ubuntu2104
 		- CentOS6
 		- CentOS7
 		- CentOS8


### PR DESCRIPTION
Ref: #2143

Adds support for U21 to VPC. In draft until VPC definitely works: https://ci.adoptopenjdk.net/job/VagrantPlaybookCheck/1145/OS=Ubuntu2104,label=vagrant/console

##### Checklist
<!-- For completed items, change [ ] to [x]. Leave unchecked if not required -->

- [x] commit message has one of the [standard prefixes](https://github.com/AdoptOpenJDK/openjdk-infrastructure/blob/master/CONTRIBUTING.md#commit-messages)
- [ ] [FAQ.md](https://github.com/AdoptOpenJDK/openjdk-infrastructure/blob/master/FAQ.md) updated if appropriate
- [ ] other documentation is changed or added (if applicable)
- [x] playbook changes run through [VPC](https://ci.adoptopenjdk.net/view/Tooling/job/VagrantPlaybookCheck/) or [QPC](https://ci.adoptopenjdk.net/view/Tooling/job/QEMUPlaybookCheck/) (if you have access) : See above
- [ ] for inventory.yml changes, bastillion/nagios/jenkins updated accordingly
