### PR TITLE
pbTests: Ignore VPC '--test' argument instead of failing

### DIFF
--- a/ansible/pbTestScripts/vagrantPlaybookCheck.sh
+++ b/ansible/pbTestScripts/vagrantPlaybookCheck.sh
@@ -89,15 +89,15 @@ usage()
 checkVars()
 {
 	if [ "$vagrantOS" == "" ]; then
-                usage
+		usage
 		echo "ERROR: No Vagrant OS specified - Use -h for help, -a for all or -v with one of the following:"
 		ls -1 ../Vagrantfile.* | cut -d. -f4
-                exit 1
+		exit 1
 	fi
 	if [[ "$runTest" == true && "$testNativeBuild" == false ]]; then 
-                echo "Unable to test an unbuilt JDK. Please specify both '--build' and '--test'"
-                exit 1
-        fi
+		echo "Unable to test an unbuilt JDK. Ignoring '--test' argument."
+		runTest=false
+	fi
 	#Sets WORKSPACE to home if WORKSPACE is empty or undefined. 
 	if [ ! -n "${WORKSPACE:-}" ]; then
 		echo "WORKSPACE not found, setting it as environment variable 'HOME'"


### PR DESCRIPTION
Ref: https://github.com/AdoptOpenJDK/openjdk-infrastructure/pull/2164#issuecomment-830009275

Also fixes a bunch of indentation issues ...

##### Checklist
<!-- For completed items, change [ ] to [x]. Leave unchecked if not required -->

- [x] commit message has one of the [standard prefixes](https://github.com/AdoptOpenJDK/openjdk-infrastructure/blob/master/CONTRIBUTING.md#commit-messages)
- [ ] [FAQ.md](https://github.com/AdoptOpenJDK/openjdk-infrastructure/blob/master/FAQ.md) updated if appropriate
- [ ] other documentation is changed or added (if applicable)
- [ ] playbook changes run through [VPC](https://ci.adoptopenjdk.net/view/Tooling/job/VagrantPlaybookCheck/) or [QPC](https://ci.adoptopenjdk.net/view/Tooling/job/QEMUPlaybookCheck/) (if you have access)
- [ ] for inventory.yml changes, bastillion/nagios/jenkins updated accordingly
