### PR TITLE
pbTests: Autodetect JDK-7 or default to JDK8 when building JDK8

### DIFF
--- a/ansible/pbTestScripts/buildJDK.sh
+++ b/ansible/pbTestScripts/buildJDK.sh
@@ -75,6 +75,27 @@ checkJDK() {
 	fi
 }
 
+# This method is required as there isn't a standardised JDK-7 for all platforms.
+# Some may be "zulu7", some may be 'java-1.7.0', or 'openjdk-7-jdk`
+findJDK7() {
+	local jdkPath=""
+	local pathSuffix="java-1.7.0 java-7-openjdk-amd64 zulu7 jdk-7"
+	for path in $pathSuffix
+	do
+		jdkPath=$(find /usr/lib/jvm/ -name $path)
+		if [[ $jdkPath != "" ]]; then
+			break
+		fi
+	done
+
+	# Last Resort: Use JDK8 to build JDK8
+	if [[ $jdkPath == "" ]]; then
+		jdkPath="/usr/lib/jvm/jdk8"
+	fi
+	
+	export JDK7_BOOT_DIR=$jdkPath
+}
+
 cloneRepo() {
 	if [ -d $WORKSPACE/openjdk-build ]; then
 		echo "Found existing openjdk-build folder"
@@ -121,6 +142,10 @@ fi
 if [[ "$(uname -m)" == "armv7l" && "$VARIANT" == "openj9" ]]; then
 	echo "OpenJ9 VM does not support armv7l - resetting VARIANT to hotspot"
 	export VARIANT=hotspot
+fi
+
+if [[ "$JAVA_TO_BUILD" == "jdk8u" ]]; then
+	findJDK7	
 fi
 
 # Don't build the debug-images as it takes too much space, and doesn't benefit VPC


### PR DESCRIPTION
Fixes: #2176 

Adds logic to detect JDK7 in circumstances of building JDK8. Not all platforms share the same process of getting a JDK7 (i.e. it may be to install it from the package manager, install zulu-7, or it may be that JDK-7 isn't available), so they often have different names within `/usr/lib/jvm`, so  `buildJDK.sh` needs to set `JDK7_BOOT_DIR` depending on the situation.

In the case of some platforms (i.e. Ubuntu1804 on S390x and PPC64LE), there is no JDK7, so JDK8 is set as a last resort.

[VPC Run](https://ci.adoptopenjdk.net/job/VagrantPlaybookCheck/1163/)
[QPC Run](https://ci.adoptopenjdk.net/job/QEMUPlaybookCheck/258/) (See Ubuntu1804/s390x to see the build start)

##### Checklist
<!-- For completed items, change [ ] to [x]. Leave unchecked if not required -->

- [x] commit message has one of the [standard prefixes](https://github.com/AdoptOpenJDK/openjdk-infrastructure/blob/master/CONTRIBUTING.md#commit-messages)
- [ ] [FAQ.md](https://github.com/AdoptOpenJDK/openjdk-infrastructure/blob/master/FAQ.md) updated if appropriate
- [ ] other documentation is changed or added (if applicable)
- [x] playbook changes run through [VPC](https://ci.adoptopenjdk.net/view/Tooling/job/VagrantPlaybookCheck/) or [QPC](https://ci.adoptopenjdk.net/view/Tooling/job/QEMUPlaybookCheck/) (if you have access)
- [ ] for inventory.yml changes, bastillion/nagios/jenkins updated accordingly
